### PR TITLE
Rename selection_method to final_response_selection for clarity

### DIFF
--- a/its_hub/algorithms/particle_gibbs.py
+++ b/its_hub/algorithms/particle_gibbs.py
@@ -106,7 +106,7 @@ class ParticleGibbs(AbstractScalingAlgorithm):
         sg: StepGeneration,
         prm: AbstractProcessRewardModel,
         num_iterations: int = 1,
-        selection_method: str | SelectionMethod = SelectionMethod.ARGMAX,
+        final_response_selection: str | SelectionMethod = SelectionMethod.ARGMAX,
         num_ref_particles: int = 1,
         does_ancestor_sampling: bool = False,
         does_entropic_annealing: bool = False,
@@ -116,8 +116,8 @@ class ParticleGibbs(AbstractScalingAlgorithm):
         resampling_method: str | ResamplingMethod = ResamplingMethod.MULTINOMIAL,
         temperature_method: str | TemperatureMethod = TemperatureMethod.ESS,
     ):
-        if isinstance(selection_method, str):
-            selection_method = SelectionMethod(selection_method)
+        if isinstance(final_response_selection, str):
+            final_response_selection = SelectionMethod(final_response_selection)
 
         if isinstance(resampling_method, str):
             resampling_method = ResamplingMethod(resampling_method)
@@ -128,7 +128,7 @@ class ParticleGibbs(AbstractScalingAlgorithm):
         self.sg = sg
         self.prm = prm
         self.num_iterations = num_iterations
-        self.selection_method = selection_method
+        self.final_response_selection = final_response_selection
         self.num_ref_particles = num_ref_particles
         self.does_ancestor_sampling = does_ancestor_sampling
         self.does_entropic_annealing = does_entropic_annealing
@@ -478,9 +478,9 @@ class ParticleGibbs(AbstractScalingAlgorithm):
             ref_indices_lst.append(ref_indices)
             steps_used_lst.append([len(p.steps) for p in particles])
 
-        # select the chosen particle based on selection method
+        # select the chosen particle based on final response selection method
         # log_weights and probabilities are from the last iteration
-        match self.selection_method:
+        match self.final_response_selection:
             case SelectionMethod.SAMPLE:
                 selected_index = random.choices(
                     range(len(particles)), weights=probabilities, k=1
@@ -508,7 +508,7 @@ class ParticleFiltering(ParticleGibbs):
         self,
         sg: StepGeneration,
         prm: AbstractProcessRewardModel,
-        selection_method: str | SelectionMethod = SelectionMethod.ARGMAX,
+        final_response_selection: str | SelectionMethod = SelectionMethod.ARGMAX,
         resampling_method: str | ResamplingMethod = ResamplingMethod.MULTINOMIAL,
     ):
         # initialize with num_iterations=1
@@ -516,7 +516,7 @@ class ParticleFiltering(ParticleGibbs):
             sg=sg,
             prm=prm,
             num_iterations=1,
-            selection_method=selection_method,
+            final_response_selection=final_response_selection,
             num_ref_particles=0,
             does_ancestor_sampling=False,
             does_entropic_annealing=False,
@@ -563,7 +563,7 @@ class EntropicParticleFiltering(ParticleGibbs):
         self,
         sg: StepGeneration,
         prm: AbstractProcessRewardModel,
-        selection_method: str | SelectionMethod = SelectionMethod.ARGMAX,
+        final_response_selection: str | SelectionMethod = SelectionMethod.ARGMAX,
         resampling_method: str | ResamplingMethod = ResamplingMethod.SYSTEMATIC,
         temperature_method: str | TemperatureMethod = TemperatureMethod.ESS,
         ess_threshold: float = 0.5,
@@ -574,7 +574,7 @@ class EntropicParticleFiltering(ParticleGibbs):
             sg=sg,
             prm=prm,
             num_iterations=1,
-            selection_method=selection_method,
+            final_response_selection=final_response_selection,
             num_ref_particles=0,
             does_ancestor_sampling=False,
             does_entropic_annealing=True,

--- a/its_hub/algorithms/planning_wrapper.py
+++ b/its_hub/algorithms/planning_wrapper.py
@@ -316,11 +316,11 @@ def create_planning_self_consistency(extract_fn=None):
     return PlanningWrapper(base_alg)
 
 
