### PR TITLE
fixes for parity with paper impl & results

### DIFF
--- a/its_hub/algorithms/beam_search.py
+++ b/its_hub/algorithms/beam_search.py
@@ -150,7 +150,7 @@ class BeamSearch(AbstractScalingAlgorithm):
         
         scores = [c.score for c in candidates]
         result = BeamSearchResult(
-            responses=[self.sg.step_token.join(c.steps) for c in candidates],
+            responses=[self.sg._post_process(c.steps, stopped=True) for c in candidates],
             scores=scores,
             selected_index=int(np.argmax(scores)),
         )

--- a/its_hub/algorithms/bon.py
+++ b/its_hub/algorithms/bon.py
@@ -28,7 +28,7 @@ class BestOfN(AbstractScalingAlgorithm):
         return_response_only: bool = True, 
     ) -> Union[str, BestOfNResult]:
         # generate responses
-        responses = lm.generate([prompt] * budget)
+        responses = lm.generate([[{"role": "user", "content": prompt}]] * budget)
 
         # score responses
         scores = [] 

--- a/its_hub/algorithms/particle_gibbs.py
+++ b/its_hub/algorithms/particle_gibbs.py
@@ -200,7 +200,7 @@ class ParticleGibbs(AbstractScalingAlgorithm):
             ref_indices = random.choices(range(len(particles)), weights=probabilities, k=self.num_ref_particles)
             ref_particles = [particles[i] for i in ref_indices]
             
-            responses_lst.append([self.sg.step_token.join(p.steps) for p in particles])
+            responses_lst.append([self.sg._post_process(p.steps, stopped=True) for p in particles])
             log_weights_lst.append(log_weights)
             ref_indices_lst.append(ref_indices)
         

--- a/its_hub/algorithms/self_consistency.py
+++ b/its_hub/algorithms/self_consistency.py
@@ -48,7 +48,7 @@ class SelfConsistency(AbstractScalingAlgorithm):
         return_response_only: bool = True, 
     ) -> Union[str, SelfConsistencyResult]:
         # generate responses
-        responses = lm.generate([prompt] * budget)
+        responses = lm.generate([[{"role": "user", "content": prompt}]] * budget)
         
         # project responses into consistency space
         responses_projected = [self.consistency_space_projection_func(r) for r in responses]

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -7,7 +7,7 @@ from .base import AbstractLanguageModel
 # TODO make it robust such that one of the particle dead (e.g. due to max tokens), the whole generation is not stopped
 class StepGeneration:
     def __init__(self, step_token: Union[str, List[str]], max_steps: int, stop_token: str = None, include_stop_str_in_output: bool = True):
-        if include_stop_str_in_output:
+        if not include_stop_str_in_output:
             assert type(stop_token) == str, "stop_token must be a string if include_stop_str_in_output is True"
         self.step_token = step_token
         self.max_steps = max_steps

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -4,6 +4,14 @@ import backoff
 from openai import OpenAI, AsyncOpenAI
 from .base import AbstractLanguageModel
 
+def rstrip_iff_entire(s, subs):
+  if s.endswith(subs):
+    # If s ends with subs, return the string without the length of subs at the end
+    return s[:-len(subs)]
+  else:
+    # Otherwise, return the original string
+    return s
+
 # TODO make it robust such that one of the particle dead (e.g. due to max tokens), the whole generation is not stopped
 # TODO change stop_token to be a function called is_stopped
 class StepGeneration:
@@ -49,7 +57,7 @@ class StepGeneration:
             if self.stop_token:
                 is_stopped = is_stopped or self.stop_token in next_step
                 if self.include_stop_str_in_output:
-                    next_step = next_step.rstrip(self.stop_token)
+                    next_step = rstrip_iff_entire(next_step, self.stop_token)
             return next_step, is_stopped
         else:
             prompts = prompt_or_prompts
@@ -71,7 +79,7 @@ class StepGeneration:
                 is_stopped = [is_stopped_per_prompt or self.stop_token in next_step
                              for is_stopped_per_prompt, next_step in zip(is_stopped, next_steps)]
                 if self.include_stop_str_in_output:
-                    next_steps = [next_step.rstrip(self.stop_token) for next_step in next_steps]
+                    next_steps = [rstrip_iff_entire(next_step, self.stop_token) for next_step in next_steps]
             return list(zip(next_steps, is_stopped))
 
 def _on_backoff(details):

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -95,6 +95,14 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         # override runtime parameters
         if stop is not None:
             request_data["stop"] = stop
