### PR TITLE
Add support for newer vLLM versions in reward_hub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
 experimental = [
     "its_hub[lm]",
     "transformers>=4.53.2",
-    "reward-hub>=0.1.8",
+    "reward-hub[prm]>=0.1.10",
 ]
 
 research = [


### PR DESCRIPTION
## Description

Reward hub 0.1.10 now supports newer vLLM versions. 

## Testing

- [x] Unit tests
- [x] Test with reward_hub:

```
uv pip install its_hub[experimental]
```

```
Name: reward-hub
Version: 0.1.10

Name: its-hub
Version: 0.3.6.dev19
```

```
from its_hub.core.utils import SAL_STEP_BY_STEP_SYSTEM_PROMPT
from its_hub import OpenAICompatibleLanguageModel, StepGeneration
from its_hub.algorithms import ParticleFiltering, BestOfN, SelfConsistency, EntropicParticleFiltering
from its_hub.core.reward_models.local_vllm_prm import LocalVllmProcessRewardModel

lm = OpenAICompatibleLanguageModel(
    endpoint="http://localhost:8100/v1",
    api_key="NO_API_KEY",
    model_name="Qwen/Qwen2.5-Math-1.5B-Instruct",
    system_prompt=SAL_STEP_BY_STEP_SYSTEM_PROMPT,
)

sg = StepGeneration(step_token="\n\n", max_steps=32, stop_token=r"\boxed")

prm = LocalVllmProcessRewardModel(
    model_name="Qwen/Qwen2.5-Math-PRM-7B",
    device="cuda:0",
    aggregation_method="prod"
)

scaling_alg = ParticleFiltering(sg, prm)

result = scaling_alg.infer(lm, "Explain quantum entanglement in simple terms", budget=4)

print(result)

import asyncio
asyncio.run(lm.close())
```