### PR TITLE
fix: Pin transformers version to resolve CI aimv2 conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "typing-extensions>=4.0.0",
     "reward-hub==0.1.1",
     "vllm<=0.9.1",  # Pin to avoid build issues with newer versions requiring Rust compilation
+    "transformers==4.53.2",  # Pin to exact version that worked in CI to avoid aimv2 config conflict with vLLM 0.9.1
     "backoff>=2.2.0",
     "click>=8.1.0",
     "fastapi>=0.115.0",


### PR DESCRIPTION
## Problem

CI was failing on PR #99 due to a dependency version conflict:
- **Working CI (July)**: transformers==4.53.2 ✅  
- **Failing CI (Now)**: transformers==4.55.0 ❌

Error: `ValueError: 'aimv2' is already used by a Transformers config, pick another name.`

## Root Cause

The newer transformers version (4.55.0) introduced an `aimv2` config that conflicts with vLLM 0.9.1's own aimv2 implementation in `vllm.transformers_utils.configs.ovis.py:76`.

## Solution

Pin `transformers==4.53.2` to the exact version that was working in the last successful CI run from July 2025.

## Testing

✅ Verified locally that:
- Import `from reward_hub.base import AggregationMethod` now succeeds
- All StepGeneration tests still pass
- Dependency resolution works correctly

This should restore CI to working state without affecting any functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)