### PR TITLE
feat: pass response_format through iaas with fallback

### DIFF
--- a/its_hub/algorithms/__init__.py
+++ b/its_hub/algorithms/__init__.py
@@ -57,6 +57,7 @@ class MetropolisHastings(AbstractScalingAlgorithm):
         budget: int,
         show_progress: bool = False,
         return_response_only: bool = True,
+        response_format: dict | None = None,
     ) -> str | MetropolisHastingsResult:
         # TODO: Implement Metropolis-Hastings algorithm
         # Will need to convert prompt_or_messages to ChatMessages format when implemented

--- a/its_hub/algorithms/beam_search.py
+++ b/its_hub/algorithms/beam_search.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 import numpy as np
 from pydantic.dataclasses import dataclass
@@ -134,6 +135,7 @@ class BeamSearch(AbstractScalingAlgorithm):
         return_response_only: bool = True,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | BeamSearchResult:
         """run inference asynchronously with beam search"""
         chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
@@ -141,6 +143,11 @@ class BeamSearch(AbstractScalingAlgorithm):
         assert budget >= self.beam_width, (
             "budget must be greater than or equal to beam_width"
         )
+
+        if response_format is not None:
+            logging.warning(
+                "response_format is ignored for beam search algorithms using step-wise generation"
+            )
 
         num_beams = budget // self.beam_width
 

--- a/its_hub/algorithms/bon.py
+++ b/its_hub/algorithms/bon.py
@@ -60,13 +60,22 @@ class BestOfN(AbstractScalingAlgorithm):
         return_response_only: bool = True,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | BestOfNResult:
         """run inference asynchronously with best-of-n"""
         chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
 
+        generation_kwargs: dict = {
+            "tools": tools,
+            "tool_choice": tool_choice,
+        }
+        if response_format is not None:
+            generation_kwargs["response_format"] = response_format
+
         # generate responses
         responses = await lm.agenerate(
-            chat_messages.to_batch(budget), tools=tools, tool_choice=tool_choice
+            chat_messages.to_batch(budget),
+            **generation_kwargs,
         )
 
         # extract content from message dict responses

--- a/its_hub/algorithms/particle_gibbs.py
+++ b/its_hub/algorithms/particle_gibbs.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import random
 from enum import Enum
 
@@ -372,12 +373,18 @@ class ParticleGibbs(AbstractScalingAlgorithm):
         return_response_only: bool = True,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | ParticleGibbsResult:
         """run inference asynchronously with particle gibbs"""
         chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
         assert budget % self.num_iterations == 0, (
             "budget must be divisible by num_iterations"
         )
+
+        if response_format is not None:
+            logging.warning(
+                "response_format is ignored for particle-based algorithms using step-wise generation"
+            )
 
         num_particles = budget // self.num_iterations
 
@@ -531,6 +538,7 @@ class ParticleFiltering(ParticleGibbs):
         return_response_only: bool = True,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | ParticleFilteringResult:
         """run inference asynchronously with particle filtering"""
         result = await super().ainfer(
@@ -540,6 +548,7 @@ class ParticleFiltering(ParticleGibbs):
             return_response_only=False,
             tools=tools,
             tool_choice=tool_choice,
+            response_format=response_format,
         )
 
         # Flatten the single-iteration result

--- a/its_hub/algorithms/particle_gibbs.py
+++ b/its_hub/algorithms/particle_gibbs.py
@@ -602,6 +602,7 @@ class EntropicParticleFiltering(ParticleGibbs):
         return_response_only: bool = True,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | ParticleFilteringResult:
         result = super().infer(
             lm,
@@ -610,6 +611,7 @@ class EntropicParticleFiltering(ParticleGibbs):
             return_response_only=False,
             tools=tools,
             tool_choice=tool_choice,
+            response_format=response_format,
         )
 
         # Flatten the single-iteration result

--- a/its_hub/algorithms/planning_wrapper.py
+++ b/its_hub/algorithms/planning_wrapper.py
@@ -136,6 +136,7 @@ class PlanningWrapper(AbstractScalingAlgorithm):
         return_response_only: bool = True,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | PlanningWrappedResult:
         """run planning-enhanced inference asynchronously"""
         chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
@@ -201,6 +202,7 @@ class PlanningWrapper(AbstractScalingAlgorithm):
                 return_response_only=False,
                 tools=tools,
                 tool_choice=tool_choice,
+                response_format=response_format,
             )
 
             # Store approach-specific result

--- a/its_hub/algorithms/self_consistency.py
+++ b/its_hub/algorithms/self_consistency.py
@@ -170,22 +170,29 @@ class SelfConsistency(AbstractScalingAlgorithm):
         return_response_only: bool = True,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | SelfConsistencyResult:
         """run inference asynchronously with self-consistency"""
         chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
 
+        generation_kwargs: dict = {
+            "tools": tools,
+            "tool_choice": tool_choice,
+        }
+        if response_format is not None:
+            generation_kwargs["response_format"] = response_format
+
         # generate responses
         responses = await lm.agenerate(
-            chat_messages.to_batch(budget), tools=tools, tool_choice=tool_choice
+            chat_messages.to_batch(budget),
+            **generation_kwargs,
         )
 
         # process responses and return result
         return self._process_responses(responses, return_response_only)
 
     def _process_responses(
-        self,
-        responses: list[dict],
-        return_response_only: bool = True
+        self, responses: list[dict], return_response_only: bool = True
     ) -> dict | SelfConsistencyResult:
         """Process responses and return result."""
         # Check if majority of responses have tool calls to decide voting method
@@ -215,7 +222,9 @@ class SelfConsistency(AbstractScalingAlgorithm):
                 i for i, r in enumerate(responses) if not r.get("tool_calls")
             ]
             responses_projected = [
-                self.consistency_space_projection_func(extract_content_from_lm_response(responses[i]))
+                self.consistency_space_projection_func(
+                    extract_content_from_lm_response(responses[i])
+                )
                 for i in eligible_indices
             ]
 

--- a/its_hub/base.py
+++ b/its_hub/base.py
@@ -51,6 +51,7 @@ class AbstractScalingAlgorithm(ABC):
         return_response_only: bool = True,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> str | AbstractScalingResult:
         """
         Run inference asynchronously with the given language model and prompt.
@@ -67,6 +68,7 @@ class AbstractScalingAlgorithm(ABC):
         return_response_only: bool = True,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> str | AbstractScalingResult:
         """
         Run inference synchronously with the given language model and prompt.
@@ -77,7 +79,13 @@ class AbstractScalingAlgorithm(ABC):
 
         return asyncio.run(
             self.ainfer(
-                lm, prompt_or_messages, budget, return_response_only, tools, tool_choice
+                lm,
+                prompt_or_messages,
+                budget,
+                return_response_only,
+                tools,
+                tool_choice,
+                response_format,
             )
         )
 

--- a/its_hub/integration/iaas.py
+++ b/its_hub/integration/iaas.py
@@ -378,6 +378,10 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: str | dict[str, Any] | None = Field(
         None, description="Tool choice strategy ('auto', 'none', or specific tool)"
     )
+    response_format: dict[str, Any] | None = Field(
+        None,
+        description="OpenAI-compatible structured output configuration",
+    )
     return_response_only: bool = Field(
         True, description="Return only final response or include algorithm metadata"
     )
@@ -502,6 +506,7 @@ async def chat_completions(request: ChatCompletionRequest) -> ChatCompletionResp
             return_response_only=request.return_response_only,
             tools=request.tools,
             tool_choice=request.tool_choice,
+            response_format=request.response_format,
         )
 
         # Extract response content and metadata

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import ssl
+from collections import OrderedDict
 
 import aiohttp
 import backoff
@@ -38,6 +39,68 @@ def _is_response_format_unsupported_error(error: Exception | str) -> bool:
         "extra inputs are not permitted",
     )
     return any(marker in message for marker in unsupported_markers)
+
+
+_RESPONSE_FORMAT_SUPPORT_CACHE_MAX_SIZE = 256
+_RESPONSE_FORMAT_SUPPORT_CACHE: OrderedDict[tuple[str, ...], bool] = OrderedDict()
+
+
+def _remove_response_format(request_data: dict) -> dict:
+    return {
+        key: value for key, value in request_data.items() if key != "response_format"
+    }
+
+
+def _get_cached_response_format_support(cache_key: tuple[str, ...]) -> bool | None:
+    support = _RESPONSE_FORMAT_SUPPORT_CACHE.get(cache_key)
+    if support is None:
+        return None
+
+    _RESPONSE_FORMAT_SUPPORT_CACHE.move_to_end(cache_key)
+    return support
+
+
+def _set_cached_response_format_support(
+    cache_key: tuple[str, ...], is_supported: bool
+) -> None:
+    _RESPONSE_FORMAT_SUPPORT_CACHE[cache_key] = is_supported
+    _RESPONSE_FORMAT_SUPPORT_CACHE.move_to_end(cache_key)
+
+    while len(_RESPONSE_FORMAT_SUPPORT_CACHE) > _RESPONSE_FORMAT_SUPPORT_CACHE_MAX_SIZE:
+        _RESPONSE_FORMAT_SUPPORT_CACHE.popitem(last=False)
+
+
+def _prepare_request_data_for_response_format_support(
+    request_data: dict,
+    cache_key: tuple[str, ...],
+) -> tuple[dict, bool]:
+    if request_data.get("response_format") is None:
+        return request_data, False
+
+    if _get_cached_response_format_support(cache_key) is False:
+        return _remove_response_format(request_data), False
+
+    return request_data, True
+
+
+def _build_response_format_fallback_request(
+    request_data: dict,
+    error: Exception | str,
+    cache_key: tuple[str, ...],
+    provider_name: str,
+) -> dict | None:
+    if request_data.get("response_format") is None:
+        return None
+
+    if not _is_response_format_unsupported_error(error):
+        return None
+
+    _set_cached_response_format_support(cache_key, False)
+    logging.warning(
+        "%s does not support response_format; retrying without response_format",
+        provider_name,
+    )
+    return _remove_response_format(request_data)
 
 
 def rstrip_iff_entire(s: str, subs: str) -> str:
