### PR TITLE
fix: Add uv.lock to gitignore for library distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.


### PR DESCRIPTION
## Summary
- Add `uv.lock` to `.gitignore` to prevent committing UV lock files
- Libraries should not commit lock files to allow dependency flexibility for consumers
- Follows Python packaging best practices for library distribution

## Test plan
- [x] Verify `uv.lock` is now ignored by git
- [x] Confirm change follows existing gitignore patterns and comments

🤖 Generated with [Claude Code](https://claude.ai/code)