### PR TITLE
feat: Add tokens_per_step parameter for StepGeneration (#97)

### DIFF
--- a/tests/mocks/language_models.py
+++ b/tests/mocks/language_models.py
@@ -1,17 +1,17 @@
 """Mock language models for testing."""
 
-from typing import List
+
 from its_hub.base import AbstractLanguageModel
 
 
 class SimpleMockLanguageModel:
     """Simple mock language model for basic testing."""
-    
-    def __init__(self, responses: List[str]):
+
+    def __init__(self, responses: list[str]):
         self.responses = responses
         self.call_count = 0
 
-    def generate(self, messages, stop=None, temperature=None, include_stop_str_in_output=None):
+    def generate(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None):
         if isinstance(messages[0], list):
             # Multiple message lists
             responses = self.responses[self.call_count:self.call_count + len(messages)]
@@ -26,12 +26,12 @@ class SimpleMockLanguageModel:
 
 class StepMockLanguageModel(AbstractLanguageModel):
     """Mock language model for step-by-step generation testing."""
-    
-    def __init__(self, step_responses: List[str]):
+
+    def __init__(self, step_responses: list[str]):
         self.step_responses = step_responses
         self.call_count = 0
-        
-    def generate(self, messages, stop=None, temperature=None, include_stop_str_in_output=None):
+
+    def generate(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None):
         if isinstance(messages, list) and len(messages) > 0 and isinstance(messages[0], list):
             # Batched generation
             num_requests = len(messages)
@@ -46,25 +46,25 @@ class StepMockLanguageModel(AbstractLanguageModel):
             response = self.step_responses[self.call_count % len(self.step_responses)]
             self.call_count += 1
             return response
-            
-    def evaluate(self, prompt: str, generation: str) -> List[float]:
+
+    def evaluate(self, prompt: str, generation: str) -> list[float]:
         """Return mock evaluation scores."""
         return [0.1] * len(generation.split())
 
 
 class ErrorMockLanguageModel(AbstractLanguageModel):
     """Mock language model that can simulate errors."""
-    
-    def __init__(self, responses: List[str], error_on_calls: List[int] = None):
+
+    def __init__(self, responses: list[str], error_on_calls: list[int] = None):
         self.responses = responses
         self.error_on_calls = error_on_calls or []
         self.call_count = 0
-        
-    def generate(self, messages, stop=None, temperature=None, include_stop_str_in_output=None):
+
+    def generate(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None):
         if self.call_count in self.error_on_calls:
             self.call_count += 1
             raise Exception("Simulated LM error")
-            
+
         if isinstance(messages, list) and len(messages) > 0 and isinstance(messages[0], list):
             # Batched generation
             num_requests = len(messages)
@@ -81,6 +81,6 @@ class ErrorMockLanguageModel(AbstractLanguageModel):
             response = self.responses[self.call_count % len(self.responses)]
             self.call_count += 1
             return response
-            
-    def evaluate(self, prompt: str, generation: str) -> List[float]:
+
+    def evaluate(self, prompt: str, generation: str) -> list[float]:
         return [0.1] * len(generation.split())


### PR DESCRIPTION
## Summary

Implements issue #97 by adding a new `tokens_per_step` parameter to `StepGeneration` with mutual exclusion to `step_token`. This makes inference-time scaling algorithms much easier to use without requiring users to define step delimiters.

### Key Features

- **Mutual Exclusion Design**: Users must specify exactly ONE of `step_token` or `tokens_per_step`
- **Precise Token Control**: `tokens_per_step` limits each generation to N tokens
- **Backward Compatible**: All existing `step_token` usage unchanged
- **Algorithm Compatible**: Works with ParticleFiltering, BeamSearch, and all algorithms

### Usage Examples

```python
# Traditional approach (existing)
sg1 = StepGeneration(step_token="\n\n", max_steps=5)

# New approach (issue #97)
sg2 = StepGeneration(tokens_per_step=50, max_steps=5)

# Use with algorithms
pf = ParticleFiltering(sg2, reward_model)
result = pf.infer(lm, prompt, budget=4)
```

### Technical Implementation

- Added `tokens_per_step: int | None` parameter to constructor
- Enhanced validation to enforce mutual exclusion
- Pass `tokens_per_step` as `max_tokens` to language model
- Updated post-processing for both modes
- Comprehensive error handling and validation

### Benefits

- ✅ **Easier PF/BS Usage**: No need to define step tokens or special prompting
- ✅ **Precise Control**: Exact token limits per generation step  
- ✅ **Lower Barrier**: Reduces complexity for new users
- ✅ **Full Compatibility**: Works with all existing algorithms

## Test plan

- [x] All existing tests pass (20 StepGeneration tests, 23 algorithm tests)
- [x] New validation tests for mutual exclusion
- [x] Integration tests with mock language models
- [x] Backward compatibility verified
- [x] Code linted and formatted

🤖 Generated with [Claude Code](https://claude.ai/code)