@@ -315,6 +378,10 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
     def _chat_completion_endpoint(self) -> str:
         return self.endpoint.rstrip("/") + "/chat/completions"
 
+    @property
+    def _response_format_cache_key(self) -> tuple[str, ...]:
+        return ("openai-compatible", self.endpoint.rstrip("/"), self.model_name)
+
     def _prepare_request_data(
         self,
         messages: list[ChatMessage],
@@ -426,6 +493,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                 messages: list[ChatMessage], _temperature: float | None
             ) -> dict:
                 async with semaphore:
+                    cache_key = self._response_format_cache_key
                     request_data = self._prepare_request_data(
                         messages,
                         stop,
@@ -435,6 +503,12 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                         tools,
                         tool_choice,
                         response_format,
+                    )
+                    request_data, attempted_response_format = (
+                        _prepare_request_data_for_response_format_support(
+                            request_data,
+                            cache_key,
+                        )
                     )
 
                     async with session.post(
@@ -446,19 +520,15 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                             error_text = await response.text()
                             api_error = parse_api_error(response.status, error_text)
 
-                            if request_data.get(
-                                "response_format"
-                            ) is not None and _is_response_format_unsupported_error(
-                                api_error
-                            ):
-                                logging.warning(
-                                    "Upstream model does not support response_format; retrying without response_format"
+                            fallback_request_data = (
+                                _build_response_format_fallback_request(
+                                    request_data,
+                                    api_error,
+                                    cache_key,
+                                    "Upstream model",
                                 )
-                                fallback_request_data = {
-                                    key: value
-                                    for key, value in request_data.items()
-                                    if key != "response_format"
-                                }
+                            )
+                            if fallback_request_data is not None:
                                 async with session.post(
                                     self._chat_completion_endpoint,
                                     headers=self.headers,
@@ -490,6 +560,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                                 logging.error(format_non_retryable_error(api_error))
                             raise api_error
                         response_json = await response.json()
+                        if attempted_response_format:
+                            _set_cached_response_format_support(cache_key, True)
                         # Return the full message object to preserve tool calls
                         return response_json["choices"][0]["message"]
 
@@ -648,6 +720,15 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
         self.custom_llm_provider = custom_llm_provider
         self.extra_kwargs = kwargs
 
+    @property
+    def _response_format_cache_key(self) -> tuple[str, ...]:
+        return (
+            "litellm",
+            self.model_name,
+            self.api_base or "",
+            self.custom_llm_provider or "",
+        )
+
     def _prepare_request_data(
         self,
         messages: list[ChatMessage],
@@ -753,6 +834,7 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
             messages: list[ChatMessage], _temperature: float | None
         ) -> dict:
             async with semaphore:
+                cache_key = self._response_format_cache_key
                 request_data = self._prepare_request_data(
                     messages,
                     stop,
@@ -763,24 +845,31 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
                     tool_choice,
                     response_format,
                 )
+                request_data, attempted_response_format = (
+                    _prepare_request_data_for_response_format_support(
+                        request_data,
+                        cache_key,
+                    )
+                )
+                used_fallback = False
 
                 try:
                     response = await litellm.acompletion(**request_data)
                 except Exception as e:
-                    if request_data.get(
-                        "response_format"
-                    ) is None or not _is_response_format_unsupported_error(e):
+                    fallback_request_data = _build_response_format_fallback_request(
+                        request_data,
+                        e,
+                        cache_key,
+                        "LiteLLM provider",
+                    )
+                    if fallback_request_data is None:
                         raise
 
-                    logging.warning(
-                        "LiteLLM provider does not support response_format; retrying without response_format"
-                    )
-                    fallback_request_data = {
-                        key: value
-                        for key, value in request_data.items()
-                        if key != "response_format"
-                    }
                     response = await litellm.acompletion(**fallback_request_data)
+                    used_fallback = True
+
+                if attempted_response_format and not used_fallback:
+                    _set_cached_response_format_support(cache_key, True)
                 # Return the full message object to preserve tool calls
                 return response.choices[0].message.dict()
 
@@ -876,6 +965,7 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
             def fetch_single_response(
                 messages: list[ChatMessage], _temperature: float | None
             ) -> dict:
+                cache_key = self._response_format_cache_key
                 request_data = self._prepare_request_data(
                     messages,
                     stop,
@@ -886,24 +976,31 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
                     tool_choice,
                     response_format,
                 )
+                request_data, attempted_response_format = (
+                    _prepare_request_data_for_response_format_support(
+                        request_data,
+                        cache_key,
+                    )
+                )
+                used_fallback = False
 
                 try:
                     response = litellm.completion(**request_data)
                 except Exception as e:
-                    if request_data.get(
-                        "response_format"
-                    ) is None or not _is_response_format_unsupported_error(e):
+                    fallback_request_data = _build_response_format_fallback_request(
+                        request_data,
+                        e,
+                        cache_key,
+                        "LiteLLM provider",
+                    )
+                    if fallback_request_data is None:
                         raise
 
-                    logging.warning(
-                        "LiteLLM provider does not support response_format; retrying without response_format"
-                    )
-                    fallback_request_data = {
-                        key: value
-                        for key, value in request_data.items()
-                        if key != "response_format"
-                    }
                     response = litellm.completion(**fallback_request_data)
+                    used_fallback = True
+
+                if attempted_response_format and not used_fallback:
+                    _set_cached_response_format_support(cache_key, True)
                 # Return the full message object to preserve tool calls
                 return response.choices[0].message.dict()
 

--- a/its_hub/lms.py
+++ b/its_hub/lms.py
@@ -25,6 +25,21 @@ from .types import ChatMessage
 from .utils import extract_content_from_lm_response
 
 
+def _is_response_format_unsupported_error(error: Exception | str) -> bool:
+    message = str(error).lower()
+    if "response_format" not in message and "json_schema" not in message:
+        return False
+
+    unsupported_markers = (
+        "not supported",
+        "unsupported",
+        "unknown",
+        "invalid parameter",
+        "extra inputs are not permitted",
+    )
+    return any(marker in message for marker in unsupported_markers)
+
+
 def rstrip_iff_entire(s: str, subs: str) -> str:
     if s.endswith(subs):
         # If s ends with subs, return the string without the length of subs at the end
@@ -309,6 +324,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict:
         # helper method to prepare request data for both sync and async methods
         # Convert dict messages to Message objects if needed
@@ -370,6 +386,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
             request_data["tools"] = tools
         if tool_choice is not None:
             request_data["tool_choice"] = tool_choice
+        if response_format is not None:
+            request_data["response_format"] = response_format
 
         return request_data
 
@@ -382,6 +400,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> list[dict]:
         # limit concurrency to max_concurrency using a semaphore
         semaphore = asyncio.Semaphore(
@@ -415,6 +434,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                         include_stop_str_in_output,
                         tools,
                         tool_choice,
+                        response_format,
                     )
 
                     async with session.post(
@@ -425,6 +445,47 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                         if response.status != 200:
                             error_text = await response.text()
                             api_error = parse_api_error(response.status, error_text)
+
+                            if request_data.get(
+                                "response_format"
+                            ) is not None and _is_response_format_unsupported_error(
+                                api_error
+                            ):
+                                logging.warning(
+                                    "Upstream model does not support response_format; retrying without response_format"
+                                )
+                                fallback_request_data = {
+                                    key: value
+                                    for key, value in request_data.items()
+                                    if key != "response_format"
+                                }
+                                async with session.post(
+                                    self._chat_completion_endpoint,
+                                    headers=self.headers,
+                                    json=fallback_request_data,
+                                ) as fallback_response:
+                                    if fallback_response.status != 200:
+                                        fallback_error_text = (
+                                            await fallback_response.text()
+                                        )
+                                        fallback_api_error = parse_api_error(
+                                            fallback_response.status,
+                                            fallback_error_text,
+                                        )
+                                        if not should_retry(fallback_api_error):
+                                            logging.error(
+                                                format_non_retryable_error(
+                                                    fallback_api_error
+                                                )
+                                            )
+                                        raise fallback_api_error
+                                    fallback_response_json = (
+                                        await fallback_response.json()
+                                    )
+                                    return fallback_response_json["choices"][0][
+                                        "message"
+                                    ]
+
                             if not should_retry(api_error):
                                 logging.error(format_non_retryable_error(api_error))
                             raise api_error
@@ -475,6 +536,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | list[dict]:
         """generate response(s) asynchronously"""
         is_single = not isinstance(messages_or_messages_lst[0], list)
@@ -489,6 +551,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
             include_stop_str_in_output,
             tools,
             tool_choice,
+            response_format,
         )
         return response_or_responses[0] if is_single else response_or_responses
 
@@ -501,6 +564,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | list[dict]:
         """Generate response(s) synchronously.
 
@@ -522,6 +586,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                 include_stop_str_in_output,
                 tools,
                 tool_choice,
+                response_format,
             )
         )
         return response_or_responses[0] if is_single else response_or_responses
@@ -592,6 +657,7 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict:
         # Convert dict messages to Message objects if needed
         messages = [
@@ -643,6 +709,8 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
             request_data["tools"] = tools
         if tool_choice is not None:
             request_data["tool_choice"] = tool_choice
+        if response_format is not None:
+            request_data["response_format"] = response_format
 
         # add any extra kwargs
         request_data.update(self.extra_kwargs)
@@ -663,6 +731,7 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> list[dict]:
         import time
 
@@ -692,9 +761,26 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
                     include_stop_str_in_output,
                     tools,
                     tool_choice,
+                    response_format,
                 )
 
-                response = await litellm.acompletion(**request_data)
+                try:
+                    response = await litellm.acompletion(**request_data)
+                except Exception as e:
+                    if request_data.get(
+                        "response_format"
+                    ) is None or not _is_response_format_unsupported_error(e):
+                        raise
+
+                    logging.warning(
+                        "LiteLLM provider does not support response_format; retrying without response_format"
+                    )
+                    fallback_request_data = {
+                        key: value
+                        for key, value in request_data.items()
+                        if key != "response_format"
+                    }
+                    response = await litellm.acompletion(**fallback_request_data)
                 # Return the full message object to preserve tool calls
                 return response.choices[0].message.dict()
 
@@ -735,6 +821,7 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | list[dict]:
         # Check if we have a single list of messages or a list of message lists
         is_single = not isinstance(messages_or_messages_lst[0], list)
@@ -759,6 +846,7 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
                                 include_stop_str_in_output,
                                 tools,
                                 tool_choice,
+                                response_format,
                             )
                         )
                     ).result()
@@ -773,6 +861,7 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
                         include_stop_str_in_output,
                         tools,
                         tool_choice,
+                        response_format,
                     )
                 )
         else:
@@ -795,9 +884,26 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
                     include_stop_str_in_output,
                     tools,
                     tool_choice,
+                    response_format,
                 )
 
-                response = litellm.completion(**request_data)
+                try:
+                    response = litellm.completion(**request_data)
+                except Exception as e:
+                    if request_data.get(
+                        "response_format"
+                    ) is None or not _is_response_format_unsupported_error(e):
+                        raise
+
+                    logging.warning(
+                        "LiteLLM provider does not support response_format; retrying without response_format"
+                    )
+                    fallback_request_data = {
+                        key: value
+                        for key, value in request_data.items()
+                        if key != "response_format"
+                    }
+                    response = litellm.completion(**fallback_request_data)
                 # Return the full message object to preserve tool calls
                 return response.choices[0].message.dict()
 
@@ -836,6 +942,7 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | list[dict]:
         """Async version of generate method for use in async contexts."""
         # Check if we have a single list of messages or a list of message lists
@@ -853,6 +960,7 @@ class LiteLLMLanguageModel(AbstractLanguageModel):
             include_stop_str_in_output,
             tools,
             tool_choice,
+            response_format,
         )
 
         return response_or_responses[0] if is_single else response_or_responses

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -352,7 +352,9 @@ class TestSelfConsistency:
             return response[-1]  # Last character
 
         sc = SelfConsistency(flat_projection)
-        result = await sc.ainfer(mock_lm, "test prompt", budget=4, return_response_only=False)
+        result = await sc.ainfer(
+            mock_lm, "test prompt", budget=4, return_response_only=False
+        )
 
         assert isinstance(result, SelfConsistencyResult)
         assert len(result.responses) == 4
@@ -370,7 +372,9 @@ class TestSelfConsistency:
             return (response[0], response[1])  # First char, second char as tuple
 
         sc = SelfConsistency(hierarchical_projection)
-        result = await sc.ainfer(mock_lm, "test prompt", budget=4, return_response_only=False)
+        result = await sc.ainfer(
+            mock_lm, "test prompt", budget=4, return_response_only=False
+        )
 
         assert isinstance(result, SelfConsistencyResult)
         assert len(result.responses) == 4
@@ -388,7 +392,9 @@ class TestSelfConsistency:
             return (response[0], response[1])
 
         sc = SelfConsistency(hierarchical_projection)
-        result = await sc.ainfer(mock_lm, "test prompt", budget=4, return_response_only=True)
+        result = await sc.ainfer(
+            mock_lm, "test prompt", budget=4, return_response_only=True
+        )
 
         assert isinstance(result, dict)
         assert result["content"] in ["a1", "a2"]  # Should be one of the "a" responses
@@ -406,7 +412,9 @@ class TestSelfConsistency:
 
         # Test with ChatMessages wrapping a string
         chat_messages = ChatMessages("test prompt")
-        result = await sc.ainfer(mock_lm, chat_messages, budget=4, return_response_only=False)
+        result = await sc.ainfer(
+            mock_lm, chat_messages, budget=4, return_response_only=False
+        )
 
         assert isinstance(result, SelfConsistencyResult)
         assert len(result.responses) == 4
@@ -417,19 +425,24 @@ class TestSelfConsistency:
     def test_with_multimodal_content(self):
         """Test SelfConsistency with multi-modal list[dict] content."""
         # Mock LM returns responses with multimodal content
-        mock_lm = StepMockLanguageModel([
-            [{"type": "text", "text": "Answer: 42"}],
-            [{"type": "text", "text": "Answer: 24"}],
-            [{"type": "text", "text": "Answer: 42"}],
-        ])
+        mock_lm = StepMockLanguageModel(
+            [
+                [{"type": "text", "text": "Answer: 42"}],
+                [{"type": "text", "text": "Answer: 24"}],
+                [{"type": "text", "text": "Answer: 42"}],
+            ]
+        )
 
         messages = [
             ChatMessage(
                 role="user",
                 content=[
                     {"type": "text", "text": "What is the answer?"},
-                    {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}
-                ]
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/img.jpg"},
+                    },
+                ],
             )
         ]
 
@@ -440,6 +453,43 @@ class TestSelfConsistency:
         assert isinstance(result, dict)
         # Content should be preserved as list
         assert result["content"] == [{"type": "text", "text": "Answer: 42"}]
+
+    @pytest.mark.asyncio
+    async def test_ainfer_forwards_response_format(self):
+        """Test SelfConsistency forwards response_format to the language model."""
+
+        class CapturingLanguageModel:
+            def __init__(self):
+                self.last_kwargs = None
+
+            async def agenerate(self, messages_or_messages_lst, **kwargs):
+                self.last_kwargs = kwargs
+                if isinstance(messages_or_messages_lst[0], list):
+                    return [
+                        {"role": "assistant", "content": f"answer-{i}"}
+                        for i, _ in enumerate(messages_or_messages_lst)
+                    ]
+                return {"role": "assistant", "content": "answer"}
+
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "sc_schema",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+        lm = CapturingLanguageModel()
+        sc = SelfConsistency()
+        await sc.ainfer(lm, "test prompt", budget=2, response_format=response_format)
+
+        assert lm.last_kwargs["response_format"] == response_format
 
 
 class TestDataStructures:
@@ -482,10 +532,12 @@ class TestDataStructures:
     def test_with_multimodal_content(self):
         """Test BestOfN with multi-modal list[dict] content."""
         # Mock LM returns responses with multimodal content
-        mock_lm = StepMockLanguageModel([
-            [{"type": "text", "text": "Answer is 42"}],
-            [{"type": "text", "text": "Answer is 24"}]
-        ])
+        mock_lm = StepMockLanguageModel(
+            [
+                [{"type": "text", "text": "Answer is 42"}],
+                [{"type": "text", "text": "Answer is 24"}],
+            ]
+        )
         mock_orm = MockOutcomeRewardModel([0.3, 0.7])
 
         messages = [
@@ -493,8 +545,11 @@ class TestDataStructures:
                 role="user",
                 content=[
                     {"type": "text", "text": "What is the answer?"},
-                    {"type": "image_url", "image_url": {"url": "https://example.com/img.jpg"}}
-                ]
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/img.jpg"},
+                    },
+                ],
             )
         ]
 
@@ -613,18 +668,30 @@ class TestBestOfN:
         assert result["content"] == "response2"
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("responses,scores,expected_index,expected_response", [
-        (["response1", "response2", "response3"], [0.5, 0.8, 0.3], 1, "response2"),
-        (["response1", "response2", "response3"], [0.8, 0.5, 0.8], 0, "response1"),  # Tie - first wins
-        (["response1"], [0.7], 0, "response1"),  # Single response
-    ])
-    async def test_ainfer_selection_logic(self, responses, scores, expected_index, expected_response):
+    @pytest.mark.parametrize(
+        "responses,scores,expected_index,expected_response",
+        [
+            (["response1", "response2", "response3"], [0.5, 0.8, 0.3], 1, "response2"),
+            (
+                ["response1", "response2", "response3"],
+                [0.8, 0.5, 0.8],
+                0,
+                "response1",
+            ),  # Tie - first wins
+            (["response1"], [0.7], 0, "response1"),  # Single response
+        ],
+    )
+    async def test_ainfer_selection_logic(
+        self, responses, scores, expected_index, expected_response
+    ):
         """Test Best-of-N async ainfer selection logic with various score scenarios."""
         mock_lm = StepMockLanguageModel(responses)
         mock_orm = MockOutcomeRewardModel(scores)
 
         bon = BestOfN(mock_orm)
-        result = await bon.ainfer(mock_lm, "test prompt", budget=len(responses), return_response_only=False)
+        result = await bon.ainfer(
+            mock_lm, "test prompt", budget=len(responses), return_response_only=False
+        )
 
         assert result.selected_index == expected_index
         assert result.the_one["content"] == expected_response
@@ -636,7 +703,9 @@ class TestBestOfN:
         mock_orm = MockOutcomeRewardModel([0.5, 0.8, 0.3])
 
         bon = BestOfN(mock_orm)
-        result = await bon.ainfer(mock_lm, "test prompt", budget=3, return_response_only=True)
+        result = await bon.ainfer(
+            mock_lm, "test prompt", budget=3, return_response_only=True
+        )
 
         assert result["content"] == "response2"
 
@@ -648,7 +717,9 @@ class TestBestOfN:
 
         bon = BestOfN(mock_orm)
         chat_messages = ChatMessages("test prompt")
-        result = await bon.ainfer(mock_lm, chat_messages, budget=3, return_response_only=False)
+        result = await bon.ainfer(
+            mock_lm, chat_messages, budget=3, return_response_only=False
+        )
 
         assert isinstance(result, BestOfNResult)
         assert result.the_one["content"] == "response2"
@@ -665,12 +736,14 @@ class TestBestOfN:
             ChatMessage(role="system", content="You are a helpful assistant"),
             ChatMessage(role="user", content="What is 2+2?"),
             ChatMessage(role="assistant", content="2+2=4"),
-            ChatMessage(role="user", content="What about 3+3?")
+            ChatMessage(role="user", content="What about 3+3?"),
         ]
         chat_messages = ChatMessages(messages)
 
         bon = BestOfN(mock_orm)
-        result = await bon.ainfer(mock_lm, chat_messages, budget=3, return_response_only=False)
+        result = await bon.ainfer(
+            mock_lm, chat_messages, budget=3, return_response_only=False
+        )
 
         assert isinstance(result, BestOfNResult)
         assert result.the_one["content"] == "response2"
@@ -683,19 +756,21 @@ class TestBestOfN:
         mock_lm = StepMockLanguageModel(["response1", "response2"])
         mock_orm = MockOutcomeRewardModel([0.3, 0.7])
 
-        messages = [
-            ChatMessage(role="user", content="Solve this problem")
-        ]
+        messages = [ChatMessage(role="user", content="Solve this problem")]
 
         bon = BestOfN(mock_orm)
-        result = await bon.ainfer(mock_lm, messages, budget=2, return_response_only=True)
+        result = await bon.ainfer(
+            mock_lm, messages, budget=2, return_response_only=True
+        )
 
         assert result["content"] == "response2"
 
     def test_deduplication_all_identical(self):
         """Test Best-of-N with all identical responses - should skip scoring."""
         # All responses are identical
-        mock_lm = StepMockLanguageModel(["response1", "response1", "response1", "response1"])
+        mock_lm = StepMockLanguageModel(
+            ["response1", "response1", "response1", "response1"]
+        )
         # Mock ORM should not be called since we skip scoring for identical responses
         mock_orm = MockOutcomeRewardModel([])
 
@@ -714,10 +789,18 @@ class TestBestOfN:
     def test_deduplication_some_duplicates(self):
         """Test Best-of-N with some duplicate responses - should deduplicate before scoring."""
         # 8 responses: 3x "response1", 2x "response2", 2x "response3", 1x "response4"
-        mock_lm = StepMockLanguageModel([
-            "response1", "response2", "response1", "response3",
-            "response2", "response1", "response4", "response3"
-        ])
+        mock_lm = StepMockLanguageModel(
+            [
+                "response1",
+                "response2",
+                "response1",
+                "response3",
+                "response2",
+                "response1",
+                "response4",
+                "response3",
+            ]
+        )
         # Only 4 unique responses should be scored: response1, response2, response3, response4
         # Scores: response2 has highest score (0.9)
         mock_orm = MockOutcomeRewardModel([0.5, 0.9, 0.3, 0.7])
@@ -732,7 +815,9 @@ class TestBestOfN:
         # Verify all 8 responses have scores
         assert len(result.scores) == 8
         # Verify score mapping: indices with same content have same score
-        assert result.scores[0] == result.scores[2] == result.scores[5] == 0.5  # response1
+        assert (
+            result.scores[0] == result.scores[2] == result.scores[5] == 0.5
+        )  # response1
         assert result.scores[1] == result.scores[4] == 0.9  # response2
         assert result.scores[3] == result.scores[7] == 0.3  # response3
         assert result.scores[6] == 0.7  # response4
@@ -761,11 +846,15 @@ class TestBestOfN:
     @pytest.mark.asyncio
     async def test_ainfer_deduplication_all_identical(self):
         """Test async Best-of-N with all identical responses - should skip scoring."""
-        mock_lm = StepMockLanguageModel(["response1", "response1", "response1", "response1"])
+        mock_lm = StepMockLanguageModel(
+            ["response1", "response1", "response1", "response1"]
+        )
         mock_orm = MockOutcomeRewardModel([])
 
         bon = BestOfN(mock_orm)
-        result = await bon.ainfer(mock_lm, "test prompt", budget=4, return_response_only=False)
+        result = await bon.ainfer(
+            mock_lm, "test prompt", budget=4, return_response_only=False
+        )
 
         assert isinstance(result, BestOfNResult)
         assert result.selected_index == 0
@@ -776,14 +865,24 @@ class TestBestOfN:
     @pytest.mark.asyncio
     async def test_ainfer_deduplication_some_duplicates(self):
         """Test async Best-of-N with some duplicate responses - should deduplicate before scoring."""
-        mock_lm = StepMockLanguageModel([
-            "response1", "response2", "response1", "response3",
-            "response2", "response1", "response4", "response3"
-        ])
+        mock_lm = StepMockLanguageModel(
+            [
+                "response1",
+                "response2",
+                "response1",
+                "response3",
+                "response2",
+                "response1",
+                "response4",
+                "response3",
+            ]
+        )
         mock_orm = MockOutcomeRewardModel([0.5, 0.9, 0.3, 0.7])
 
         bon = BestOfN(mock_orm)
-        result = await bon.ainfer(mock_lm, "test prompt", budget=8, return_response_only=False)
+        result = await bon.ainfer(
+            mock_lm, "test prompt", budget=8, return_response_only=False
+        )
 
         assert isinstance(result, BestOfNResult)
         assert result.selected_index in [1, 4]
@@ -795,6 +894,42 @@ class TestBestOfN:
         assert result.scores[6] == 0.7
         assert mock_orm.score_call_count == 1
         assert mock_orm.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_ainfer_forwards_response_format(self):
+        """Test BestOfN forwards response_format to the language model."""
+
+        class CapturingLanguageModel:
+            def __init__(self):
+                self.last_kwargs = None
+
+            async def agenerate(self, messages_or_messages_lst, **kwargs):
+                self.last_kwargs = kwargs
+                return [
+                    {"role": "assistant", "content": f"candidate-{i}"}
+                    for i, _ in enumerate(messages_or_messages_lst)
+                ]
+
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "bon_schema",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+        lm = CapturingLanguageModel()
+        orm = MockOutcomeRewardModel([0.9, 0.1])
+        bon = BestOfN(orm)
+        await bon.ainfer(lm, "test prompt", budget=2, response_format=response_format)
+
+        assert lm.last_kwargs["response_format"] == response_format
 
 
 class TestBeamSearch:
@@ -913,7 +1048,9 @@ class TestBeamSearch:
         sg = StepGeneration(step_token="\n", max_steps=2)
         beam_search = BeamSearch(sg, mock_prm, beam_width=2)
 
-        result = await beam_search.ainfer(mock_lm, "Solve this problem:", budget=2, return_response_only=True)
+        result = await beam_search.ainfer(
+            mock_lm, "Solve this problem:", budget=2, return_response_only=True
+        )
 
         assert isinstance(result, dict)
 
@@ -927,19 +1064,25 @@ class TestBeamSearch:
         beam_search = BeamSearch(sg, mock_prm, beam_width=2)
 
         # Test budget not divisible by beam_width
-        with pytest.raises(AssertionError, match="budget must be divisible by beam_width"):
+        with pytest.raises(
+            AssertionError, match="budget must be divisible by beam_width"
+        ):
             await beam_search.ainfer(mock_lm, "test prompt", budget=3)
 
     @pytest.mark.asyncio
     async def test_ainfer_path_selection(self):
         """Test that async beam search selects the highest scoring path."""
-        mock_lm = StepMockLanguageModel(["good_step", "bad_step", "good_step", "bad_step"])
+        mock_lm = StepMockLanguageModel(
+            ["good_step", "bad_step", "good_step", "bad_step"]
+        )
         mock_prm = MockProcessRewardModel([0.9, 0.1, 0.8, 0.2])
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         beam_search = BeamSearch(sg, mock_prm, beam_width=2)
 
-        result = await beam_search.ainfer(mock_lm, "Solve this:", budget=4, return_response_only=False)
+        result = await beam_search.ainfer(
+            mock_lm, "Solve this:", budget=4, return_response_only=False
+        )
 
         assert isinstance(result, BeamSearchResult)
         assert result.selected_index == result.scores.index(max(result.scores))
@@ -954,7 +1097,9 @@ class TestBeamSearch:
         beam_search = BeamSearch(sg, mock_prm, beam_width=2)
 
         chat_messages = ChatMessages("Solve this problem:")
-        result = await beam_search.ainfer(mock_lm, chat_messages, budget=2, return_response_only=False)
+        result = await beam_search.ainfer(
+            mock_lm, chat_messages, budget=2, return_response_only=False
+        )
 
         assert isinstance(result, BeamSearchResult)
         assert isinstance(result.the_one, dict)
@@ -967,13 +1112,15 @@ class TestBeamSearch:
 
         messages = [
             ChatMessage(role="system", content="You are a problem solver"),
-            ChatMessage(role="user", content="Solve step by step:")
+            ChatMessage(role="user", content="Solve step by step:"),
         ]
         chat_messages = ChatMessages(messages)
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         beam_search = BeamSearch(sg, mock_prm, beam_width=2)
-        result = await beam_search.ainfer(mock_lm, chat_messages, budget=2, return_response_only=True)
+        result = await beam_search.ainfer(
+            mock_lm, chat_messages, budget=2, return_response_only=True
+        )
 
         assert isinstance(result, dict)
 
@@ -1020,7 +1167,10 @@ class TestParticleGibbs:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(
-            sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX
+            sg,
+            mock_prm,
+            num_iterations=1,
+            final_response_selection=SelectionMethod.ARGMAX,
         )
 
         result = particle_gibbs.infer(
@@ -1057,7 +1207,10 @@ class TestParticleGibbs:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(
-            sg, mock_prm, num_iterations=1, final_response_selection=final_response_selection
+            sg,
+            mock_prm,
+            num_iterations=1,
+            final_response_selection=final_response_selection,
         )
         result = particle_gibbs.infer(
             mock_lm, "Solve this:", budget=2, return_response_only=True
@@ -1110,7 +1263,10 @@ class TestParticleGibbs:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(
-            sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX
+            sg,
+            mock_prm,
+            num_iterations=1,
+            final_response_selection=SelectionMethod.ARGMAX,
         )
 
         chat_messages = ChatMessages("Solve this:")
@@ -1134,7 +1290,10 @@ class TestParticleGibbs:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(
-            sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX
+            sg,
+            mock_prm,
+            num_iterations=1,
+            final_response_selection=SelectionMethod.ARGMAX,
         )
         result = particle_gibbs.infer(
             mock_lm, chat_messages, budget=2, return_response_only=True
@@ -1149,9 +1308,16 @@ class TestParticleGibbs:
         mock_prm = MockProcessRewardModel([0.7, 0.6])
 
         sg = StepGeneration(step_token="\n", max_steps=1)
-        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX)
+        particle_gibbs = ParticleGibbs(
+            sg,
+            mock_prm,
+            num_iterations=1,
+            final_response_selection=SelectionMethod.ARGMAX,
+        )
 
-        result = await particle_gibbs.ainfer(mock_lm, "Solve this:", budget=2, return_response_only=True)
+        result = await particle_gibbs.ainfer(
+            mock_lm, "Solve this:", budget=2, return_response_only=True
+        )
 
         assert isinstance(result, dict)
 
@@ -1164,23 +1330,37 @@ class TestParticleGibbs:
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=3)
 
-        with pytest.raises(AssertionError, match="budget must be divisible by num_iterations"):
+        with pytest.raises(
+            AssertionError, match="budget must be divisible by num_iterations"
+        ):
             await particle_gibbs.ainfer(mock_lm, "test prompt", budget=4)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("final_response_selection,expected_type", [
-        (SelectionMethod.ARGMAX, dict),
-        (SelectionMethod.SAMPLE, dict),
-        ("argmax", dict),  # Test string conversion
-    ])
-    async def test_ainfer_selection_methods(self, final_response_selection, expected_type):
+    @pytest.mark.parametrize(
+        "final_response_selection,expected_type",
+        [
+            (SelectionMethod.ARGMAX, dict),
+            (SelectionMethod.SAMPLE, dict),
+            ("argmax", dict),  # Test string conversion
+        ],
+    )
+    async def test_ainfer_selection_methods(
+        self, final_response_selection, expected_type
+    ):
         """Test async different selection methods."""
         mock_lm = StepMockLanguageModel(["good_step", "bad_step"])
         mock_prm = MockProcessRewardModel([0.9, 0.1])
 
         sg = StepGeneration(step_token="\n", max_steps=1)
-        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, final_response_selection=final_response_selection)
-        result = await particle_gibbs.ainfer(mock_lm, "Solve this:", budget=2, return_response_only=True)
+        particle_gibbs = ParticleGibbs(
+            sg,
+            mock_prm,
+            num_iterations=1,
+            final_response_selection=final_response_selection,
+        )
+        result = await particle_gibbs.ainfer(
+            mock_lm, "Solve this:", budget=2, return_response_only=True
+        )
 
         assert isinstance(result, expected_type)
 
@@ -1192,13 +1372,16 @@ class TestParticleGibbs:
 
         sg = StepGeneration(step_token="\n", max_steps=1)
         particle_gibbs = ParticleGibbs(
-            sg, mock_prm,
+            sg,
+            mock_prm,
             num_iterations=2,
             final_response_selection=SelectionMethod.ARGMAX,
-            num_ref_particles=1
+            num_ref_particles=1,
         )
 
-        result = await particle_gibbs.ainfer(mock_lm, "Solve this:", budget=4, return_response_only=False)
+        result = await particle_gibbs.ainfer(
+            mock_lm, "Solve this:", budget=4, return_response_only=False
+        )
 
         assert isinstance(result, ParticleGibbsResult)
         assert len(result.responses_lst) == 2  # num_iterations = 2
@@ -1212,10 +1395,17 @@ class TestParticleGibbs:
         mock_prm = MockProcessRewardModel([0.7, 0.6])
 
         sg = StepGeneration(step_token="\n", max_steps=1)
-        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX)
+        particle_gibbs = ParticleGibbs(
+            sg,
+            mock_prm,
+            num_iterations=1,
+            final_response_selection=SelectionMethod.ARGMAX,
+        )
 
         chat_messages = ChatMessages("Solve this:")
-        result = await particle_gibbs.ainfer(mock_lm, chat_messages, budget=2, return_response_only=False)
+        result = await particle_gibbs.ainfer(
+            mock_lm, chat_messages, budget=2, return_response_only=False
+        )
 
         assert isinstance(result, ParticleGibbsResult)
         assert isinstance(result.the_one, dict)
@@ -1228,13 +1418,20 @@ class TestParticleGibbs:
 
         messages = [
             ChatMessage(role="system", content="Solve step by step"),
-            ChatMessage(role="user", content="Problem:")
+            ChatMessage(role="user", content="Problem:"),
         ]
         chat_messages = ChatMessages(messages)
 
         sg = StepGeneration(step_token="\n", max_steps=1)
-        particle_gibbs = ParticleGibbs(sg, mock_prm, num_iterations=1, final_response_selection=SelectionMethod.ARGMAX)
-        result = await particle_gibbs.ainfer(mock_lm, chat_messages, budget=2, return_response_only=True)
+        particle_gibbs = ParticleGibbs(
+            sg,
+            mock_prm,
+            num_iterations=1,
+            final_response_selection=SelectionMethod.ARGMAX,
+        )
+        result = await particle_gibbs.ainfer(
+            mock_lm, chat_messages, budget=2, return_response_only=True
+        )
 
         assert isinstance(result, dict)
 
@@ -1321,6 +1518,29 @@ class TestParticleFiltering:
         )
 
         assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_ainfer_logs_warning_and_ignores_response_format(self, caplog):
+        """Test ParticleFiltering warns and ignores response_format."""
+        mock_lm = StepMockLanguageModel(["step1", "step2"])
+        mock_prm = MockProcessRewardModel([0.7, 0.6])
+        sg = StepGeneration(step_token="\n", max_steps=1)
+        particle_filtering = ParticleFiltering(
+            sg, mock_prm, final_response_selection=SelectionMethod.ARGMAX
+        )
+
+        with caplog.at_level("WARNING"):
+            result = await particle_filtering.ainfer(
+                mock_lm,
+                "Solve this:",
+                budget=2,
+                return_response_only=True,
+                response_format={"type": "json_schema"},
+            )
+
+        assert isinstance(result, dict)
+        assert "response_format" in caplog.text
+        assert "ignored" in caplog.text
 
 
 class TestEntropicParticleFiltering:

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -454,6 +454,42 @@ class TestSelfConsistency:
         # Content should be preserved as list
         assert result["content"] == [{"type": "text", "text": "Answer: 42"}]
 
+    def test_infer_forwards_response_format(self):
+        """Test SelfConsistency.infer forwards response_format to the language model."""
+
+        class CapturingLanguageModel:
+            def __init__(self):
+                self.last_kwargs = None
+
+            async def agenerate(self, messages_or_messages_lst, **kwargs):
+                self.last_kwargs = kwargs
+                if isinstance(messages_or_messages_lst[0], list):
+                    return [
+                        {"role": "assistant", "content": f"answer-{i}"}
+                        for i, _ in enumerate(messages_or_messages_lst)
+                    ]
+                return {"role": "assistant", "content": "answer"}
+
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "sc_schema_sync",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+        lm = CapturingLanguageModel()
+        sc = SelfConsistency()
+        sc.infer(lm, "test prompt", budget=2, response_format=response_format)
+
+        assert lm.last_kwargs["response_format"] == response_format
+
     @pytest.mark.asyncio
     async def test_ainfer_forwards_response_format(self):
         """Test SelfConsistency forwards response_format to the language model."""
@@ -895,6 +931,41 @@ class TestBestOfN:
         assert mock_orm.score_call_count == 1
         assert mock_orm.call_count == 4
 
+    def test_infer_forwards_response_format(self):
+        """Test BestOfN.infer forwards response_format to the language model."""
+
+        class CapturingLanguageModel:
+            def __init__(self):
+                self.last_kwargs = None
+
+            async def agenerate(self, messages_or_messages_lst, **kwargs):
+                self.last_kwargs = kwargs
+                return [
+                    {"role": "assistant", "content": f"candidate-{i}"}
+                    for i, _ in enumerate(messages_or_messages_lst)
+                ]
+
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "bon_schema_sync",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+
+        lm = CapturingLanguageModel()
+        orm = MockOutcomeRewardModel([0.9, 0.1])
+        bon = BestOfN(orm)
+        bon.infer(lm, "test prompt", budget=2, response_format=response_format)
+
+        assert lm.last_kwargs["response_format"] == response_format
+
     @pytest.mark.asyncio
     async def test_ainfer_forwards_response_format(self):
         """Test BestOfN forwards response_format to the language model."""
@@ -972,6 +1043,27 @@ class TestBeamSearch:
         )
 
         assert isinstance(result, dict)
+
+    def test_infer_logs_warning_and_ignores_response_format(self, caplog):
+        """Test BeamSearch warns and ignores response_format."""
+        mock_lm = StepMockLanguageModel(["step1"])
+        mock_prm = MockProcessRewardModel([0.7])
+
+        sg = StepGeneration(step_token="\n", max_steps=1)
+        beam_search = BeamSearch(sg, mock_prm, beam_width=1)
+
+        with caplog.at_level("WARNING"):
+            result = beam_search.infer(
+                mock_lm,
+                "Solve this problem:",
+                budget=1,
+                return_response_only=True,
+                response_format={"type": "json_schema"},
+            )
+
+        assert isinstance(result, dict)
+        assert "response_format" in caplog.text
+        assert "ignored" in caplog.text
 
     def test_budget_validation(self):
         """Test budget validation constraints."""

--- a/tests/test_iaas.py
+++ b/tests/test_iaas.py
@@ -209,7 +209,7 @@ class TestSelfConsistencyToolVote:
             "alg": "self-consistency",
             "regex_patterns": [r"\\boxed{([^}]+)}"],
             "tool_vote": "tool_args",
-            "exclude_tool_args": ["timestamp", "request_id"]
+            "exclude_tool_args": ["timestamp", "request_id"],
         }
 
         response = iaas_client.post("/configure", json=config_data)
@@ -227,7 +227,7 @@ class TestSelfConsistencyToolVote:
             "alg": "self-consistency",
             "regex_patterns": [r"\\boxed{([^}]+)}"],
             "tool_vote": "tool_hierarchical",
-            "exclude_tool_args": ["timestamp", "id", "session_id"]
+            "exclude_tool_args": ["timestamp", "id", "session_id"],
         }
 
         response = iaas_client.post("/configure", json=config_data)
@@ -262,7 +262,7 @@ class TestSelfConsistencyToolVote:
                 "alg": "self-consistency",
                 "regex_patterns": [r"\\boxed{([^}]+)}"],
                 "tool_vote": "tool_hierarchical",
-                "exclude_tool_args": ["timestamp", "id"]
+                "exclude_tool_args": ["timestamp", "id"],
             }
 
             response = iaas_client.post("/configure", json=config_data)
@@ -295,7 +295,9 @@ class TestSelfConsistencyToolVote:
         import its_hub.integration.iaas as iaas_module
 
         mock_scaling_alg = MagicMock()
-        mock_scaling_alg.ainfer = AsyncMock(return_value={"role": "assistant", "content": "Tool voting response"})
+        mock_scaling_alg.ainfer = AsyncMock(
+            return_value={"role": "assistant", "content": "Tool voting response"}
+        )
         iaas_module.SCALING_ALG = mock_scaling_alg
 
         # Make chat completion request
@@ -312,12 +314,20 @@ class TestSelfConsistencyToolVote:
         # Verify the scaling algorithm was called
         mock_scaling_alg.ainfer.assert_called_once()
 
-    @pytest.mark.parametrize("tool_vote_config", [
-        {"tool_vote": "tool_name"},
-        {"tool_vote": "tool_args", "exclude_tool_args": ["id"]},
-        {"tool_vote": "tool_hierarchical", "exclude_tool_args": ["timestamp", "session_id"]},
-    ])
-    def test_various_tool_vote_configurations(self, iaas_client, vllm_server, tool_vote_config):
+    @pytest.mark.parametrize(
+        "tool_vote_config",
+        [
+            {"tool_vote": "tool_name"},
+            {"tool_vote": "tool_args", "exclude_tool_args": ["id"]},
+            {
+                "tool_vote": "tool_hierarchical",
+                "exclude_tool_args": ["timestamp", "session_id"],
+            },
+        ],
+    )
+    def test_various_tool_vote_configurations(
+        self, iaas_client, vllm_server, tool_vote_config
+    ):
         """Test various valid tool-vote configurations."""
         config_data = {
             "endpoint": vllm_server,
@@ -382,7 +392,9 @@ class TestChatCompletions:
         import its_hub.integration.iaas as iaas_module
 
         mock_scaling_alg = MagicMock()
-        mock_scaling_alg.ainfer = AsyncMock(return_value={"role": "assistant", "content": "Mocked scaling response"})
+        mock_scaling_alg.ainfer = AsyncMock(
+            return_value={"role": "assistant", "content": "Mocked scaling response"}
+        )
         iaas_module.SCALING_ALG = mock_scaling_alg
 
         request_data = TestDataFactory.create_chat_completion_request(
@@ -425,7 +437,9 @@ class TestChatCompletions:
         import its_hub.integration.iaas as iaas_module
 
         mock_scaling_alg = MagicMock()
-        mock_scaling_alg.ainfer = AsyncMock(return_value={"role": "assistant", "content": "Response with system prompt"})
+        mock_scaling_alg.ainfer = AsyncMock(
+            return_value={"role": "assistant", "content": "Response with system prompt"}
+        )
         iaas_module.SCALING_ALG = mock_scaling_alg
 
         request_data = TestDataFactory.create_chat_completion_request(
@@ -441,6 +455,52 @@ class TestChatCompletions:
 
         # Verify the scaling algorithm was called
         mock_scaling_alg.ainfer.assert_called_once()
+
+    def test_chat_completions_forwards_response_format(self, iaas_client, vllm_server):
+        """Test response_format passthrough to scaling algorithm."""
+        self._configure_service(iaas_client, vllm_server)
+
+        import its_hub.integration.iaas as iaas_module
+
+        mock_scaling_alg = MagicMock()
+        mock_scaling_alg.ainfer = AsyncMock(
+            return_value={"role": "assistant", "content": '{"decision":"lgtm"}'}
+        )
+        iaas_module.SCALING_ALG = mock_scaling_alg
+
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "adapter_patch_response",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "decision": {
+                            "type": "string",
+                            "enum": ["lgtm", "patch"],
+                        }
+                    },
+                    "required": ["decision"],
+                },
+            },
+        }
+
+        request_data = TestDataFactory.create_chat_completion_request(
+            user_content="Polish this response",
+            budget=4,
+        )
+        request_data["response_format"] = response_format
+
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        mock_scaling_alg.ainfer.assert_called_once()
+        assert (
+            mock_scaling_alg.ainfer.call_args.kwargs["response_format"]
+            == response_format
+        )
 
     def test_chat_completions_algorithm_error(self, iaas_client, vllm_server):
         """Test chat completion when scaling algorithm raises an error."""
@@ -555,7 +615,7 @@ class TestPydanticModels:
             alg="self-consistency",
             regex_patterns=[r"\\boxed{([^}]+)}"],
             tool_vote="tool_hierarchical",
-            exclude_tool_args=["timestamp", "id"]
+            exclude_tool_args=["timestamp", "id"],
         )
 
         assert config.tool_vote == "tool_hierarchical"
@@ -585,6 +645,30 @@ class TestPydanticModels:
         )
 
         assert request.return_response_only is False
+
+    def test_chat_completion_request_with_response_format(self):
+        """Test ChatCompletionRequest supports response_format field."""
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "test_schema",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {"x": {"type": "integer"}},
+                    "required": ["x"],
+                },
+            },
+        }
+        request = ChatCompletionRequest(
+            model=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            messages=[ChatMessage(role="user", content="Test")],
+            budget=4,
+            response_format=response_format,
+        )
+
+        assert request.response_format == response_format
 
     def test_chat_completion_request_defaults(self):
         """Test ChatCompletionRequest default values."""

--- a/tests/test_lms.py
+++ b/tests/test_lms.py
@@ -139,7 +139,7 @@ class TestOpenAICompatibleLanguageModel:
         assert request_data["response_format"] == response_format
 
     def test_response_format_fallback_when_unsupported(self):
-        """Test fallback to plain generation when response_format is unsupported."""
+        """Test fallback and caching when response_format is unsupported."""
 
         class MockResponse:
             def __init__(
@@ -196,7 +196,7 @@ class TestOpenAICompatibleLanguageModel:
         model = OpenAICompatibleLanguageModel(
             endpoint="http://mock-server",
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
-            model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            model_name="response-format-cache-model",
             max_tries=1,
         )
         response_format = {
@@ -219,10 +219,14 @@ class TestOpenAICompatibleLanguageModel:
         mock_session = MockClientSession()
         with patch("aiohttp.ClientSession", return_value=mock_session):
             response = model.generate(messages, response_format=response_format)
+            second_response = model.generate(messages, response_format=response_format)
 
         assert response["content"] == "fallback response"
+        assert second_response["content"] == "fallback response"
         assert mock_session.requests[0]["response_format"] == response_format
         assert "response_format" not in mock_session.requests[1]
+        assert "response_format" not in mock_session.requests[2]
+        assert len(mock_session.requests) == 3
 
     def test_async_generation(self, openai_server):
         """Test async generation functionality."""

--- a/tests/test_lms.py
+++ b/tests/test_lms.py
@@ -105,6 +105,125 @@ class TestOpenAICompatibleLanguageModel:
         ]
         assert responses == expected
 
+    def test_prepare_request_data_with_response_format(self, openai_server):
+        """Test response_format is included in request payload."""
+        model = OpenAICompatibleLanguageModel(
+            endpoint=openai_server,
+            api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
+            model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            max_tries=2,
+        )
+
+        messages = TestDataFactory.create_chat_messages(
+            "Return JSON"
+        ).to_chat_messages()
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "test_schema",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {"x": {"type": "integer"}},
+                    "required": ["x"],
+                },
+            },
+        }
+
+        request_data = model._prepare_request_data(
+            messages,
+            response_format=response_format,
+        )
+
+        assert request_data["response_format"] == response_format
+
+    def test_response_format_fallback_when_unsupported(self):
+        """Test fallback to plain generation when response_format is unsupported."""
+
+        class MockResponse:
+            def __init__(
+                self, status: int, *, text_body: str = "", json_body: dict | None = None
+            ):
+                self.status = status
+                self._text_body = text_body
+                self._json_body = json_body or {}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def text(self):
+                return self._text_body
+
+            async def json(self):
+                return self._json_body
+
+        class MockClientSession:
+            def __init__(self):
+                self.requests: list[dict] = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            def post(self, url, headers=None, json=None):
+                del url, headers
+                self.requests.append(json)
+                if len(self.requests) == 1:
+                    return MockResponse(
+                        400,
+                        text_body='{"error": {"message": "response_format not supported"}}',
+                    )
+                return MockResponse(
+                    200,
+                    json_body={
+                        "choices": [
+                            {
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "fallback response",
+                                }
+                            }
+                        ]
+                    },
+                )
+
+        model = OpenAICompatibleLanguageModel(
+            endpoint="http://mock-server",
+            api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
+            model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            max_tries=1,
+        )
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "test_schema",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {"x": {"type": "integer"}},
+                    "required": ["x"],
+                },
+            },
+        }
+        messages = TestDataFactory.create_chat_messages(
+            "Return JSON"
+        ).to_chat_messages()
+
+        mock_session = MockClientSession()
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            response = model.generate(messages, response_format=response_format)
+
+        assert response["content"] == "fallback response"
+        assert mock_session.requests[0]["response_format"] == response_format
+        assert "response_format" not in mock_session.requests[1]
+
     def test_async_generation(self, openai_server):
         """Test async generation functionality."""
         async_model = OpenAICompatibleLanguageModel(
@@ -240,12 +359,15 @@ class TestOpenAICompatibleLanguageModel:
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
             system_prompt="You are a helpful assistant.",
-            max_tries=2
+            max_tries=2,
         )
 
         chat_messages = TestDataFactory.create_chat_messages("Hello, world!")
         response = await model.agenerate(chat_messages.to_chat_messages())
-        assert response == {"role": "assistant", "content": "Response to: Hello, world!"}
+        assert response == {
+            "role": "assistant",
+            "content": "Response to: Hello, world!",
+        }
 
     @pytest.mark.asyncio
     async def test_agenerate_batch(self, openai_server):
@@ -254,23 +376,25 @@ class TestOpenAICompatibleLanguageModel:
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
-            max_tries=2
+            max_tries=2,
         )
 
         messages_lst = [
             TestDataFactory.create_chat_messages("Hello, world!").to_chat_messages(),
-            TestDataFactory.create_chat_messages("How are you?").to_chat_messages()
+            TestDataFactory.create_chat_messages("How are you?").to_chat_messages(),
         ]
 
         responses = await model.agenerate(messages_lst)
         expected = [
             {"role": "assistant", "content": "Response to: Hello, world!"},
-            {"role": "assistant", "content": "Response to: How are you?"}
+            {"role": "assistant", "content": "Response to: How are you?"},
         ]
         assert responses == expected
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("scenario_name", ["simple_chat", "math_problem", "with_system_prompt"])
+    @pytest.mark.parametrize(
+        "scenario_name", ["simple_chat", "math_problem", "with_system_prompt"]
+    )
     async def test_agenerate_scenarios(self, openai_server, scenario_name):
         """Test async generation with various predefined scenarios."""
         scenario = TEST_SCENARIOS[scenario_name]
@@ -282,37 +406,41 @@ class TestOpenAICompatibleLanguageModel:
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
-            max_tries=2
+            max_tries=2,
         )
 
         chat_messages = TestDataFactory.create_chat_messages(
-            scenario["user_content"],
-            scenario.get("system_content")
+            scenario["user_content"], scenario.get("system_content")
         )
 
         response = await model.agenerate(chat_messages.to_chat_messages())
         assert response == scenario["expected_response"]
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("stop_token,include_stop,expected_suffix", [
-        (None, False, ""),
-        ("STOP", False, ""),
-        ("STOP", True, "STOP"),
-    ])
-    async def test_agenerate_stop_token_handling(self, openai_server, stop_token, include_stop, expected_suffix):
+    @pytest.mark.parametrize(
+        "stop_token,include_stop,expected_suffix",
+        [
+            (None, False, ""),
+            ("STOP", False, ""),
+            ("STOP", True, "STOP"),
+        ],
+    )
+    async def test_agenerate_stop_token_handling(
+        self, openai_server, stop_token, include_stop, expected_suffix
+    ):
         """Test async generation stop token handling with different configurations."""
         model = OpenAICompatibleLanguageModel(
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
-            max_tries=2
+            max_tries=2,
         )
 
         chat_messages = TestDataFactory.create_chat_messages("Hello, world!")
         response = await model.agenerate(
             chat_messages.to_chat_messages(),
             stop=stop_token,
-            include_stop_str_in_output=include_stop
+            include_stop_str_in_output=include_stop,
         )
 
         expected_content = "Response to: Hello, world!" + expected_suffix
@@ -326,10 +454,12 @@ class TestOpenAICompatibleLanguageModel:
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
-            max_tries=2
+            max_tries=2,
         )
 
-        chat_messages = TestDataFactory.create_chat_messages(TEST_CONSTANTS["ERROR_TRIGGER"])
+        chat_messages = TestDataFactory.create_chat_messages(
+            TEST_CONSTANTS["ERROR_TRIGGER"]
+        )
 
         with pytest.raises(Exception) as exc_info:
             await model.agenerate(chat_messages.to_chat_messages())
@@ -337,22 +467,29 @@ class TestOpenAICompatibleLanguageModel:
         assert "Server error" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("error_message,expected_result", [
-        ("[CUSTOM ERROR]", "[CUSTOM ERROR]"),
-        ("", ""),
-        (None, Exception),  # Should raise exception
-    ])
-    async def test_agenerate_replace_error_with_message(self, openai_server, error_message, expected_result):
+    @pytest.mark.parametrize(
+        "error_message,expected_result",
+        [
+            ("[CUSTOM ERROR]", "[CUSTOM ERROR]"),
+            ("", ""),
+            (None, Exception),  # Should raise exception
+        ],
+    )
+    async def test_agenerate_replace_error_with_message(
+        self, openai_server, error_message, expected_result
+    ):
         """Test async replace_error_with_message functionality."""
         model = OpenAICompatibleLanguageModel(
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
             max_tries=1,
-            replace_error_with_message=error_message
+            replace_error_with_message=error_message,
         )
 
-        chat_messages = TestDataFactory.create_chat_messages(TEST_CONSTANTS["ERROR_TRIGGER"])
+        chat_messages = TestDataFactory.create_chat_messages(
+            TEST_CONSTANTS["ERROR_TRIGGER"]
+        )
 
         if expected_result is Exception:
             with pytest.raises(Exception):  # noqa: B017
@@ -371,20 +508,22 @@ class TestOpenAICompatibleLanguageModel:
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
             max_tries=1,
-            replace_error_with_message=error_message
+            replace_error_with_message=error_message,
         )
 
         messages_lst = [
             TestDataFactory.create_chat_messages("Hello, world!").to_chat_messages(),
-            TestDataFactory.create_chat_messages(TEST_CONSTANTS["ERROR_TRIGGER"]).to_chat_messages(),
-            TestDataFactory.create_chat_messages("How are you?").to_chat_messages()
+            TestDataFactory.create_chat_messages(
+                TEST_CONSTANTS["ERROR_TRIGGER"]
+            ).to_chat_messages(),
+            TestDataFactory.create_chat_messages("How are you?").to_chat_messages(),
         ]
 
         results = await model.agenerate(messages_lst)
         expected = [
             {"role": "assistant", "content": "Response to: Hello, world!"},
             {"role": "assistant", "content": error_message},
-            {"role": "assistant", "content": "Response to: How are you?"}
+            {"role": "assistant", "content": "Response to: How are you?"},
         ]
         assert results == expected
 
@@ -396,12 +535,15 @@ class TestOpenAICompatibleLanguageModel:
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
             system_prompt="You are a helpful assistant.",
-            max_tries=2
+            max_tries=2,
         )
 
         chat_messages = TestDataFactory.create_chat_messages("Hello, world!")
         response = await model.agenerate(chat_messages.to_chat_messages())
-        assert response == {"role": "assistant", "content": "Response to: Hello, world!"}
+        assert response == {
+            "role": "assistant",
+            "content": "Response to: Hello, world!",
+        }
 
     @pytest.mark.asyncio
     async def test_agenerate_batch(self, openai_server):
@@ -410,23 +552,25 @@ class TestOpenAICompatibleLanguageModel:
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
-            max_tries=2
+            max_tries=2,
         )
 
         messages_lst = [
             TestDataFactory.create_chat_messages("Hello, world!").to_chat_messages(),
-            TestDataFactory.create_chat_messages("How are you?").to_chat_messages()
+            TestDataFactory.create_chat_messages("How are you?").to_chat_messages(),
         ]
 
         responses = await model.agenerate(messages_lst)
         expected = [
             {"role": "assistant", "content": "Response to: Hello, world!"},
-            {"role": "assistant", "content": "Response to: How are you?"}
+            {"role": "assistant", "content": "Response to: How are you?"},
         ]
         assert responses == expected
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("scenario_name", ["simple_chat", "math_problem", "with_system_prompt"])
+    @pytest.mark.parametrize(
+        "scenario_name", ["simple_chat", "math_problem", "with_system_prompt"]
+    )
     async def test_agenerate_scenarios(self, openai_server, scenario_name):
         """Test async generation with various predefined scenarios."""
         scenario = TEST_SCENARIOS[scenario_name]
@@ -438,37 +582,41 @@ class TestOpenAICompatibleLanguageModel:
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
-            max_tries=2
+            max_tries=2,
         )
 
         chat_messages = TestDataFactory.create_chat_messages(
-            scenario["user_content"],
-            scenario.get("system_content")
+            scenario["user_content"], scenario.get("system_content")
         )
 
         response = await model.agenerate(chat_messages.to_chat_messages())
         assert response == scenario["expected_response"]
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("stop_token,include_stop,expected_suffix", [
-        (None, False, ""),
-        ("STOP", False, ""),
-        ("STOP", True, "STOP"),
-    ])
-    async def test_agenerate_stop_token_handling(self, openai_server, stop_token, include_stop, expected_suffix):
+    @pytest.mark.parametrize(
+        "stop_token,include_stop,expected_suffix",
+        [
+            (None, False, ""),
+            ("STOP", False, ""),
+            ("STOP", True, "STOP"),
+        ],
+    )
+    async def test_agenerate_stop_token_handling(
+        self, openai_server, stop_token, include_stop, expected_suffix
+    ):
         """Test async generation stop token handling with different configurations."""
         model = OpenAICompatibleLanguageModel(
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
-            max_tries=2
+            max_tries=2,
         )
 
         chat_messages = TestDataFactory.create_chat_messages("Hello, world!")
         response = await model.agenerate(
             chat_messages.to_chat_messages(),
             stop=stop_token,
-            include_stop_str_in_output=include_stop
+            include_stop_str_in_output=include_stop,
         )
 
         expected_content = "Response to: Hello, world!" + expected_suffix
@@ -482,10 +630,12 @@ class TestOpenAICompatibleLanguageModel:
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
-            max_tries=2
+            max_tries=2,
         )
 
-        chat_messages = TestDataFactory.create_chat_messages(TEST_CONSTANTS["ERROR_TRIGGER"])
+        chat_messages = TestDataFactory.create_chat_messages(
+            TEST_CONSTANTS["ERROR_TRIGGER"]
+        )
 
         with pytest.raises(Exception) as exc_info:
             await model.agenerate(chat_messages.to_chat_messages())
@@ -493,22 +643,29 @@ class TestOpenAICompatibleLanguageModel:
         assert "Server error" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("error_message,expected_result", [
-        ("[CUSTOM ERROR]", "[CUSTOM ERROR]"),
-        ("", ""),
-        (None, Exception),  # Should raise exception
-    ])
-    async def test_agenerate_replace_error_with_message(self, openai_server, error_message, expected_result):
+    @pytest.mark.parametrize(
+        "error_message,expected_result",
+        [
+            ("[CUSTOM ERROR]", "[CUSTOM ERROR]"),
+            ("", ""),
+            (None, Exception),  # Should raise exception
+        ],
+    )
+    async def test_agenerate_replace_error_with_message(
+        self, openai_server, error_message, expected_result
+    ):
         """Test async replace_error_with_message functionality."""
         model = OpenAICompatibleLanguageModel(
             endpoint=openai_server,
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
             max_tries=1,
-            replace_error_with_message=error_message
+            replace_error_with_message=error_message,
         )
 
-        chat_messages = TestDataFactory.create_chat_messages(TEST_CONSTANTS["ERROR_TRIGGER"])
+        chat_messages = TestDataFactory.create_chat_messages(
+            TEST_CONSTANTS["ERROR_TRIGGER"]
+        )
 
         if expected_result is Exception:
             with pytest.raises(Exception):  # noqa: B017
@@ -527,20 +684,22 @@ class TestOpenAICompatibleLanguageModel:
             api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
             model_name=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
             max_tries=1,
-            replace_error_with_message=error_message
+            replace_error_with_message=error_message,
         )
 
         messages_lst = [
             TestDataFactory.create_chat_messages("Hello, world!").to_chat_messages(),
-            TestDataFactory.create_chat_messages(TEST_CONSTANTS["ERROR_TRIGGER"]).to_chat_messages(),
-            TestDataFactory.create_chat_messages("How are you?").to_chat_messages()
+            TestDataFactory.create_chat_messages(
+                TEST_CONSTANTS["ERROR_TRIGGER"]
+            ).to_chat_messages(),
+            TestDataFactory.create_chat_messages("How are you?").to_chat_messages(),
         ]
 
         results = await model.agenerate(messages_lst)
         expected = [
             {"role": "assistant", "content": "Response to: Hello, world!"},
             {"role": "assistant", "content": error_message},
-            {"role": "assistant", "content": "Response to: How are you?"}
+            {"role": "assistant", "content": "Response to: How are you?"},
         ]
         assert results == expected
 
@@ -750,7 +909,9 @@ class TestStepGeneration:
         from unittest.mock import AsyncMock, Mock
 
         mock_lm = Mock()
-        mock_lm.agenerate = AsyncMock(return_value={"role": "assistant", "content": "test response"})
+        mock_lm.agenerate = AsyncMock(
+            return_value={"role": "assistant", "content": "test response"}
+        )
 
         step_gen = StepGeneration(tokens_per_step=100, max_steps=3)
         step_gen.forward(mock_lm, "test prompt")
@@ -758,4 +919,4 @@ class TestStepGeneration:
         # Verify that max_tokens=100 was passed to the language model
         mock_lm.agenerate.assert_called_once()
         call_args = mock_lm.agenerate.call_args
-        assert call_args.kwargs['max_tokens'] == 100
+        assert call_args.kwargs["max_tokens"] == 100


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible `response_format` support to IaaS chat requests and forward it through scaling algorithms.
- Add non-breaking fallback in LM adapters: if upstream rejects `response_format`, retry once without it and continue.
- Keep compatibility for particle-filtering by ignoring `response_format` with a warning instead of failing.
- Add tests for request passthrough, LM fallback behavior, algorithm forwarding, and particle-filter warning behavior.

## Test plan
- [x] Baseline before changes: `uv run --extra dev pytest tests/test_lms.py tests/test_iaas.py tests/test_algorithms.py`
- [x] Red tests for new behavior: `uv run --extra dev pytest tests/test_lms.py tests/test_iaas.py tests/test_algorithms.py -k "response_format"`
- [x] Updated suites after implementation: `uv run --extra dev pytest tests/test_lms.py tests/test_iaas.py tests/test_algorithms.py`
- [x] Full suite: `uv run --extra dev pytest`
- [x] Behavioral smoke with adapter path via IaaS: `adapter_critic` run using local `its_hub` + `reward_hub` branch

## Unit tests
```bash
uv run --extra dev pytest tests/test_lms.py tests/test_iaas.py tests/test_algorithms.py
uv run --extra dev pytest
```