### PR TITLE
docs: Update URLs to use custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 For comprehensive documentation, including installation guides, tutorials, and API reference, visit:
 
-**[https://red-hat-ai-innovation-team.github.io/its_hub](https://red-hat-ai-innovation-team.github.io/its_hub)**
+**[https://ai-innovation.team/its_hub](https://ai-innovation.team/its_hub)**
 
 ## Quick Start
 
@@ -69,4 +69,4 @@ pip install -e ".[dev]"
 pytest tests
 ```
 
-For detailed documentation, visit: [https://red-hat-ai-innovation-team.github.io/its_hub](https://red-hat-ai-innovation-team.github.io/its_hub)
+For detailed documentation, visit: [https://ai-innovation.team/its_hub](https://ai-innovation.team/its_hub)

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -7,5 +7,5 @@
 - ⚡ Async generation with concurrency limits and error handling
 - 📊 Comprehensive benchmarking tools
 
-[GitHub](https://github.com/Red-Hat-AI-Innovation-Team/its_hub)
+[GitHub](https://ai-innovation.team/its_hub)
 [Get Started](#quick-start-guide)

--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,5 +1,5 @@
 - Links
-  - [GitHub](https://github.com/Red-Hat-AI-Innovation-Team/its_hub)
+  - [GitHub](https://ai-innovation.team/its_hub)
   - [PyPI](https://pypi.org/project/its_hub/)
-  - [Tests](https://github.com/Red-Hat-AI-Innovation-Team/its_hub/actions/workflows/tests.yml)
+  - [Tests](https://ai-innovation.team/its_hub/actions/workflows/tests.yml)
   - [Coverage](https://codecov.io/gh/Red-Hat-AI-Innovation-Team/its_hub)

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
   <script>
     window.$docsify = {
       name: 'its_hub',
-      repo: 'https://github.com/Red-Hat-AI-Innovation-Team/its_hub',
+      repo: 'https://ai-innovation.team/its_hub',
       loadSidebar: true,
       loadNavbar: true,
       subMaxLevel: 3,
@@ -27,7 +27,7 @@
       plugins: [
         function(hook, vm) {
           hook.beforeEach(function (html) {
-            var url = 'https://github.com/Red-Hat-AI-Innovation-Team/its_hub/blob/main/docs/' + vm.route.file
+            var url = 'https://ai-innovation.team/its_hub/blob/main/docs/' + vm.route.file
             var editHtml = '[:memo: Edit Document](' + url + ')\n'
             return editHtml + html
           })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ version_file = "its_hub/_version.py"
 local_scheme = "no-local-version"
 
 [project.urls]
-Homepage = "https://github.com/Red-Hat-AI-Innovation-Team/its_hub"
+Homepage = "https://ai-innovation.team/its_hub"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- Update all documentation URLs from GitHub Pages default to custom domain https://ai-innovation.team/its_hub
- Fix URLs in README.md, documentation site configuration, and project metadata

## Test plan
- [ ] Verify all updated URLs resolve correctly
- [ ] Check documentation site loads properly with new domain
- [ ] Confirm project homepage link works in package metadata

🤖 Generated with [Claude Code](https://claude.ai/code)