### PR TITLE
Lower Python version requirement to >=3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "Kai Xu and the Red Hat AI Innovation Team", email = "xuk@redhat.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- Update minimum Python version from 3.11 to 3.10 in `pyproject.toml`
- Add Python 3.10 to the CI test matrix in `.github/workflows/tests.yaml`

This change broadens the compatibility of the library to support Python 3.10+, making it accessible to more users and environments.

## Test plan
- CI will run tests on Python 3.10, 3.11, and 3.12
- Verify all tests pass on Python 3.10