### PR TITLE
Add demo video walkthrough to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,12 @@ print(result)
 - ⚡ **Async Support**: Concurrent generation with limits and error handling
 
 
+## Demo
+
+See the library in action with a walkthrough of inference-time scaling algorithms:
+
+[![Demo walkthrough](https://img.youtube.com/vi/qaXyvmR-YBU/maxresdefault.jpg)](https://www.youtube.com/watch?v=qaXyvmR-YBU)
+
+To run the demo yourself, see the [demo setup instructions](https://github.com/lukeinglis/its_hub_demo/blob/main/demo_ui/README.md).
+
 For detailed documentation, visit: [https://ai-innovation.team/its_hub](https://ai-innovation.team/its_hub)

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ See the library in action with a walkthrough of inference-time scaling algorithm
 
 [![Demo walkthrough](https://img.youtube.com/vi/qaXyvmR-YBU/maxresdefault.jpg)](https://www.youtube.com/watch?v=qaXyvmR-YBU)
 
+Try it in your browser: [https://red.ht/its-hub-demo](https://red.ht/its-hub-demo)
+
 To run the demo yourself, see the [demo setup instructions](https://github.com/lukeinglis/its_hub_demo/blob/main/demo_ui/README.md).
 
 For detailed documentation, visit: [https://ai-innovation.team/its_hub](https://ai-innovation.team/its_hub)


### PR DESCRIPTION
## Summary

- Add a demo section to the README with an embedded YouTube video walkthrough of the inference-time scaling algorithms
- Add link to the live demo at https://red.ht/its-hub-demo (GitHub Pages — Guided Demo works with no setup)
- Link to setup instructions for running the full demo locally (including Interactive Demo with live API calls)

## Test plan

- [x] YouTube thumbnail renders correctly in markdown
- [x] Demo setup instructions link resolves
- [ ] Live demo link (red.ht/its-hub-demo) resolves correctly