### PR TITLE
relax dependency bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,7 @@ dependencies = [
     "numpy",
     "requests",
     "aiohttp>=3.9.0",
-    "litellm>=1.70.0,<1.75.0",
-    "torch>=2.7.0",
-    "python-dotenv>=1.0.0",
-    "tenacity>=8.0.0"
+    "litellm>=1.70.0,<1.75.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
1. upgrade reward-hub to be >=0.1.6
2. remove pinned version, in favor of lower-bounding. 
3. allow [prm] group to support legacy reward models