### PR TITLE
Update reward_hub dependency to v0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "openai>=1.75.0",
     "tqdm>=4.65.0",
     "typing-extensions>=4.0.0",
-    "reward-hub @ git+https://github.com/Red-Hat-AI-Innovation-Team/reward_hub.git@main",
+    "reward-hub @ git+https://github.com/Red-Hat-AI-Innovation-Team/reward_hub.git@v0.1.3",
     "transformers==4.53.2",  # Pin to exact version that worked in CI to avoid aimv2 config conflict with vLLM 0.9.1
     "backoff>=2.2.0",
     "click>=8.1.0",


### PR DESCRIPTION
## Summary
- Updates the reward_hub dependency from @main to the stable v0.1.3 release

## Changes
- Updated pyproject.toml to pin reward_hub to v0.1.3 tag instead of tracking @main

## Motivation
This change provides better version stability and reproducibility by using a tagged release instead of tracking the main branch.