### PR TITLE
docs: Fix URL structure following docsify best practices

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -7,5 +7,5 @@
 - ⚡ Async generation with concurrency limits and error handling
 - 📊 Comprehensive benchmarking tools
 
-[GitHub](https://ai-innovation.team/its_hub)
+[GitHub](https://github.com/Red-Hat-AI-Innovation-Team/its_hub)
 [Get Started](#quick-start-guide)

--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,5 +1,5 @@
 - Links
-  - [GitHub](https://ai-innovation.team/its_hub)
+  - [GitHub](https://github.com/Red-Hat-AI-Innovation-Team/its_hub)
   - [PyPI](https://pypi.org/project/its_hub/)
-  - [Tests](https://ai-innovation.team/its_hub/actions/workflows/tests.yml)
+  - [Tests](https://github.com/Red-Hat-AI-Innovation-Team/its_hub/actions/workflows/tests.yml)
   - [Coverage](https://codecov.io/gh/Red-Hat-AI-Innovation-Team/its_hub)

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,6 @@
   <script>
     window.$docsify = {
       name: 'its_hub',
-      repo: 'https://ai-innovation.team/its_hub',
       loadSidebar: true,
       loadNavbar: true,
       subMaxLevel: 3,
@@ -27,7 +26,7 @@
       plugins: [
         function(hook, vm) {
           hook.beforeEach(function (html) {
-            var url = 'https://ai-innovation.team/its_hub/blob/main/docs/' + vm.route.file
+            var url = 'https://github.com/Red-Hat-AI-Innovation-Team/its_hub/blob/main/docs/' + vm.route.file
             var editHtml = '[:memo: Edit Document](' + url + ')\n'
             return editHtml + html
           })


### PR DESCRIPTION
## Summary
- Fix URL structure to follow docsify's own patterns and best practices
- Use GitHub URLs for repository actions (navbar links, coverpage GitHub link)
- Remove repo config from docsify following upstream pattern (docsify itself doesn't use this)
- Keep GitHub URLs for edit document functionality

## Changes
- **docs/_navbar.md**: GitHub and Tests links now point to actual GitHub repository
- **docs/_coverpage.md**: GitHub link points to repository for development activities  
- **docs/index.html**: Removed `repo` config and fixed edit document URLs to use GitHub

## Rationale
Based on analysis of https://github.com/docsifyjs/docsify/blob/develop/docs/index.html:
- Docsify itself does not use the `repo` configuration
- Repository-related actions should use GitHub URLs
- Documentation consumption uses custom domain (already correct in README)

🤖 Generated with [Claude Code](https://claude.ai/code)