-def create_planning_particle_filtering(sg, prm, selection_method="argmax"):
+def create_planning_particle_filtering(sg, prm, final_response_selection="argmax"):
     """Create Planning-Enhanced Particle Filtering algorithm."""
     from its_hub.algorithms import ParticleFiltering
 
-    base_alg = ParticleFiltering(sg, prm, selection_method)
+    base_alg = ParticleFiltering(sg, prm, final_response_selection)
     return PlanningWrapper(base_alg)
 
 

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -1020,7 +1020,7 @@ class TestParticleGibbs:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(
-            sg, mock_prm, num_iterations=1, selection_method=SelectionMethod.ARGMAX
+            sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX
         )
 
         result = particle_gibbs.infer(
@@ -1043,21 +1043,21 @@ class TestParticleGibbs:
             particle_gibbs.infer(mock_lm, "test prompt", budget=4)
 
     @pytest.mark.parametrize(
-        "selection_method,expected_type",
+        "final_response_selection,expected_type",
         [
             (SelectionMethod.ARGMAX, dict),
             (SelectionMethod.SAMPLE, dict),
             ("argmax", dict),  # Test string conversion
         ],
     )
-    def test_selection_methods(self, selection_method, expected_type):
+    def test_selection_methods(self, final_response_selection, expected_type):
         """Test different selection methods."""
         mock_lm = StepMockLanguageModel(["good_step", "bad_step"])
         mock_prm = MockProcessRewardModel([0.9, 0.1])
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(
-            sg, mock_prm, num_iterations=1, selection_method=selection_method
+            sg, mock_prm, num_iterations=1, final_response_selection=final_response_selection
         )
         result = particle_gibbs.infer(
             mock_lm, "Solve this:", budget=2, return_response_only=True
@@ -1075,7 +1075,7 @@ class TestParticleGibbs:
             sg,
             mock_prm,
             num_iterations=2,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             num_ref_particles=1,
         )
 
@@ -1110,7 +1110,7 @@ class TestParticleGibbs:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(
-            sg, mock_prm, num_iterations=1, selection_method=SelectionMethod.ARGMAX
+            sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX
         )
 
         chat_messages = ChatMessages("Solve this:")
@@ -1134,7 +1134,7 @@ class TestParticleGibbs:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(
-            sg, mock_prm, num_iterations=1, selection_method=SelectionMethod.ARGMAX
+            sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX
         )
         result = particle_gibbs.infer(
             mock_lm, chat_messages, budget=2, return_response_only=True
@@ -1149,7 +1149,7 @@ class TestParticleGibbs:
         mock_prm = MockProcessRewardModel([0.7, 0.6])
 
         sg = StepGeneration(step_token="\n", max_steps=1)
-        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, selection_method=SelectionMethod.ARGMAX)
+        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX)
 
         result = await particle_gibbs.ainfer(mock_lm, "Solve this:", budget=2, return_response_only=True)
 
@@ -1168,18 +1168,18 @@ class TestParticleGibbs:
             await particle_gibbs.ainfer(mock_lm, "test prompt", budget=4)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("selection_method,expected_type", [
+    @pytest.mark.parametrize("final_response_selection,expected_type", [
         (SelectionMethod.ARGMAX, dict),
         (SelectionMethod.SAMPLE, dict),
         ("argmax", dict),  # Test string conversion
     ])
-    async def test_ainfer_selection_methods(self, selection_method, expected_type):
+    async def test_ainfer_selection_methods(self, final_response_selection, expected_type):
         """Test async different selection methods."""
         mock_lm = StepMockLanguageModel(["good_step", "bad_step"])
         mock_prm = MockProcessRewardModel([0.9, 0.1])
 
         sg = StepGeneration(step_token="\n", max_steps=1)
-        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, selection_method=selection_method)
+        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, final_response_selection=final_response_selection)
         result = await particle_gibbs.ainfer(mock_lm, "Solve this:", budget=2, return_response_only=True)
 
         assert isinstance(result, expected_type)
@@ -1194,7 +1194,7 @@ class TestParticleGibbs:
         particle_gibbs = ParticleGibbs(
             sg, mock_prm,
             num_iterations=2,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             num_ref_particles=1
         )
 
