### PR TITLE
fix: Use dict format instead of ChatMessage for reward model integration

### DIFF
--- a/its_hub/integration/reward_hub.py
+++ b/its_hub/integration/reward_hub.py
@@ -17,7 +17,7 @@ class LocalVllmProcessRewardModel(AbstractProcessRewardModel):
     def score(self, prompt: str, response_or_responses: Union[str, List[str]]) -> float:
         is_single_response = isinstance(response_or_responses, str)
         messages = [
-            [ChatMessage(role="user", content=prompt), ChatMessage(role="assistant", content=r)]
+            [{"role": "user", "content": prompt}, {"role": "assistant", "content": r}]
             for r in ([response_or_responses] if is_single_response else response_or_responses)
         ]
         res = self.model.score(


### PR DESCRIPTION
## Summary
- Replace ChatMessage objects with dictionary format in LocalVllmProcessRewardModel
- Ensures compatibility with the reward_hub library's expected message format

## Test plan
- [x] Verify LocalVllmProcessRewardModel works with reward_hub integration

🤖 Generated with [Claude Code](https://claude.ai/code)