### PR TITLE
fix: Update devcontainer workspace mount path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,7 +47,7 @@
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
   },
-  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/its_hub,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "sudo /usr/local/bin/init-firewall.sh"
 }


### PR DESCRIPTION
## Summary
• Updated devcontainer workspace mount target from `/workspace` to `/workspace/its_hub` to align with project structure

## Test plan
- [ ] Verify devcontainer builds successfully
- [ ] Confirm workspace mounting works correctly in devcontainer environment

🤖 Generated with [Claude Code](https://claude.ai/code)