### PR TITLE
Improve self-consistency answer extraction and voting

### DIFF
--- a/its_hub/algorithms/__init__.py
+++ b/its_hub/algorithms/__init__.py
@@ -7,7 +7,7 @@ from .particle_gibbs import (
     ParticleGibbs,
     ParticleGibbsResult,
 )
-from .self_consistency import SelfConsistency, SelfConsistencyResult
+from .self_consistency import ProjectionPreset, SelfConsistency, SelfConsistencyResult
 
 __all__ = [
     "BeamSearch",
@@ -21,6 +21,7 @@ __all__ = [
     "ParticleFilteringResult",
     "ParticleGibbs",
     "ParticleGibbsResult",
+    "ProjectionPreset",
     "SelfConsistency",
     "SelfConsistencyResult",
 ]

--- a/its_hub/algorithms/self_consistency.py
+++ b/its_hub/algorithms/self_consistency.py
@@ -17,14 +17,64 @@ from its_hub.utils import extract_content_from_lm_response
 
 
 def _default_projection_func(response: str) -> str:
-    """Default projection function that uses exact content matching.
-    This function strips whitespace and returns the content as-is for voting.
-    Responses with identical content (after stripping) will be considered equivalent.
-    Args:
-        response: The response content string to project.
-    Returns:
-        The stripped response content.
+    """Default projection that extracts the final answer for voting.
+
+    Tries, in order:
+    1. \\boxed{...} extraction (math)
+    2. Explicit answer patterns ("Final Answer:", "Therefore, the answer is...")
+    3. Last short line that looks like an answer
+    4. Last paragraph (as a rough conclusion)
+    5. Full text stripped (fallback)
+
+    All extracted answers are lowercased to prevent case-only duplicates.
     """
+    if not response:
+        return ""
+
+    # 1. Boxed answer (math) — handle nested braces
+    boxed_idx = response.find('\\boxed{')
+    if boxed_idx != -1:
+        brace_count = 0
+        start = boxed_idx + 7
+        for i in range(start, len(response)):
+            if response[i] == '{':
+                brace_count += 1
+            elif response[i] == '}':
+                if brace_count == 0:
+                    if i > start:
+                        return response[start:i].strip().lower()
+                    break
+                brace_count -= 1
+
+    # 2. Explicit answer patterns
+    patterns = [
+        r'Final Answer:\s*(.+?)(?:\n\n|$)',
+        r'Answer:\s*(.+?)(?:\n\n|$)',
+        r'Therefore,?\s+the\s+(?:answer|value|result)\s+(?:is|equals?)\s+(.+?)(?:\.|$)',
+        r'Therefore,?\s+(.+?)(?:\n\n|$)',
+        r'Thus,?\s+(.+?)(?:\n\n|$)',
+        r'So,?\s+the\s+(?:answer|value|result)\s+(?:is|equals?)\s+(.+?)(?:\.|$)',
+        r'In conclusion,?\s+(.+?)(?:\n\n|$)',
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, response, re.IGNORECASE | re.DOTALL)
+        if match:
+            answer = match.group(1).strip()
+            if len(answer) < 200:
+                return answer.lower()
+
+    # 3. Short last line that looks like an answer
+    lines = response.strip().split('\n')
+    last_line = lines[-1].strip()
+    if last_line and len(last_line) < 150:
+        return last_line.lower()
+
+    # 4. Last paragraph
+    paragraphs = [p.strip() for p in response.strip().split('\n\n') if p.strip()]
+    if paragraphs:
+        return paragraphs[-1].lower()
+
+    # 5. Fallback
     return response.strip()
 
 
@@ -121,10 +171,18 @@ def _select_hierarchical_most_common_or_random(
     return tuple_counts, selected_index
 
 
+class ProjectionPreset:
+    """Built-in projection presets for common use cases."""
+    MATH = "math"        # \\boxed{} extraction via regex
+    GENERAL = "general"  # Answer pattern extraction (default)
+    EXACT = "exact"      # Full text matching (legacy behavior)
+
+
 class SelfConsistency(AbstractScalingAlgorithm):
     def __init__(
         self,
         consistency_space_projection_func: Callable | None = None,
+        projection_preset: str | None = None,
         tool_vote: str | None = None,
         exclude_args: list[str] | None = None,
     ):
@@ -134,6 +192,13 @@ class SelfConsistency(AbstractScalingAlgorithm):
             consistency_space_projection_func: Function that maps response content (str)
                 to a comparable value for voting. Used when tool_vote is None or when
                 responses don't contain tool calls. Can return str, tuple, or any hashable type.
+                Takes priority over projection_preset if both are provided.
+
+            projection_preset: Built-in projection preset name. Options:
+                - "math": Extract \\boxed{} answers via regex
+                - "general": Extract final answer using pattern matching (default)
+                - "exact": Full text matching (legacy .strip() behavior)
+                Ignored if consistency_space_projection_func is provided.
 
             tool_vote: Tool voting strategy when responses contain tool calls. Options:
                 - None (default): Vote on message content using consistency_space_projection_func
@@ -147,18 +212,35 @@ class SelfConsistency(AbstractScalingAlgorithm):
                 non-semantic arguments like timestamps, request IDs, etc.
 
         Raises:
-            ValueError: If tool_vote is not one of the supported options.
+            ValueError: If tool_vote or projection_preset is not one of the supported options.
         """
-        # Validate tool_vote parameter - only validation needed since typing handles the rest
+        # Validate tool_vote parameter
         valid_tool_vote_options = {None, "tool_name", "tool_args", "tool_hierarchical"}
         if tool_vote not in valid_tool_vote_options:
             raise ValueError(
                 f"tool_vote must be one of {valid_tool_vote_options}, got: {tool_vote}"
             )
-        # Set default projection function if provided None
-        self.consistency_space_projection_func = (
-            consistency_space_projection_func or _default_projection_func
-        )
+
+        # Validate projection_preset parameter
+        valid_presets = {None, ProjectionPreset.MATH, ProjectionPreset.GENERAL, ProjectionPreset.EXACT}
+        if projection_preset not in valid_presets:
+            raise ValueError(
+                f"projection_preset must be one of {valid_presets}, got: {projection_preset}"
+            )
+
+        # Resolve projection function: explicit func > preset > default
+        if consistency_space_projection_func is not None:
+            self.consistency_space_projection_func = consistency_space_projection_func
+        elif projection_preset == ProjectionPreset.MATH:
+            self.consistency_space_projection_func = create_regex_projection_function(
+                r'\\boxed\{([^}]+)\}'
+            )
+        elif projection_preset == ProjectionPreset.EXACT:
+            self.consistency_space_projection_func = lambda r: r.strip()
+        else:
+            # Default (including projection_preset="general" or None)
+            self.consistency_space_projection_func = _default_projection_func
+
         self.tool_vote = tool_vote
         self.exclude_args = exclude_args or []
 
@@ -305,8 +387,8 @@ class SelfConsistency(AbstractScalingAlgorithm):
 
 def create_regex_projection_function(
     patterns: str | list[str],
-) -> Callable[[str], tuple]:
-    """Create a hierarchical projection function from regex pattern(s).
+) -> Callable[[str], str | tuple]:
+    """Create a projection function from regex pattern(s).
 
     Args:
         patterns: Single regex pattern string or list of regex patterns.
@@ -315,23 +397,25 @@ def create_regex_projection_function(
                  higher hierarchy levels.
 
     Returns:
-        A projection function that takes a response string and returns a tuple
-        where each element corresponds to the first match from each pattern.
-        If no match is found for a pattern, None is used for that position.
+        A projection function that takes a response string and returns:
+        - A plain string when a single pattern is provided (clean response_counts keys)
+        - A tuple when multiple patterns are provided (for hierarchical voting)
 
     Example:
-        # Single pattern for extracting final answer
-        pattern = r'\\\\boxed\\{([^}]+)\\}'
-        proj_func = create_regex_projection_function(pattern)
-        proj_func("The answer is \\\\boxed{42}") -> ("42",)
+        # Single pattern — returns a string, not a tuple
+        proj_func = create_regex_projection_function(r'\\\\boxed\\{([^}]+)\\}')
+        proj_func("The answer is \\\\boxed{42}") -> "42"
 
-        # Multiple patterns for hierarchical consistency
+        # Multiple patterns — returns a tuple for hierarchical consistency
         patterns = [r'Method:\\s*(\\w+)', r'\\\\boxed\\{([^}]+)\\}']
         proj_func = create_regex_projection_function(patterns)
         proj_func("Method: algebra\\n...\\nAnswer: \\\\boxed{42}") -> ("algebra", "42")
     """
+    # Track whether a single pattern was provided
+    single_pattern = isinstance(patterns, str)
+
     # Ensure patterns is a list
-    if isinstance(patterns, str):
+    if single_pattern:
         patterns = [patterns]
 
     # Compile regex patterns for efficiency
@@ -339,7 +423,7 @@ def create_regex_projection_function(
         re.compile(pattern, re.DOTALL | re.IGNORECASE) for pattern in patterns
     ]
 
-    def projection_function(response: str) -> tuple:
+    def projection_function(response: str) -> str | tuple:
         """Extract features from response using compiled regex patterns."""
         results = []
 
@@ -359,6 +443,11 @@ def create_regex_projection_function(
             else:
                 # No match found, use None
                 results.append(None)
+
+        # For single patterns, return the string directly so
+        # response_counts keys are clean strings, not 1-tuples
+        if single_pattern:
+            return results[0]
 
         return tuple(results)
 

--- a/its_hub/algorithms/self_consistency.py
+++ b/its_hub/algorithms/self_consistency.py
@@ -4,6 +4,7 @@ import random
 import re
 from collections import Counter
 from collections.abc import Callable
+from enum import StrEnum
 
 from pydantic.dataclasses import dataclass
 
@@ -17,14 +18,27 @@ from its_hub.utils import extract_content_from_lm_response
 
 
 def _default_projection_func(response: str) -> str:
-    """Default projection that extracts the final answer for voting.
+    """Default projection function that strips whitespace and lowercases for voting.
 
-    Tries, in order:
-    1. \\boxed{...} extraction (math)
+    Responses with identical content (after stripping and lowercasing) will be
+    considered equivalent. This is the safest default for any response format.
+
+    Args:
+        response: The response content string to project.
+    Returns:
+        The stripped, lowercased response content.
+    """
+    return response.strip().lower() if response else ""
+
+
+def _extract_answer(response: str) -> str:
+    """Extract the final answer from a response for voting.
+
+    Used by the GENERAL projection preset. Tries, in order:
+    1. \\boxed{...} extraction (math, handles nested braces)
     2. Explicit answer patterns ("Final Answer:", "Therefore, the answer is...")
-    3. Last short line that looks like an answer
-    4. Last paragraph (as a rough conclusion)
-    5. Full text stripped (fallback)
+    3. Last paragraph (as a rough conclusion)
+    4. Full text stripped (fallback)
 
     All extracted answers are lowercased to prevent case-only duplicates.
     """
@@ -32,19 +46,9 @@ def _default_projection_func(response: str) -> str:
         return ""
 
     # 1. Boxed answer (math) — handle nested braces
-    boxed_idx = response.find('\\boxed{')
-    if boxed_idx != -1:
-        brace_count = 0
-        start = boxed_idx + 7
-        for i in range(start, len(response)):
-            if response[i] == '{':
-                brace_count += 1
-            elif response[i] == '}':
-                if brace_count == 0:
-                    if i > start:
-                        return response[start:i].strip().lower()
-                    break
-                brace_count -= 1
+    boxed = _extract_boxed(response)
+    if boxed is not None:
+        return boxed.strip().lower()
 
     # 2. Explicit answer patterns
     patterns = [
@@ -63,19 +67,35 @@ def _default_projection_func(response: str) -> str:
             if len(answer) < 200:
                 return answer.lower()
 
-    # 3. Short last line that looks like an answer
-    lines = response.strip().split('\n')
-    last_line = lines[-1].strip()
-    if last_line and len(last_line) < 150:
-        return last_line.lower()
-
-    # 4. Last paragraph
+    # 3. Last paragraph
     paragraphs = [p.strip() for p in response.strip().split('\n\n') if p.strip()]
     if paragraphs:
         return paragraphs[-1].lower()
 
-    # 5. Fallback
-    return response.strip()
+    # 4. Fallback
+    return response.strip().lower()
+
+
+def _extract_boxed(response: str) -> str | None:
+    """Extract content from \\boxed{...}, handling nested braces.
+
+    Returns the extracted content or None if no boxed expression is found.
+    """
+    boxed_idx = response.find('\\boxed{')
+    if boxed_idx == -1:
+        return None
+    brace_count = 0
+    start = boxed_idx + 7
+    for i in range(start, len(response)):
+        if response[i] == '{':
+            brace_count += 1
+        elif response[i] == '}':
+            if brace_count == 0:
+                if i > start:
+                    return response[start:i]
+                return None
+            brace_count -= 1
+    return None
 
 
 @dataclass
@@ -171,11 +191,11 @@ def _select_hierarchical_most_common_or_random(
     return tuple_counts, selected_index
 
 
-class ProjectionPreset:
+class ProjectionPreset(StrEnum):
     """Built-in projection presets for common use cases."""
-    MATH = "math"        # \\boxed{} extraction via regex
-    GENERAL = "general"  # Answer pattern extraction (default)
-    EXACT = "exact"      # Full text matching (legacy behavior)
+    MATH = "math"        # \\boxed{} extraction with nested brace handling
+    GENERAL = "general"  # Answer pattern extraction (tries boxed, then patterns)
+    EXACT = "exact"      # Full text matching (legacy .strip() behavior)
 
 
 class SelfConsistency(AbstractScalingAlgorithm):
@@ -195,9 +215,11 @@ class SelfConsistency(AbstractScalingAlgorithm):
                 Takes priority over projection_preset if both are provided.
 
             projection_preset: Built-in projection preset name. Options:
-                - "math": Extract \\boxed{} answers via regex
-                - "general": Extract final answer using pattern matching (default)
+                - "math": Extract \\boxed{} answers (handles nested braces)
+                - "general": Extract final answer using pattern matching
+                  (boxed, "Final Answer:", "Therefore...", last paragraph)
                 - "exact": Full text matching (legacy .strip() behavior)
+                When None (default), uses strip + lowercase matching.
                 Ignored if consistency_space_projection_func is provided.
 
             tool_vote: Tool voting strategy when responses contain tool calls. Options:
@@ -232,13 +254,16 @@ class SelfConsistency(AbstractScalingAlgorithm):
         if consistency_space_projection_func is not None:
             self.consistency_space_projection_func = consistency_space_projection_func
         elif projection_preset == ProjectionPreset.MATH:
-            self.consistency_space_projection_func = create_regex_projection_function(
-                r'\\boxed\{([^}]+)\}'
-            )
+            def _math_projection(response: str) -> str:
+                boxed = _extract_boxed(response) if response else None
+                return boxed.strip().lower() if boxed else (response.strip().lower() if response else "")
+            self.consistency_space_projection_func = _math_projection
+        elif projection_preset == ProjectionPreset.GENERAL:
+            self.consistency_space_projection_func = _extract_answer
         elif projection_preset == ProjectionPreset.EXACT:
             self.consistency_space_projection_func = lambda r: r.strip()
         else:
-            # Default (including projection_preset="general" or None)
+            # Default (projection_preset=None)
             self.consistency_space_projection_func = _default_projection_func
 
         self.tool_vote = tool_vote

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -19,8 +19,11 @@ from its_hub.algorithms.particle_gibbs import (
     TemperatureMethod,
 )
 from its_hub.algorithms.self_consistency import (
+    ProjectionPreset,
     SelfConsistency,
     SelfConsistencyResult,
+    _extract_answer,
+    _extract_boxed,
     _select_hierarchical_most_common_or_random,
     _select_most_common_or_random,
     create_regex_projection_function,
@@ -182,21 +185,21 @@ class TestSelfConsistency:
         pattern = r"\\boxed\{([^}]+)\}"
         proj_func = create_regex_projection_function(pattern)
 
-        # Test successful extraction
+        # Test successful extraction — single pattern returns string, not tuple
         response1 = "The solution is 42. Therefore, the answer is \\boxed{42}."
         result1 = proj_func(response1)
-        assert result1 == ("42",)
+        assert result1 == "42"
 
         # Test no match
         response2 = "The answer is 42 but not in boxed format."
         result2 = proj_func(response2)
-        assert result2 == (None,)
+        assert result2 is None
 
         # Test pattern without capturing groups
         pattern_no_groups = r"\\boxed\{[^}]+\}"
         proj_func_no_groups = create_regex_projection_function(pattern_no_groups)
         result3 = proj_func_no_groups(response1)
-        assert result3 == ("\\boxed{42}",)
+        assert result3 == "\\boxed{42}"
 
     def test_create_regex_projection_function_multiple_patterns(self):
         """Test creating projection function from multiple regex patterns."""
@@ -232,7 +235,7 @@ class TestSelfConsistency:
         pattern = r"ANSWER:\s*(\w+)"
         proj_func = create_regex_projection_function(pattern)
 
-        # Test different cases
+        # Test different cases — single pattern returns string
         responses = [
             "ANSWER: correct",
             "answer: correct",
@@ -242,7 +245,7 @@ class TestSelfConsistency:
 
         for response in responses:
             result = proj_func(response)
-            assert result == ("correct",), f"Failed for: {response}"
+            assert result == "correct", f"Failed for: {response}"
 
     def test_create_regex_projection_function_multiline(self):
         """Test regex projection function with multiline and DOTALL flags."""
@@ -255,7 +258,7 @@ class TestSelfConsistency:
         Result: success"""
 
         result = proj_func(response)
-        assert result == ("success",)
+        assert result == "success"
 
     def test_create_regex_projection_function_with_self_consistency(self):
         """Test integration of regex projection function with SelfConsistency."""
@@ -277,7 +280,7 @@ class TestSelfConsistency:
 
         assert isinstance(result, SelfConsistencyResult)
         # "42" appears 3 times, should be selected over "24" (1 time)
-        extracted_answer = proj_func(result.the_one["content"])[0]
+        extracted_answer = proj_func(result.the_one["content"])
         assert extracted_answer == "42"
 
     def test_create_regex_projection_function_hierarchical_with_self_consistency(self):
@@ -308,8 +311,8 @@ class TestSelfConsistency:
         """Test the default projection function behavior."""
         from its_hub.algorithms.self_consistency import _default_projection_func
 
-        # Test basic stripping
-        assert _default_projection_func("  hello world  ") == "hello world"
+        # Test basic stripping and lowercasing
+        assert _default_projection_func("  Hello World  ") == "hello world"
         assert _default_projection_func("test") == "test"
         assert _default_projection_func("") == ""
 
@@ -317,16 +320,17 @@ class TestSelfConsistency:
         assert _default_projection_func("\n\ttest\n\t") == "test"
         assert _default_projection_func("   ") == ""
 
-        # Test that it preserves internal whitespace
-        assert _default_projection_func("  hello world  ") == "hello world"
-        assert _default_projection_func("\nhello\nworld\n") == "hello\nworld"
+        # Test case normalization
+        assert _default_projection_func("YES") == "yes"
+        assert _default_projection_func("  Hello World  ") == "hello world"
+        assert _default_projection_func("\nHello\nWorld\n") == "hello\nworld"
 
     def test_default_projection_function_with_self_consistency(self):
         """Test that default projection function works correctly with SelfConsistency."""
         responses = [
             "  answer: 42  ",  # Leading/trailing whitespace
             "answer: 42",  # No whitespace
-            "  answer: 42  ",  # Duplicate with whitespace
+            "  ANSWER: 42  ",  # Case variation
             "answer: 24",  # Different answer
         ]
         mock_lm = StepMockLanguageModel(responses)
@@ -336,10 +340,10 @@ class TestSelfConsistency:
         result = sc.infer(mock_lm, "test prompt", budget=4, return_response_only=False)
 
         assert isinstance(result, SelfConsistencyResult)
-        # "answer: 42" should be most common after stripping whitespace
-        assert result.the_one["content"].strip() == "answer: 42"
+        # "answer: 42" should be most common after stripping and lowercasing
+        assert result.the_one["content"].strip().lower() == "answer: 42"
 
-        # Verify the counts - "answer: 42" should appear 3 times after projection
+        # Verify the counts — all 3 variants map to "answer: 42" after projection
         assert result.response_counts["answer: 42"] == 3
         assert result.response_counts["answer: 24"] == 1
 
@@ -440,6 +444,93 @@ class TestSelfConsistency:
         assert isinstance(result, dict)
         # Content should be preserved as list
         assert result["content"] == [{"type": "text", "text": "Answer: 42"}]
+
+    # --- Projection preset tests ---
+
+    def test_projection_preset_is_enum(self):
+        """Test that ProjectionPreset is a proper Enum."""
+        assert isinstance(ProjectionPreset.MATH, ProjectionPreset)
+        assert ProjectionPreset.MATH.value == "math"
+        assert ProjectionPreset("general") == ProjectionPreset.GENERAL
+
+    def test_projection_preset_invalid_raises(self):
+        """Test that invalid projection_preset raises ValueError."""
+        with pytest.raises(ValueError, match="projection_preset"):
+            SelfConsistency(projection_preset="invalid")
+
+    def test_projection_preset_exact(self):
+        """Test that exact preset preserves legacy .strip() behavior (no lowercasing)."""
+        sc = SelfConsistency(projection_preset="exact")
+        assert sc.consistency_space_projection_func("  Hello  ") == "Hello"
+
+    def test_projection_preset_math(self):
+        """Test that math preset extracts boxed answers with nested braces."""
+        sc = SelfConsistency(projection_preset="math")
+        func = sc.consistency_space_projection_func
+        assert func("The answer is \\boxed{42}") == "42"
+        assert func("Result: \\boxed{x^{2}+1}") == "x^{2}+1"
+        # No boxed — falls back to strip+lower
+        assert func("  Just text  ") == "just text"
+
+    def test_projection_preset_general(self):
+        """Test that general preset extracts answers via pattern matching."""
+        sc = SelfConsistency(projection_preset="general")
+        func = sc.consistency_space_projection_func
+        assert func("Reasoning...\n\nFinal Answer: 45") == "45"
+        assert func("Lots of work.\n\n\\boxed{42}") == "42"
+
+    def test_custom_func_takes_priority_over_preset(self):
+        """Test that explicit function takes priority over preset."""
+        def custom(r):
+            return "custom"
+        sc = SelfConsistency(
+            consistency_space_projection_func=custom,
+            projection_preset="math",
+        )
+        assert sc.consistency_space_projection_func("anything") == "custom"
+
+    # --- _extract_boxed tests ---
+
+    def test_extract_boxed_simple(self):
+        """Test boxed extraction with simple content."""
+        assert _extract_boxed("\\boxed{42}") == "42"
+
+    def test_extract_boxed_nested(self):
+        """Test boxed extraction with nested braces."""
+        assert _extract_boxed("\\boxed{x^{2}+1}") == "x^{2}+1"
+        assert _extract_boxed("\\boxed{\\frac{1}{2}}") == "\\frac{1}{2}"
+
+    def test_extract_boxed_none(self):
+        """Test boxed extraction returns None when no boxed expression."""
+        assert _extract_boxed("no boxed here") is None
+        assert _extract_boxed("") is None
+
+    # --- _extract_answer tests ---
+
+    def test_extract_answer_boxed(self):
+        """Test answer extraction with boxed format."""
+        assert _extract_answer("Reasoning...\n\\boxed{42}") == "42"
+
+    def test_extract_answer_final_answer_pattern(self):
+        """Test answer extraction with Final Answer pattern."""
+        assert _extract_answer("Work...\nFinal Answer: 45") == "45"
+
+    def test_extract_answer_therefore_pattern(self):
+        """Test answer extraction with Therefore pattern."""
+        assert _extract_answer("Therefore, the answer is 99.") == "99"
+
+    def test_extract_answer_last_paragraph_fallback(self):
+        """Test answer extraction falls back to last paragraph."""
+        response = "First paragraph.\n\nSecond paragraph.\n\nThe answer is 7."
+        assert _extract_answer(response) == "the answer is 7."
+
+    def test_extract_answer_empty(self):
+        """Test answer extraction with empty string."""
+        assert _extract_answer("") == ""
+
+    def test_extract_answer_case_normalization(self):
+        """Test that extracted answers are lowercased."""
+        assert _extract_answer("Final Answer: YES") == "yes"
 
 
 class TestDataStructures:


### PR DESCRIPTION
## Summary

- **Safe default projection**: Default now uses `strip().lower()` instead of just `.strip()`, adding case normalization while keeping behavior predictable. Smart answer extraction is available via opt-in presets.
- **Built-in presets**: Add `ProjectionPreset` `StrEnum` (`MATH`, `GENERAL`, `EXACT`) and `projection_preset` parameter to `SelfConsistency.__init__()` so callers can opt into smart answer extraction without writing custom functions.
  - `MATH`: Extracts `\boxed{}` content with nested brace handling
  - `GENERAL`: Tries boxed extraction, explicit answer patterns ("Final Answer:", "Therefore..."), last paragraph fallback — per [Wang et al., 2022](https://arxiv.org/abs/2205.11822)
  - `EXACT`: Legacy `.strip()` behavior (no lowercasing)
- **Fix single-pattern regex**: `create_regex_projection_function` now returns a plain string (not a 1-tuple like `('45',)`) when given a single pattern, producing clean `response_counts` keys
- **Shared `_extract_boxed` helper**: Consistent nested-brace handling used by both the `MATH` preset and the `_extract_answer` function, eliminating behavioral divergence
- **Tests**: 15 new tests covering presets, `_extract_boxed`, `_extract_answer`, Enum validation, and custom function priority

## Motivation

Per [Wang et al., 2022](https://arxiv.org/abs/2205.11822), self-consistency works by sampling diverse reasoning chains, **extracting the final answer** from each, and taking a majority vote over the extracted answers. The previous default `.strip()` projection means every caller must supply their own projection function to get correct voting behavior.

Rather than making the default aggressively heuristic (which would be a breaking change), this PR keeps the default simple (`strip().lower()`) and provides **opt-in presets** for smart extraction. Users who want paper-correct behavior can use `projection_preset="general"` or `projection_preset="math"`.

Additionally, `create_regex_projection_function` returned 1-tuples for single patterns (e.g. `('45',)` instead of `'45'`), which created awkward keys in `response_counts` that every consumer had to unwrap.

## Backwards compatibility

- Callers passing a custom `consistency_space_projection_func` are **unaffected** — explicit functions still take priority over presets
- The **default behavior change is minimal**: `strip()` → `strip().lower()`. Only case-sensitive comparisons would see different results.
- Callers needing exact legacy behavior can use `projection_preset="exact"`
- Smart answer extraction is **opt-in** via `projection_preset="general"` or `projection_preset="math"`

## Test plan

- [x] Boxed answer extraction (`\boxed{42}` → `"42"`, nested braces `\boxed{x^{2}+1}` → `"x^{2}+1"`)
- [x] Explicit answer pattern extraction ("Final Answer: 45" → `"45"`)
- [x] Case normalization ("YES" → `"yes"`)
- [x] Single regex returns string, not tuple
- [x] Multi regex still returns tuple for hierarchical voting
- [x] `ProjectionPreset` is a proper `StrEnum`
- [x] All presets initialize correctly (`math`, `general`, `exact`)
- [x] `"exact"` preset preserves legacy `.strip()` behavior
- [x] Invalid preset raises `ValueError`
- [x] Custom function takes priority over preset
- [x] `_extract_boxed` returns `None` when no boxed expression found
- [x] `_extract_answer` falls back through patterns correctly
- [x] Ruff linting passes
- [x] All 42 self-consistency tests pass