+        
+        # set default runtime parameters
+        if self.max_tokens is not None:
+            request_data["max_tokens"] = self.max_tokens
+        if self.temperature is not None:
+            request_data["temperature"] = self.temperature
+        
+        # override runtime parameters
         if max_tokens is not None:
             request_data["max_tokens"] = max_tokens
         if temperature is not None:

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -5,7 +5,6 @@ from openai import OpenAI, AsyncOpenAI
 from .base import AbstractLanguageModel
 
 # TODO make it robust such that one of the particle dead (e.g. due to max tokens), the whole generation is not stopped
-# TODO support multiple step_token
 class StepGeneration:
     def __init__(self, step_token: Union[str, List[str]], max_steps: int, stop_token: str = None, include_stop_str_in_output: bool = True):
         if include_stop_str_in_output:

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -129,7 +129,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         return request_data
 
     async def _generate(
-        self, messages_lst, stop: str = None, max_tokens: int = None, temperature: float = None, max_retries: int = 3
+        self, messages_lst, stop: str = None, max_tokens: int = None, temperature: float = None, max_retries: int = 5
     ) -> List[str]:
         # use openai's async client for batch requests
         async def fetch_response(messages):
@@ -159,7 +159,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         return await asyncio.gather(*(fetch_response(messages) for messages in messages_lst))
     
     def generate(
-        self, messages_or_messages_lst, stop: str = None, max_tokens: int = None, temperature: float = None, max_retries: int = 3
+        self, messages_or_messages_lst, stop: str = None, max_tokens: int = None, temperature: float = None, max_retries: int = 5
     ) -> Union[str, List[str]]:
         is_single = isinstance(messages_or_messages_lst[0], dict)
         messages_lst = [messages_or_messages_lst] if is_single else messages_or_messages_lst

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -135,23 +135,27 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         return request_data
 
     async def _generate(
-        self, messages_lst, stop: str = None, max_tokens: int = None, temperature: float = None, max_tries: int = 5
+        self, messages_lst, stop: str = None, max_tokens: int = None, temperature: float = None, max_tries: int = 5, max_concurrency: int = 8
     ) -> List[str]:
         # use openai's async client for batch requests
+        # limit concurrency to max_concurrency using a semaphore
+        semaphore = asyncio.Semaphore(max_concurrency)
+
         @backoff.on_exception(backoff.expo, Exception, max_tries=max_tries, on_backoff=_on_backoff)
         async def fetch_response(messages):
-            request_data = self._prepare_request_data(messages, stop, max_tokens, temperature)
-            response = await self._openai_client.chat.completions.create(
-                model=request_data["model"],
-                messages=request_data["messages"],
-                stop=request_data.get("stop"),
-                max_tokens=request_data.get("max_tokens"),
-                temperature=request_data.get("temperature"),
-                extra_body=request_data.get("extra_body", {}),
-            )
-            return response.choices[0].message.content
+            async with semaphore:
+                request_data = self._prepare_request_data(messages, stop, max_tokens, temperature)
+                response = await self._openai_client.chat.completions.create(
+                    model=request_data["model"],
+                    messages=request_data["messages"],
+                    stop=request_data.get("stop"),
+                    max_tokens=request_data.get("max_tokens"),
+                    temperature=request_data.get("temperature"),
+                    extra_body=request_data.get("extra_body", {}),
+                )
+                return response.choices[0].message.content
 