@@ -1212,7 +1212,7 @@ class TestParticleGibbs:
         mock_prm = MockProcessRewardModel([0.7, 0.6])
 
         sg = StepGeneration(step_token="\n", max_steps=1)
-        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, selection_method=SelectionMethod.ARGMAX)
+        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX)
 
         chat_messages = ChatMessages("Solve this:")
         result = await particle_gibbs.ainfer(mock_lm, chat_messages, budget=2, return_response_only=False)
@@ -1233,7 +1233,7 @@ class TestParticleGibbs:
         chat_messages = ChatMessages(messages)
 
         sg = StepGeneration(step_token="\n", max_steps=1)
-        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, selection_method=SelectionMethod.ARGMAX)
+        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX)
         result = await particle_gibbs.ainfer(mock_lm, chat_messages, budget=2, return_response_only=True)
 
         assert isinstance(result, dict)
@@ -1250,7 +1250,7 @@ class TestParticleFiltering:
         sg = StepGeneration(step_token="\n", max_steps=1)
 
         particle_filtering = ParticleFiltering(
-            sg, mock_prm, selection_method=SelectionMethod.ARGMAX
+            sg, mock_prm, final_response_selection=SelectionMethod.ARGMAX
         )
         result = particle_filtering.infer(
             mock_lm, "Solve this:", budget=2, return_response_only=False
@@ -1273,7 +1273,7 @@ class TestParticleFiltering:
         sg = StepGeneration(step_token="\n", max_steps=1)
 
         particle_filtering = ParticleFiltering(
-            sg, mock_prm, selection_method=SelectionMethod.ARGMAX
+            sg, mock_prm, final_response_selection=SelectionMethod.ARGMAX
         )
         result = particle_filtering.infer(
             mock_lm, "Solve this:", budget=2, return_response_only=True
@@ -1290,7 +1290,7 @@ class TestParticleFiltering:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_filtering = ParticleFiltering(
-            sg, mock_prm, selection_method=SelectionMethod.ARGMAX
+            sg, mock_prm, final_response_selection=SelectionMethod.ARGMAX
         )
 
         chat_messages = ChatMessages("Solve this:")
@@ -1314,7 +1314,7 @@ class TestParticleFiltering:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_filtering = ParticleFiltering(
-            sg, mock_prm, selection_method=SelectionMethod.ARGMAX
+            sg, mock_prm, final_response_selection=SelectionMethod.ARGMAX
         )
         result = particle_filtering.infer(
             mock_lm, chat_messages, budget=2, return_response_only=True
@@ -1336,7 +1336,7 @@ class TestEntropicParticleFiltering:
         particle_filtering = EntropicParticleFiltering(
             sg,
             mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             temperature_method=TemperatureMethod.ESS,
             resampling_method=ResamplingMethod.MULTINOMIAL,
         )
@@ -1357,7 +1357,7 @@ class TestEntropicParticleFiltering:
         particle_filtering = EntropicParticleFiltering(
             sg,
             mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             temperature_method=TemperatureMethod.ESS,
             resampling_method=ResamplingMethod.MULTINOMIAL,
         )
@@ -1385,7 +1385,7 @@ class TestEntropicParticleFiltering:
         particle_filtering = EntropicParticleFiltering(
             sg,
             mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             temperature_method=TemperatureMethod.ESS,
             resampling_method=ResamplingMethod.MULTINOMIAL,
         )

--- a/tests/test_entropic_annealing.py
+++ b/tests/test_entropic_annealing.py
@@ -87,7 +87,7 @@ class TestEntropicAnnealing:
         epf = EntropicParticleFiltering(
             sg=sg,
             prm=mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             resampling_method=ResamplingMethod.MULTINOMIAL,
             temperature_method=TemperatureMethod.ESS,
             ess_threshold=0.5,
@@ -109,7 +109,7 @@ class TestEntropicAnnealing:
         epf = EntropicParticleFiltering(
             sg=sg,
             prm=mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             resampling_method=ResamplingMethod.MULTINOMIAL,
             temperature_method=TemperatureMethod.ESS,
             ess_threshold=0.5,
@@ -148,7 +148,7 @@ class TestEntropicAnnealing:
         epf = EntropicParticleFiltering(
             sg=sg,
             prm=mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             resampling_method=ResamplingMethod.MULTINOMIAL,
             temperature_method=TemperatureMethod.ESS,
             ess_threshold=0.5,
@@ -199,7 +199,7 @@ class TestEntropicAnnealing:
         epf = EntropicParticleFiltering(
             sg=sg,
             prm=mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             resampling_method=ResamplingMethod.MULTINOMIAL,
             temperature_method=TemperatureMethod.ESS,
             ess_threshold=0.5,
@@ -228,7 +228,7 @@ class TestEntropicAnnealing:
         epf = EntropicParticleFiltering(
             sg=sg,
             prm=mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             resampling_method=ResamplingMethod.MULTINOMIAL,
             temperature_method=TemperatureMethod.ENTROPY,
             ess_threshold=0.5,
@@ -257,7 +257,7 @@ class TestEntropicAnnealing:
         epf = EntropicParticleFiltering(
             sg=sg,
             prm=mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             resampling_method=ResamplingMethod.MULTINOMIAL,
             temperature_method=TemperatureMethod.BASE,
             ess_threshold=0.5,
@@ -286,7 +286,7 @@ class TestEntropicAnnealing:
         epf = EntropicParticleFiltering(
             sg=sg,
             prm=mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             resampling_method=ResamplingMethod.SYSTEMATIC,
             temperature_method=TemperatureMethod.ESS,
             ess_threshold=0.5,
@@ -314,7 +314,7 @@ class TestEntropicAnnealing:
         epf = EntropicParticleFiltering(
             sg=sg,
             prm=mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             resampling_method=ResamplingMethod.SYSTEMATIC,
             temperature_method=TemperatureMethod.ENTROPY,
             ess_threshold=0.5,
@@ -343,7 +343,7 @@ class TestEntropicAnnealing:
         epf = EntropicParticleFiltering(
             sg=sg,
             prm=mock_prm,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             resampling_method=ResamplingMethod.SYSTEMATIC,
             temperature_method=TemperatureMethod.BASE,
             ess_threshold=0.5,

--- a/tests/test_particle_gibbs_resampling.py
+++ b/tests/test_particle_gibbs_resampling.py
@@ -91,7 +91,7 @@ class TestParticleGibbsResampling:
             sg=sg,
             prm=mock_prm,
             num_iterations=2,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             num_ref_particles=1,
         )
 
@@ -141,7 +141,7 @@ class TestParticleGibbsResampling:
             sg=sg,
             prm=mock_prm,
             num_iterations=1,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             num_ref_particles=1,
         )
 
@@ -176,7 +176,7 @@ class TestParticleGibbsResampling:
             sg=sg,
             prm=mock_prm,
             num_iterations=2,
-            selection_method=SelectionMethod.ARGMAX,
+            final_response_selection=SelectionMethod.ARGMAX,
             num_ref_particles=1,
         )
 


### PR DESCRIPTION
## Summary
Renames the `selection_method` parameter to `final_response_selection` in `ParticleGibbs` and related classes to better reflect its purpose.

## Background
The `selection_method` parameter was misleading as it only controls **final response selection**, not intermediate resampling steps. During intermediate steps, the algorithm always performs resampling (multinomial or systematic) based on particle weights. The `selection_method` parameter only determines how to select the final response from the last iteration's particles (either by sampling according to weights or selecting the highest-scoring particle).

As pointed out by @gx-ai-architect in #169, the parameter name should clarify this distinction.

## Changes
- Renamed `selection_method` → `final_response_selection` in:
  - `ParticleGibbs.__init__()`
  - `ParticleFiltering.__init__()`
  - `EntropicParticleFiltering.__init__()`
  - `create_planning_particle_filtering()`
- Updated all references in implementation code
- Updated all test parameter names for consistency
- Updated inline comments to clarify usage

## Testing
All existing tests pass:
- `tests/test_algorithms.py::TestParticleGibbs` ✅
- `tests/test_algorithms.py::TestParticleFiltering` ✅
- `tests/test_algorithms.py::TestEntropicParticleFiltering` ✅
- `tests/test_particle_gibbs_resampling.py` ✅
- `tests/test_entropic_annealing.py` ✅

Fixes #169