### PR TITLE
Clean up session for current event loop in algorithm::infer

### DIFF
--- a/its_hub/api/algorithm.py
+++ b/its_hub/api/algorithm.py
@@ -75,8 +75,14 @@ class AbstractScalingAlgorithm(ABC):
 
         Default implementation wraps ainfer() using asyncio.run().
         """
-        return asyncio.run(
-            self.ainfer(
-                lm, prompt_or_messages, budget, return_response_only, tools, tool_choice
-            )
-        )
+        async def _run():
+            try:
+                return await self.ainfer(
+                    lm, prompt_or_messages, budget, return_response_only, tools, tool_choice
+                )
+            finally:
+                # Clean up session if there is one that was created for current event loop
+                if hasattr(lm, 'close_session'):
+                    await lm.close_session(asyncio.get_running_loop())
+
+        return asyncio.run(_run())

--- a/its_hub/core/lms/openai_lm.py
+++ b/its_hub/core/lms/openai_lm.py
@@ -92,7 +92,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         # endpoint type
         self.endpoint_type = "openai" if "openai" in self.endpoint else "vllm"
 
-        # Session cache: one session per event loop, auto-cleaned via weak references
+        # Session cache: one session per event loop, entry is auto-cleaned via weak references.
+        # Session(s) need to be closed via close or close_session function calls.
         self._sessions: weakref.WeakKeyDictionary[
             asyncio.AbstractEventLoop, aiohttp.ClientSession
         ] = weakref.WeakKeyDictionary()
@@ -129,6 +130,19 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         for session in sessions:
             if not session.closed:
                 await session.close()
+
+    async def close_session(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
+        """Close the cached session for the given event loop.
+
+        Args:
+            loop: Event loop whose session to close. Defaults to the current running loop.
+        """
+        if loop is None:
+            loop = asyncio.get_running_loop()
+        with self._session_lock:
+            session = self._sessions.get(loop)
+        if session and not session.closed:
+            await session.close()
 
     async def __aenter__(self):
         """Async context manager entry."""


### PR DESCRIPTION
## Problem

Algorithm::infer uses asyncio.run which creates a new event loop. When asyncio.run finishes, the event loop is destroyed but the session isn't explicitly closed. The underlying TCP connections enter CLOSE_WAIT state and accumulate.

**Steps to reproduce**

`python its_hub/benchmarking/benchmark.py --benchmark math500 --model_name Qwen/Qwen2.5-Math-1.5B-Instruct --endpoint http://0.0.0.0:8000/v1 --alg self-consistency --budgets 1,2,4,8,16 --does_eval`

## Solution

- Clean up the session tied to the ephemeral loop created by asyncio.run() without touching user-managed sessions
- No clean-up necessary in openai_lm as the WeakKeyDictionary is keyed by the event loop and once asyncio.run() finishes and the loop is GC'd, the entry is automatically removed.

## Test

- Ran benchmark.py on math500, there were no TCP connections in the CLOSE_WAIT state after the changes