### PR TITLE
fix: Correct devcontainer workspace mount path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,7 +47,7 @@
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
   },
-  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/its_hub,type=bind,consistency=delegated",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "sudo /usr/local/bin/init-firewall.sh"
 }


### PR DESCRIPTION
## Summary
- Fixed devcontainer workspace mount path configuration
- Updated workspaceMount target from `/workspace/its_hub` to `/workspace` to match workspaceFolder setting

## Test plan
- [ ] Verify devcontainer builds and mounts workspace correctly
- [ ] Test that workspace folder is accessible at expected path

🤖 Generated with [Claude Code](https://claude.ai/code)