-        # gather all responses asynchronously
+        # gather all responses asynchronously, with concurrency limited to max_concurrency
         return await asyncio.gather(*(fetch_response(messages) for messages in messages_lst))
     
     def generate(

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -17,7 +17,7 @@ def rstrip_iff_entire(s, subs):
 class StepGeneration:
     def __init__(self, step_token: Union[str, List[str]], max_steps: int, stop_token: str = None, temperature: float = 0.8, include_stop_str_in_output: bool = False):
         if not include_stop_str_in_output:
-            assert type(step_token) == str, "step_token must be a string if include_stop_str_in_output is False"
+            assert isinstance(step_token, str), "step_token must be a string if include_stop_str_in_output is False"
         else:
             assert step_token is not None, "step_token must be provided if include_stop_str_in_output is True"
         self.step_token = step_token

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -7,7 +7,9 @@ from .base import AbstractLanguageModel
 # TODO make it robust such that one of the particle dead (e.g. due to max tokens), the whole generation is not stopped
 # TODO support multiple step_token
 class StepGeneration:
-    def __init__(self, step_token: str, max_steps: int, stop_token: str = None, include_stop_str_in_output: bool = True):
+    def __init__(self, step_token: Union[str, List[str]], max_steps: int, stop_token: str = None, include_stop_str_in_output: bool = True):
+        if include_stop_str_in_output:
+            assert type(stop_token) == str, "stop_token must be a string if include_stop_str_in_output is True"
         self.step_token = step_token
         self.max_steps = max_steps
         self.stop_token = stop_token

--- a/its_hub/utils.py
+++ b/its_hub/utils.py
@@ -1,2 +1,4 @@
 # the system prompt for step-by-step reasoning taken from https://github.com/huggingface/search-and-learn
 SAL_STEP_BY_STEP_SYSTEM_PROMPT = "Solve the following math problem efficiently and clearly:\n\n- For simple problems (2 steps or fewer):\nProvide a concise solution with minimal explanation.\n\n- For complex problems (3 steps or more):\nUse this step-by-step format:\n\n## Step 1: [Concise description]\n[Brief explanation and calculations]\n\n## Step 2: [Concise description]\n[Brief explanation and calculations]\n\n...\n\nRegardless of the approach, always conclude with:\n\nTherefore, the final answer is: $\\boxed{answer}$. I hope it is correct.\n\nWhere [answer] is just the final number or expression that solves the problem."
+
+QWEN_SYSTEM_PROMPT = "Please reason step by step, and put your final answer within \\boxed{}."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "requests>=2.31.0",
+    "openai>=1.75.0",
     "tqdm>=4.65.0",
     "typing-extensions>=4.0.0",
     "reward-hub==0.1.0",
+    "backoff>=2.2.0",
 ]
 
 [tool.setuptools_scm]

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -80,6 +80,7 @@ def display_results(df: pd.DataFrame):
 @click.option("--is_async", is_flag=True, default=False, help="whether to use async mode")
 @click.option("--max_tokens", type=int, default=None, help="max tokens to use for inference-time scaling")
 @click.option("--temperature", type=float, default=None, help="temperature to use for inference-time scaling")
+@click.option("--max_concurrency", type=int, default=8, help="max concurrency to use for inference-time scaling")
 @click.option("--endpoint", type=str, help="endpoint to use for inference-time scaling")
 @click.option("--api_key", type=str, default="NO_API_KEY", help="api key to use for inference-time scaling")
 @click.option("--rm_name", type=str, default="Qwen/Qwen2.5-Math-PRM-7B", help="name of reward model to use")
@@ -105,6 +106,7 @@ def main(
     is_async: bool,
     max_tokens: int,
     temperature: float,
+    max_concurrency: int,
     endpoint: str, 
     api_key: str, 
     rm_name: str,
@@ -177,6 +179,7 @@ def main(
             is_async=is_async,
             temperature=temperature,
             max_tokens=max_tokens,
+            max_concurrency=max_concurrency,
         )
 
     print("initializing algorithm...")

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -46,17 +46,18 @@ def _extract_boxed(s: str) -> str:
     # return the last match if any were found
     return boxed_matches[-1] if boxed_matches else ""
 
-def init_algorithm(alg: ScalingAlgorithm, rm_name: str, rm_device: str, rm_agg_method: AggregationMethod):
+def init_algorithm(alg: ScalingAlgorithm, model_name: str, rm_name: str, rm_device: str, rm_agg_method: AggregationMethod):
+    step_token = "\n\n##" if "llama" in model_name.lower() else "\n\n"
     if alg == ScalingAlgorithm.SELF_CONSISTENCY:
         return SelfConsistency(_extract_boxed)
     elif alg == ScalingAlgorithm.BEAM_SEARCH:
-        sg = StepGeneration("\n\n", 50, "\\boxed")
+        sg = StepGeneration(step_token, 50, "\\boxed")
         prm = LocalVllmProcessRewardModel(
             model_name=rm_name, device=rm_device, aggregation_method=rm_agg_method
         )
         return BeamSearch(sg, prm, beam_width=4)
     elif alg == ScalingAlgorithm.PARTICLE_FILTERING:
-        sg = StepGeneration("\n\n", 50, "\\boxed")
+        sg = StepGeneration(step_token, 50, "\\boxed")
         prm = LocalVllmProcessRewardModel(
             model_name=rm_name, device=rm_device, aggregation_method=rm_agg_method
         )
@@ -179,7 +180,7 @@ def main(
         )
 
     print("initializing algorithm...")
-    scaling_alg = init_algorithm(alg, rm_name, rm_device, rm_agg_method)
+    scaling_alg = init_algorithm(alg, model_name, rm_name, rm_device, rm_agg_method)
 
     # ensure output directory exists
     if not os.path.exists(output_dir):


### PR DESCRIPTION
summary of changes
- language models now use the message format
- `requests` is replaced with `openai` client with `backoff` for retries
- the wrong use of raw string is fixed
- different sys prompt for Qwen models
- benchmark script doesn't append any more