### PR TITLE
feat: Improve internal typing with Pydantic dataclasses and ChatMessage type

### DIFF
--- a/its_hub/algorithms/beam_search.py
+++ b/its_hub/algorithms/beam_search.py
@@ -1,6 +1,6 @@
 from typing import Union, List
 import copy
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 import numpy as np
 from tqdm import tqdm
 

--- a/its_hub/algorithms/bon.py
+++ b/its_hub/algorithms/bon.py
@@ -28,7 +28,7 @@ class BestOfN(AbstractScalingAlgorithm):
         return_response_only: bool = True, 
     ) -> Union[str, BestOfNResult]:
         # generate responses
-        responses = lm.generate([[ChatMessage(role="user", content=prompt)]] * budget)
+        responses = lm.generate([[ChatMessage(role="user", content=prompt)] for _ in range(budget)])
 
         # score responses
         # TODO: make batched a configurable parameter or remove non-batched branch

--- a/its_hub/algorithms/bon.py
+++ b/its_hub/algorithms/bon.py
@@ -1,8 +1,9 @@
 from typing import Union, List
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 from tqdm import tqdm
 
 from ..base import AbstractLanguageModel, AbstractScalingResult, AbstractScalingAlgorithm, AbstractOutcomeRewardModel
+from ..types import ChatMessage
 
 
 @dataclass
@@ -27,7 +28,7 @@ class BestOfN(AbstractScalingAlgorithm):
         return_response_only: bool = True, 
     ) -> Union[str, BestOfNResult]:
         # generate responses
-        responses = lm.generate([[{"role": "user", "content": prompt}]] * budget)
+        responses = lm.generate([[ChatMessage(role="user", content=prompt)]] * budget)
 
         # score responses
         # TODO: make batched a configurable parameter or remove non-batched branch

--- a/its_hub/algorithms/particle_gibbs.py
+++ b/its_hub/algorithms/particle_gibbs.py
@@ -1,7 +1,7 @@
 from typing import Union, List
 from enum import Enum
 import copy
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 import random
 import numpy as np
 from tqdm import tqdm

--- a/its_hub/algorithms/self_consistency.py
+++ b/its_hub/algorithms/self_consistency.py
@@ -1,10 +1,11 @@
 from typing import Callable, Union, List
 from collections import Counter
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 import random
 from tqdm import tqdm
 
 from ..base import AbstractLanguageModel, AbstractScalingResult, AbstractScalingAlgorithm
+from ..types import ChatMessage
 
 
 @dataclass
@@ -47,7 +48,7 @@ class SelfConsistency(AbstractScalingAlgorithm):
         return_response_only: bool = True, 
     ) -> Union[str, SelfConsistencyResult]:
         # generate responses
-        responses = lm.generate([[{"role": "user", "content": prompt}]] * budget)
+        responses = lm.generate([[ChatMessage(role="user", content=prompt)]] * budget)
         
         # project responses into consistency space
         responses_projected = [self.consistency_space_projection_func(r) for r in responses]

--- a/its_hub/algorithms/self_consistency.py
+++ b/its_hub/algorithms/self_consistency.py
@@ -48,7 +48,7 @@ class SelfConsistency(AbstractScalingAlgorithm):
         return_response_only: bool = True, 
     ) -> Union[str, SelfConsistencyResult]:
         # generate responses
-        responses = lm.generate([[ChatMessage(role="user", content=prompt)]] * budget)
+        responses = lm.generate([[ChatMessage(role="user", content=prompt)] for _ in range(budget)])
         
         # project responses into consistency space
         responses_projected = [self.consistency_space_projection_func(r) for r in responses]

--- a/its_hub/integration/reward_hub.py
+++ b/its_hub/integration/reward_hub.py
@@ -3,6 +3,7 @@ from typing import List, Union
 from reward_hub.base import AggregationMethod
 
 from ..base import AbstractOutcomeRewardModel, AbstractProcessRewardModel
+from ..types import ChatMessage
 
 class LocalVllmProcessRewardModel(AbstractProcessRewardModel):
     def __init__(self, model_name: str, device: str, aggregation_method: AggregationMethod):
@@ -16,7 +17,7 @@ class LocalVllmProcessRewardModel(AbstractProcessRewardModel):
     def score(self, prompt: str, response_or_responses: Union[str, List[str]]) -> float:
         is_single_response = isinstance(response_or_responses, str)
         messages = [
-            [{"role": "user", "content": prompt}, {"role": "assistant", "content": r}]
+            [ChatMessage(role="user", content=prompt), ChatMessage(role="assistant", content=r)]
             for r in ([response_or_responses] if is_single_response else response_or_responses)
         ]
         res = self.model.score(


### PR DESCRIPTION
## Summary
- Convert all algorithm result dataclasses to use Pydantic for enhanced type validation
- Convert algorithm data structures (Particle, Path) to use Pydantic dataclasses  
- Replace dict-based message structures with ChatMessage type across algorithms and reward model integration

## Test plan
- [x] Convert SelfConsistencyResult, BestOfNResult, BeamSearchResult, ParticleGibbsResult to Pydantic dataclasses
- [x] Convert Particle and Path data structures to use Pydantic dataclasses
- [x] Replace dict message structures in algorithms with ChatMessage type
- [x] Replace dict message structures in reward model integration with ChatMessage type
- [ ] Verify all tests pass in CI
- [ ] Confirm backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.ai/code)

---

resolves # 29