### PR TITLE
feat: add response_format support for structured outputs

### DIFF
--- a/its_hub/__init__.py
+++ b/its_hub/__init__.py
@@ -41,7 +41,14 @@ try:
     from its_hub.core.orchestrator import LMOrchestrator
     from its_hub.core.reward_models.llm_judge import LLMJudge
 
-    __all__.extend(["LLMJudge", "LMOrchestrator", "OpenAICompatibleLanguageModel", "StepGeneration"])
+    __all__.extend(
+        [
+            "LLMJudge",
+            "LMOrchestrator",
+            "OpenAICompatibleLanguageModel",
+            "StepGeneration",
+        ]
+    )
 except ImportError:
     # LM implementations not available - install with: pip install its_hub[lm]
     pass

--- a/its_hub/api/algorithm.py
+++ b/its_hub/api/algorithm.py
@@ -75,14 +75,20 @@ class AbstractScalingAlgorithm(ABC):
 
         Default implementation wraps ainfer() using asyncio.run().
         """
+
         async def _run():
             try:
                 return await self.ainfer(
-                    lm, prompt_or_messages, budget, return_response_only, tools, tool_choice
+                    lm,
+                    prompt_or_messages,
+                    budget,
+                    return_response_only,
+                    tools,
+                    tool_choice,
                 )
             finally:
                 # Clean up session if there is one that was created for current event loop
-                if hasattr(lm, 'close_session'):
+                if hasattr(lm, "close_session"):
                     await lm.close_session(asyncio.get_running_loop())
 
         return asyncio.run(_run())

--- a/its_hub/api/lm.py
+++ b/its_hub/api/lm.py
@@ -26,7 +26,8 @@ class AbstractLanguageModel(ABC):
         Args:
             messages: Single conversation or batch of conversations
             stop: Optional stop sequence for generation
-            **kwargs: Additional model-specific parameters (tools, tool_choice, etc.)
+            **kwargs: Additional model-specific parameters (tools, tool_choice,
+                      response_format, etc.)
 
         Returns:
             Single response dict or list of response dicts (for batched input)
@@ -46,7 +47,8 @@ class AbstractLanguageModel(ABC):
         Args:
             messages: Single conversation
             stop: Optional stop sequence for generation
-            **kwargs: Additional model-specific parameters (tools, tool_choice, etc.)
+            **kwargs: Additional model-specific parameters (tools, tool_choice,
+                      response_format, etc.)
 
         Returns:
             Single response dict

--- a/its_hub/api/orchestrator.py
+++ b/its_hub/api/orchestrator.py
@@ -24,6 +24,7 @@ class AbstractOrchestrator(ABC):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> list[dict]:
         """
         Generate responses for a batch of messages asynchronously.
@@ -37,6 +38,9 @@ class AbstractOrchestrator(ABC):
             include_stop_str_in_output: (Optional) Whether to include stop string in output (vLLM only)
             tools: (Optional) List of available tools
             tool_choice: (Optional) Tool choice mode
+            response_format: (Optional) Response format specification for structured outputs.
+                Supports OpenAI-compatible json_schema format, e.g.:
+                {"type": "json_schema", "json_schema": {"name": "...", "strict": True, "schema": {...}}}
 
         Returns:
             List of response dicts in the same order as messages_lst
@@ -53,6 +57,7 @@ class AbstractOrchestrator(ABC):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> list[dict]:
         """
         Synchronous wrapper for agenerate. Runs async generation in event loop.
@@ -73,5 +78,6 @@ class AbstractOrchestrator(ABC):
                 include_stop_str_in_output=include_stop_str_in_output,
                 tools=tools,
                 tool_choice=tool_choice,
+                response_format=response_format,
             )
         )

--- a/its_hub/api/orchestrator.py
+++ b/its_hub/api/orchestrator.py
@@ -19,12 +19,7 @@ class AbstractOrchestrator(ABC):
         lm: AbstractLanguageModel,
         messages_lst: list[list[ChatMessage]],
         stop: str | None = None,
-        max_tokens: int | None = None,
-        temperature: float | list[float] | None = None,
-        include_stop_str_in_output: bool | None = None,
-        tools: list[dict] | None = None,
-        tool_choice: str | dict | None = None,
-        response_format: dict | None = None,
+        **kwargs,
     ) -> list[dict]:
         """
         Generate responses for a batch of messages asynchronously.
@@ -33,14 +28,8 @@ class AbstractOrchestrator(ABC):
             lm: Language model to use for generation
             messages_lst: List of conversations to process
             stop: (Optional) Stop sequence for generation
-            max_tokens: (Optional) Maximum tokens to generate per response
-            temperature: (Optional) Temperature value(s) for sampling. Can be single float or list of floats
-            include_stop_str_in_output: (Optional) Whether to include stop string in output (vLLM only)
-            tools: (Optional) List of available tools
-            tool_choice: (Optional) Tool choice mode
-            response_format: (Optional) Response format specification for structured outputs.
-                Supports OpenAI-compatible json_schema format, e.g.:
-                {"type": "json_schema", "json_schema": {"name": "...", "strict": True, "schema": {...}}}
+            **kwargs: Additional model-specific parameters (max_tokens, temperature,
+                      tools, tool_choice, response_format, etc.)
 
         Returns:
             List of response dicts in the same order as messages_lst
@@ -52,12 +41,7 @@ class AbstractOrchestrator(ABC):
         lm: AbstractLanguageModel,
         messages_lst: list[list[ChatMessage]],
         stop: str | None = None,
-        max_tokens: int | None = None,
-        temperature: float | list[float] | None = None,
-        include_stop_str_in_output: bool | None = None,
-        tools: list[dict] | None = None,
-        tool_choice: str | dict | None = None,
-        response_format: dict | None = None,
+        **kwargs,
     ) -> list[dict]:
         """
         Synchronous wrapper for agenerate. Runs async generation in event loop.
@@ -73,11 +57,6 @@ class AbstractOrchestrator(ABC):
                 lm,
                 messages_lst,
                 stop=stop,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                include_stop_str_in_output=include_stop_str_in_output,
-                tools=tools,
-                tool_choice=tool_choice,
-                response_format=response_format,
+                **kwargs,
             )
         )

--- a/its_hub/core/algorithms/bon.py
+++ b/its_hub/core/algorithms/bon.py
@@ -101,7 +101,11 @@ class BestOfNResult(AbstractScalingResult):
 
 
 class BestOfN(AbstractScalingAlgorithm):
-    def __init__(self, orm: AbstractOutcomeRewardModel, orchestrator: AbstractOrchestrator | None = None):
+    def __init__(
+        self,
+        orm: AbstractOutcomeRewardModel,
+        orchestrator: AbstractOrchestrator | None = None,
+    ):
         if orchestrator is None:
             # Fallback to default implementation
             orchestrator = LMOrchestrator()
@@ -148,7 +152,9 @@ class BestOfN(AbstractScalingAlgorithm):
             ]
             for cand in unique_responses
         ]
-        unique_scores = await self.orm.ascore(unique_conversations, orchestrator=self.orchestrator)
+        unique_scores = await self.orm.ascore(
+            unique_conversations, orchestrator=self.orchestrator
+        )
 
         # map scores back to original response indices
         scores = [unique_scores[idx] for idx in inverse_idx]

--- a/its_hub/core/lms/openai_lm.py
+++ b/its_hub/core/lms/openai_lm.py
@@ -131,7 +131,9 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
             if not session.closed:
                 await session.close()
 
-    async def close_session(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
+    async def close_session(
+        self, loop: asyncio.AbstractEventLoop | None = None
+    ) -> None:
         """Close the cached session for the given event loop.
 
         Args:

--- a/its_hub/core/lms/openai_lm.py
+++ b/its_hub/core/lms/openai_lm.py
@@ -162,6 +162,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict:
         # helper method to prepare request data for both sync and async methods
         # Convert dict messages to Message objects if needed
@@ -224,6 +225,10 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         if tool_choice is not None:
             request_data["tool_choice"] = tool_choice
 
+        # add response_format for structured outputs
+        if response_format is not None:
+            request_data["response_format"] = response_format
+
         return request_data
 
     async def _agenerate(
@@ -235,6 +240,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> list[dict]:
         # limit concurrency to max_concurrency using a semaphore
         semaphore = asyncio.Semaphore(
@@ -265,6 +271,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                         include_stop_str_in_output,
                         tools,
                         tool_choice,
+                        response_format,
                     )
 
                     async with session.post(
@@ -325,6 +332,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> dict | list[dict]:
         """
         generate response(s) asynchronously
@@ -352,6 +360,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
             include_stop_str_in_output,
             tools,
             tool_choice,
+            response_format,
         )
         return response_or_responses[0] if is_single else response_or_responses
 
@@ -364,6 +373,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> dict:
         # Fallback to the current event loop
@@ -390,6 +400,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                 include_stop_str_in_output,
                 tools,
                 tool_choice,
+                response_format,
             )
 
             async with session.post(

--- a/its_hub/core/orchestrator.py
+++ b/its_hub/core/orchestrator.py
@@ -55,7 +55,9 @@ class LMOrchestrator(AbstractOrchestrator):
 
     def __init__(self, max_concurrency: int = 32):
         if max_concurrency < -1 or max_concurrency == 0:
-            raise ValueError("max_concurrency must be -1 (unlimited concurrency) or a positive integer")
+            raise ValueError(
+                "max_concurrency must be -1 (unlimited concurrency) or a positive integer"
+            )
 
         self.max_concurrency = max_concurrency
         self._semaphore: _ThreadSafeAsyncSemaphore | None = (
@@ -98,20 +100,24 @@ class LMOrchestrator(AbstractOrchestrator):
             return []
 
         logging.debug(
-            "LMOrchestrator: Processing batch of %d messages",
-            len(messages_lst)
+            "LMOrchestrator: Processing batch of %d messages", len(messages_lst)
         )
 
         # Prepare temperature list
         temperature_list = (
-            temperature if isinstance(temperature, list)
+            temperature
+            if isinstance(temperature, list)
             else [temperature] * len(messages_lst)
         )
 
         current_loop = asyncio.get_running_loop()
 
         async def _gen_coro(messages, temp):
-            ctx = self._semaphore if self._semaphore is not None else contextlib.nullcontext()
+            ctx = (
+                self._semaphore
+                if self._semaphore is not None
+                else contextlib.nullcontext()
+            )
             async with ctx:
                 return await lm.agenerate_single(
                     messages,

--- a/its_hub/core/orchestrator.py
+++ b/its_hub/core/orchestrator.py
@@ -74,6 +74,7 @@ class LMOrchestrator(AbstractOrchestrator):
         include_stop_str_in_output: bool | None = None,
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
+        response_format: dict | None = None,
     ) -> list[dict]:
         """
         Generate responses for a batch of messages asynchronously.
@@ -87,6 +88,7 @@ class LMOrchestrator(AbstractOrchestrator):
             include_stop_str_in_output: (Optional) Whether to include stop string in output (vLLM only)
             tools: (Optional) List of available tools
             tool_choice: (Optional) Tool choice mode
+            response_format: (Optional) Response format specification for structured outputs
 
         Returns:
             List of response dicts in the same order as messages_lst
@@ -119,6 +121,7 @@ class LMOrchestrator(AbstractOrchestrator):
                     include_stop_str_in_output=include_stop_str_in_output,
                     tools=tools,
                     tool_choice=tool_choice,
+                    response_format=response_format,
                     loop=current_loop,
                 )
 

--- a/its_hub/core/reward_models/llm_judge.py
+++ b/its_hub/core/reward_models/llm_judge.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 from typing import ClassVar
 
 from its_hub.api import (
@@ -52,7 +53,7 @@ Format: {{"score": <number>}}"""
         lm: AbstractLanguageModel,
         judge_prompt: str | None = None,
         fallback_score: float = 5.0,
-        response_format: dict | None = "default",
+        response_format: dict | None = SCORE_RESPONSE_FORMAT,
     ):
         """
         Initialize LLM judge.
@@ -70,10 +71,7 @@ Format: {{"score": <number>}}"""
         self.lm = lm
         self.judge_prompt = judge_prompt or self.DEFAULT_JUDGE_PROMPT
         self.fallback_score = fallback_score
-        if response_format == "default":
-            self.response_format = self.SCORE_RESPONSE_FORMAT
-        else:
-            self.response_format = response_format
+        self.response_format = response_format
 
     def _format_conversation(self, messages: list[ChatMessage]) -> str:
         """Format conversation messages as readable text, including tool calls."""
@@ -115,8 +113,6 @@ Format: {{"score": <number>}}"""
         - Markdown code blocks: ```json\n{"score": 7}\n```
         - JSON embedded in surrounding text
         """
-        import re
-
         # 1. Try direct parse
         try:
             return json.loads(text)

--- a/its_hub/core/reward_models/llm_judge.py
+++ b/its_hub/core/reward_models/llm_judge.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from typing import ClassVar
 
 from its_hub.api import (
     AbstractLanguageModel,
@@ -29,11 +30,29 @@ Conversation:
 
 Format: {{"score": <number>}}"""
 
+    SCORE_RESPONSE_FORMAT: ClassVar[dict] = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "judge_score",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "score": {"type": "number"},
+                    "reasoning": {"type": "string"},
+                },
+                "required": ["score", "reasoning"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
     def __init__(
         self,
         lm: AbstractLanguageModel,
         judge_prompt: str | None = None,
         fallback_score: float = 5.0,
+        response_format: dict | None = "default",
     ):
         """
         Initialize LLM judge.
@@ -43,10 +62,18 @@ Format: {{"score": <number>}}"""
             judge_prompt: Custom judge prompt template. Use {conversation} placeholder.
                          If None, uses DEFAULT_JUDGE_PROMPT.
             fallback_score: Score to return if JSON parsing fails (default: 5.0)
+            response_format: Response format for structured outputs. Defaults to
+                SCORE_RESPONSE_FORMAT which enforces a {"score": <number>, "reasoning": "..."}
+                schema. Pass None to disable structured outputs (relies on prompt-based
+                JSON extraction only). Pass a custom dict to use your own schema.
         """
         self.lm = lm
         self.judge_prompt = judge_prompt or self.DEFAULT_JUDGE_PROMPT
         self.fallback_score = fallback_score
+        if response_format == "default":
+            self.response_format = self.SCORE_RESPONSE_FORMAT
+        else:
+            self.response_format = response_format
 
     def _format_conversation(self, messages: list[ChatMessage]) -> str:
         """Format conversation messages as readable text, including tool calls."""
@@ -80,19 +107,57 @@ Format: {{"score": <number>}}"""
         prompt_text = self.judge_prompt.format(conversation=conversation_text)
         return [ChatMessage(role="user", content=prompt_text)]
 
+    def _extract_json(self, text: str) -> dict | None:
+        """Extract JSON object from LLM response text.
+
+        Handles common LLM response patterns:
+        - Raw JSON: {"score": 7}
+        - Markdown code blocks: ```json\n{"score": 7}\n```
+        - JSON embedded in surrounding text
+        """
+        import re
+
+        # 1. Try direct parse
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+
+        # 2. Try extracting from markdown code blocks
+        match = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group(1).strip())
+            except json.JSONDecodeError:
+                pass
+
+        # 3. Try finding a JSON object in the text
+        match = re.search(r"\{[^{}]*\}", text)
+        if match:
+            try:
+                return json.loads(match.group(0))
+            except json.JSONDecodeError:
+                pass
+
+        return None
+
     def _parse_score(self, response_content: str) -> float:
         """Parse score from LLM response with fallback."""
-        try:
-            # Try to parse JSON
-            parsed = json.loads(response_content)
-            score = float(parsed.get("score", self.fallback_score))
-            return score
-        except (json.JSONDecodeError, ValueError, TypeError) as e:
-            logging.warning(
-                f"Failed to parse score from response: {response_content[:100]}. "
-                f"Using fallback score {self.fallback_score}. Error: {e}"
-            )
-            return self.fallback_score
+        parsed = self._extract_json(response_content)
+        if parsed is not None:
+            try:
+                return float(parsed.get("score", self.fallback_score))
+            except (ValueError, TypeError, AttributeError) as e:
+                logging.warning(
+                    f"JSON parsed but 'score' field invalid: {parsed}. Error: {e}"
+                )
+                return self.fallback_score
+
+        logging.warning(
+            f"Failed to extract JSON from response: {response_content[:200]}. "
+            f"Using fallback score {self.fallback_score}."
+        )
+        return self.fallback_score
 
     def score(
         self,
@@ -138,6 +203,10 @@ Format: {{"score": <number>}}"""
         if orchestrator is None:
             # Fallback to default implementation
             orchestrator = LMOrchestrator()
+
+        # Use structured outputs if configured, but allow kwargs to override
+        if "response_format" not in kwargs and self.response_format is not None:
+            kwargs["response_format"] = self.response_format
 
         responses = await orchestrator.agenerate(self.lm, judge_prompts, **kwargs)
 

--- a/its_hub/core/reward_models/llm_judge.py
+++ b/its_hub/core/reward_models/llm_judge.py
@@ -113,6 +113,8 @@ Format: {{"score": <number>}}"""
         - Markdown code blocks: ```json\n{"score": 7}\n```
         - JSON embedded in surrounding text
         """
+        text = text.strip()
+
         # 1. Try direct parse
         try:
             return json.loads(text)
@@ -138,7 +140,12 @@ Format: {{"score": <number>}}"""
         return None
 
     def _parse_score(self, response_content: str) -> float:
-        """Parse score from LLM response with fallback."""
+        """Parse score from LLM response with fallback.
+
+        Tries full JSON parsing first, then falls back to regex extraction
+        for truncated JSON (common with models that pad output with whitespace
+        or repeating characters).
+        """
         parsed = self._extract_json(response_content)
         if parsed is not None:
             try:
@@ -149,8 +156,21 @@ Format: {{"score": <number>}}"""
                 )
                 return self.fallback_score
 
+        # Fallback: extract score directly from truncated/malformed JSON
+        # Handles cases like: {"score": 7.5\n\n\n... (no closing brace)
+        match = re.search(r'"score"\s*:\s*([\d.]+)', response_content)
+        if match:
+            try:
+                score = float(match.group(1))
+                logging.info(
+                    f"Extracted score {score} from truncated JSON via regex fallback."
+                )
+                return score
+            except ValueError:
+                pass
+
         logging.warning(
-            f"Failed to extract JSON from response: {response_content[:200]}. "
+            f"Failed to extract score from response: {response_content[:200]}. "
             f"Using fallback score {self.fallback_score}."
         )
         return self.fallback_score
@@ -207,7 +227,7 @@ Format: {{"score": <number>}}"""
         responses = await orchestrator.agenerate(self.lm, judge_prompts, **kwargs)
 
         # Parse scores from responses
-        scores = [self._parse_score(r.get("content", "")) for r in responses]
+        scores = [self._parse_score(r.get("content") or "") for r in responses]
 
         # Return single or batch
         return scores if is_batch else scores[0]

--- a/its_hub/core/reward_models/local_vllm_prm.py
+++ b/its_hub/core/reward_models/local_vllm_prm.py
@@ -2,6 +2,7 @@
 Process reward model implementation for experimental algorithms. This requires installing reward-hub:
     pip install its_hub[experimental]
 """
+
 import asyncio
 
 from reward_hub.base import AggregationMethod

--- a/scripts/test_structured_output.py
+++ b/scripts/test_structured_output.py
@@ -1,0 +1,153 @@
+"""Test structured output support with a locally hosted model (Qwen3-4B via vLLM)."""
+
+import asyncio
+import json
+import logging
+
+from its_hub.core.lms.openai_lm import OpenAICompatibleLanguageModel
+from its_hub.core.reward_models.llm_judge import LLMJudge
+from its_hub.api.types import ChatMessage
+
+logging.basicConfig(level=logging.INFO)
+
+ENDPOINT = "http://localhost:8200/v1"
+MODEL = "Qwen/Qwen3-4B"
+# Qwen3 uses thinking mode by default - needs generous max_tokens
+MAX_TOKENS = 4096
+
+
+async def test_raw_structured_output():
+    """Test response_format directly through the LM layer."""
+    print("\n=== Test 1: Raw structured output via LM ===")
+    async with OpenAICompatibleLanguageModel(
+        endpoint=ENDPOINT, api_key="NO_API_KEY", model_name=MODEL
+    ) as lm:
+        response = await lm.agenerate_single(
+            messages=[ChatMessage(role="user", content="What is 2+2? Return JSON with 'answer' field.")],
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "math_answer",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "answer": {"type": "number"},
+                        },
+                        "required": ["answer"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            max_tokens=MAX_TOKENS,
+            temperature=0.6,
+        )
+        content = response.get("content") or ""
+        reasoning = response.get("reasoning")
+        print(f"Reasoning present: {reasoning is not None}")
+
+        # vLLM + Qwen3 can pad JSON with excessive whitespace
+        content_stripped = content.strip()
+        print(f"Content (stripped, first 200 chars): {content_stripped[:200]!r}")
+
+        if not content_stripped:
+            print("SKIPPED - model returned no content (thinking mode exhausted tokens)")
+            return
+
+        parsed = json.loads(content_stripped)
+        print(f"Parsed JSON: {parsed}")
+        assert "answer" in parsed, "Missing 'answer' field"
+        print("PASSED\n")
+
+
+async def test_llm_judge_with_structured_output():
+    """Test LLMJudge using structured output (default behavior)."""
+    print("=== Test 2: LLMJudge with structured output (default) ===")
+    async with OpenAICompatibleLanguageModel(
+        endpoint=ENDPOINT, api_key="NO_API_KEY", model_name=MODEL
+    ) as lm:
+        judge = LLMJudge(lm=lm)
+        conversation = [
+            ChatMessage(role="user", content="What is the capital of France?"),
+            ChatMessage(role="assistant", content="The capital of France is Paris."),
+        ]
+        score = await judge.ascore(
+            messages=conversation,
+            max_tokens=MAX_TOKENS,
+            temperature=0.6,
+        )
+        print(f"Score: {score}")
+        assert isinstance(score, float), f"Expected float, got {type(score)}"
+        print("PASSED\n")
+
+
+async def test_llm_judge_without_structured_output():
+    """Test LLMJudge with structured output disabled (prompt-only JSON extraction)."""
+    print("=== Test 3: LLMJudge WITHOUT structured output (response_format=None) ===")
+    async with OpenAICompatibleLanguageModel(
+        endpoint=ENDPOINT, api_key="NO_API_KEY", model_name=MODEL
+    ) as lm:
+        judge = LLMJudge(lm=lm, response_format=None)
+        conversation = [
+            ChatMessage(role="user", content="Explain quantum computing in one sentence."),
+            ChatMessage(role="assistant", content="Quantum computing uses qubits that can exist in superposition to perform certain calculations exponentially faster than classical computers."),
+        ]
+        score = await judge.ascore(
+            messages=conversation,
+            max_tokens=MAX_TOKENS,
+            temperature=0.6,
+        )
+        print(f"Score: {score}")
+        assert isinstance(score, float), f"Expected float, got {type(score)}"
+        print("PASSED\n")
+
+
+async def test_llm_judge_batch():
+    """Test LLMJudge scoring multiple conversations in batch."""
+    print("=== Test 4: LLMJudge batch scoring with structured output ===")
+    async with OpenAICompatibleLanguageModel(
+        endpoint=ENDPOINT, api_key="NO_API_KEY", model_name=MODEL
+    ) as lm:
+        judge = LLMJudge(lm=lm)
+        conversations = [
+            [
+                ChatMessage(role="user", content="What is 2+2?"),
+                ChatMessage(role="assistant", content="4"),
+            ],
+            [
+                ChatMessage(role="user", content="What is the meaning of life?"),
+                ChatMessage(role="assistant", content="I don't know."),
+            ],
+            [
+                ChatMessage(role="user", content="Write a haiku about Python."),
+                ChatMessage(role="assistant", content="Indentation rules\nSnakes and code intertwine here\nBeautiful syntax"),
+            ],
+        ]
+        scores = await judge.ascore(
+            messages=conversations,
+            max_tokens=MAX_TOKENS,
+            temperature=0.6,
+        )
+        print(f"Scores: {scores}")
+        assert isinstance(scores, list), f"Expected list, got {type(scores)}"
+        assert len(scores) == 3, f"Expected 3 scores, got {len(scores)}"
+        for s in scores:
+            assert isinstance(s, float), f"Expected float, got {type(s)}"
+        print("PASSED\n")
+
+
+async def main():
+    print("Testing structured output support against Qwen/Qwen3-4B (vLLM)")
+    print("=" * 60)
+
+    await test_raw_structured_output()
+    await test_llm_judge_with_structured_output()
+    await test_llm_judge_without_structured_output()
+    await test_llm_judge_batch()
+
+    print("=" * 60)
+    print("ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/mocks/language_models.py
+++ b/tests/mocks/language_models.py
@@ -47,13 +47,13 @@ class StepMockLanguageModel(AbstractLanguageModel):
         self.step_responses = step_responses
         self.call_count = 0
 
-    async def agenerate_single(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None, loop=None):
+    async def agenerate_single(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None, response_format=None, loop=None):
         """Single message generation used by the orchestrator."""
         content = self.step_responses[self.call_count % len(self.step_responses)]
         self.call_count += 1
         return {"role": "assistant", "content": content}
 
-    async def agenerate(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None):
+    async def agenerate(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None, response_format=None):
         return self.generate(messages, stop, max_tokens, temperature, include_stop_str_in_output, tools, tool_choice)
 
     def generate(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None):
@@ -89,7 +89,7 @@ class ErrorMockLanguageModel(AbstractLanguageModel):
         self.error_on_calls = error_on_calls or []
         self.call_count = 0
 
-    async def agenerate_single(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None, loop=None):
+    async def agenerate_single(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None, response_format=None, loop=None):
         """Single message generation used by the orchestrator."""
         if self.call_count in self.error_on_calls:
             self.call_count += 1
@@ -98,7 +98,7 @@ class ErrorMockLanguageModel(AbstractLanguageModel):
         self.call_count += 1
         return {"role": "assistant", "content": content}
 
-    async def agenerate(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None):
+    async def agenerate(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None, response_format=None):
         return self.generate(messages, stop, max_tokens, temperature, include_stop_str_in_output, tools, tool_choice)
 
     def generate(self, messages, stop=None, max_tokens=None, temperature=None, include_stop_str_in_output=None, tools=None, tool_choice=None):

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -1,0 +1,317 @@
+"""Tests for LLMJudge JSON parsing and structured output support."""
+
+import threading
+
+import pytest
+
+from its_hub.api import ChatMessage
+from its_hub.core.orchestrator import LMOrchestrator
+from its_hub.core.reward_models.llm_judge import LLMJudge
+
+
+class DummyLM:
+    """Minimal stub — only _parse_score is tested, no LM calls needed."""
+    pass
+
+
+class MockLM:
+    """Mock LM that returns configurable responses and records call kwargs."""
+
+    def __init__(self, response_content: str = '{"score": 8, "reasoning": "good"}'):
+        self.response_content = response_content
+        self.calls: list[dict] = []
+        self._lock = threading.Lock()
+
+    async def agenerate_single(self, messages, loop=None, **kwargs):
+        with self._lock:
+            self.calls.append({"messages": messages, **kwargs})
+        return {"role": "assistant", "content": self.response_content}
+
+
+@pytest.fixture
+def judge():
+    return LLMJudge(lm=DummyLM(), fallback_score=5.0)
+
+
+# ===========================================================================
+# 1. JSON Parsing
+# ===========================================================================
+
+class TestParseScore:
+    """Test _parse_score handles common LLM response patterns."""
+
+    def test_raw_json(self, judge):
+        assert judge._parse_score('{"score": 8}') == 8.0
+
+    def test_json_with_whitespace(self, judge):
+        assert judge._parse_score('  {"score": 7.5}  ') == 7.5
+
+    def test_markdown_code_block(self, judge):
+        text = '```json\n{"score": 9}\n```'
+        assert judge._parse_score(text) == 9.0
+
+    def test_markdown_code_block_no_lang(self, judge):
+        text = '```\n{"score": 6}\n```'
+        assert judge._parse_score(text) == 6.0
+
+    def test_json_with_preamble(self, judge):
+        text = 'Here is my evaluation:\n{"score": 4}'
+        assert judge._parse_score(text) == 4.0
+
+    def test_json_with_surrounding_text(self, judge):
+        text = 'Based on analysis, {"score": 3} is my rating.'
+        assert judge._parse_score(text) == 3.0
+
+    def test_json_with_reasoning(self, judge):
+        text = '{"score": 7, "reasoning": "Good response"}'
+        assert judge._parse_score(text) == 7.0
+
+    def test_missing_score_key(self, judge):
+        assert judge._parse_score('{"rating": 8}') == 5.0
+
+    def test_no_json_at_all(self, judge):
+        assert judge._parse_score("This is a great response") == 5.0
+
+    def test_empty_string(self, judge):
+        assert judge._parse_score("") == 5.0
+
+    def test_integer_score(self, judge):
+        assert judge._parse_score('{"score": 10}') == 10.0
+
+    def test_markdown_with_extra_text(self, judge):
+        text = 'I evaluated the conversation:\n```json\n{"score": 2}\n```\nHope this helps!'
+        assert judge._parse_score(text) == 2.0
+
+
+class TestExtractJson:
+    """Test _extract_json directly for edge cases."""
+
+    def test_returns_none_for_garbage(self, judge):
+        assert judge._extract_json("no json here") is None
+
+    def test_nested_braces_takes_first_flat_object(self, judge):
+        result = judge._extract_json('outer {"score": 5} end')
+        assert result == {"score": 5}
+
+    def test_code_block_preferred_over_inline(self, judge):
+        text = 'text {"score": 1}\n```json\n{"score": 9}\n```'
+        result = judge._extract_json(text)
+        assert result["score"] == 9
+
+
+# ===========================================================================
+# 2. Structured Output Configuration
+# ===========================================================================
+
+class TestStructuredOutputConfig:
+    """Test LLMJudge response_format configuration."""
+
+    def test_default_response_format(self):
+        judge = LLMJudge(lm=DummyLM())
+        assert judge.response_format is not None
+        assert judge.response_format["type"] == "json_schema"
+        schema = judge.response_format["json_schema"]["schema"]
+        assert "score" in schema["properties"]
+        assert "reasoning" in schema["properties"]
+
+    def test_disabled_response_format(self):
+        judge = LLMJudge(lm=DummyLM(), response_format=None)
+        assert judge.response_format is None
+
+    def test_custom_response_format(self):
+        custom = {"type": "json_object"}
+        judge = LLMJudge(lm=DummyLM(), response_format=custom)
+        assert judge.response_format == {"type": "json_object"}
+
+    def test_score_response_format_schema_is_valid(self):
+        """Verify the default schema matches OpenAI structured output requirements."""
+        fmt = LLMJudge.SCORE_RESPONSE_FORMAT
+        assert fmt["type"] == "json_schema"
+        js = fmt["json_schema"]
+        assert js["name"] == "judge_score"
+        assert js["strict"] is True
+        schema = js["schema"]
+        assert schema["additionalProperties"] is False
+        assert set(schema["required"]) == {"score", "reasoning"}
+
+
+# ===========================================================================
+# 3. Structured Output Forwarding (LLMJudge → Orchestrator → LM)
+# ===========================================================================
+
+class TestStructuredOutputForwarding:
+    """Test that response_format flows from LLMJudge through orchestrator to LM."""
+
+    @pytest.mark.asyncio
+    async def test_default_response_format_forwarded(self):
+        lm = MockLM()
+        judge = LLMJudge(lm=lm)
+        messages = [ChatMessage(role="user", content="hello")]
+
+        await judge.ascore(messages)
+
+        assert len(lm.calls) == 1
+        assert lm.calls[0]["response_format"] == LLMJudge.SCORE_RESPONSE_FORMAT
+
+    @pytest.mark.asyncio
+    async def test_disabled_response_format_not_forwarded(self):
+        lm = MockLM()
+        judge = LLMJudge(lm=lm, response_format=None)
+        messages = [ChatMessage(role="user", content="hello")]
+
+        await judge.ascore(messages)
+
+        assert len(lm.calls) == 1
+        # response_format should be None when disabled
+        assert lm.calls[0].get("response_format") is None
+
+    @pytest.mark.asyncio
+    async def test_kwargs_override_default_response_format(self):
+        lm = MockLM()
+        judge = LLMJudge(lm=lm)
+        messages = [ChatMessage(role="user", content="hello")]
+        custom = {"type": "json_object"}
+
+        await judge.ascore(messages, response_format=custom)
+
+        assert lm.calls[0]["response_format"] == {"type": "json_object"}
+
+    @pytest.mark.asyncio
+    async def test_batch_scoring_forwards_response_format(self):
+        lm = MockLM()
+        judge = LLMJudge(lm=lm)
+        batch = [
+            [ChatMessage(role="user", content="conv1")],
+            [ChatMessage(role="user", content="conv2")],
+        ]
+
+        scores = await judge.ascore(batch)
+
+        assert len(scores) == 2
+        for call in lm.calls:
+            assert call["response_format"] == LLMJudge.SCORE_RESPONSE_FORMAT
+
+    @pytest.mark.asyncio
+    async def test_score_parsed_from_structured_output(self):
+        lm = MockLM(response_content='{"score": 9.5, "reasoning": "excellent"}')
+        judge = LLMJudge(lm=lm)
+        messages = [ChatMessage(role="user", content="hello")]
+
+        score = await judge.ascore(messages)
+        assert score == 9.5
+
+
+# ===========================================================================
+# 4. Orchestrator response_format Forwarding
+# ===========================================================================
+
+class TestOrchestratorResponseFormat:
+    """Test that LMOrchestrator threads response_format to the LM."""
+
+    @pytest.mark.asyncio
+    async def test_response_format_forwarded(self):
+        lm = MockLM()
+        orch = LMOrchestrator(max_concurrency=4)
+        batch = [[ChatMessage(role="user", content="msg")]]
+        fmt = {"type": "json_object"}
+
+        await orch.agenerate(lm, batch, response_format=fmt)
+
+        assert lm.calls[0]["response_format"] == {"type": "json_object"}
+
+    @pytest.mark.asyncio
+    async def test_response_format_none_by_default(self):
+        lm = MockLM()
+        orch = LMOrchestrator(max_concurrency=4)
+        batch = [[ChatMessage(role="user", content="msg")]]
+
+        await orch.agenerate(lm, batch)
+
+        assert lm.calls[0].get("response_format") is None
+
+    @pytest.mark.asyncio
+    async def test_response_format_with_other_params(self):
+        lm = MockLM()
+        orch = LMOrchestrator(max_concurrency=4)
+        batch = [[ChatMessage(role="user", content="msg")]]
+        fmt = {"type": "json_schema", "json_schema": {"name": "test", "strict": True, "schema": {}}}
+
+        await orch.agenerate(
+            lm, batch,
+            temperature=0.0,
+            max_tokens=100,
+            response_format=fmt,
+        )
+
+        call = lm.calls[0]
+        assert call["temperature"] == 0.0
+        assert call["max_tokens"] == 100
+        assert call["response_format"] == fmt
+
+    @pytest.mark.asyncio
+    async def test_response_format_same_across_batch(self):
+        lm = MockLM()
+        orch = LMOrchestrator(max_concurrency=4)
+        batch = [
+            [ChatMessage(role="user", content=f"msg-{i}")]
+            for i in range(3)
+        ]
+        fmt = {"type": "json_object"}
+
+        await orch.agenerate(lm, batch, response_format=fmt)
+
+        assert len(lm.calls) == 3
+        for call in lm.calls:
+            assert call["response_format"] == fmt
+
+    def test_sync_generate_forwards_response_format(self):
+        lm = MockLM()
+        orch = LMOrchestrator(max_concurrency=4)
+        batch = [[ChatMessage(role="user", content="msg")]]
+        fmt = {"type": "json_object"}
+
+        orch.generate(lm, batch, response_format=fmt)
+
+        assert lm.calls[0]["response_format"] == {"type": "json_object"}
+
+
+# ===========================================================================
+# 5. _prepare_request_data
+# ===========================================================================
+
+class TestPrepareRequestData:
+    """Test that response_format is set in the HTTP request payload."""
+
+    def _make_lm(self):
+        from its_hub.core.lms.openai_lm import OpenAICompatibleLanguageModel
+        return OpenAICompatibleLanguageModel(
+            endpoint="http://localhost:8000/v1",
+            api_key="test",
+            model_name="test-model",
+        )
+
+    def test_response_format_included(self):
+        lm = self._make_lm()
+        fmt = {"type": "json_object"}
+        data = lm._prepare_request_data(
+            [ChatMessage(role="user", content="hi")],
+            response_format=fmt,
+        )
+        assert data["response_format"] == {"type": "json_object"}
+
+    def test_response_format_not_included_when_none(self):
+        lm = self._make_lm()
+        data = lm._prepare_request_data(
+            [ChatMessage(role="user", content="hi")],
+        )
+        assert "response_format" not in data
+
+    def test_response_format_json_schema(self):
+        lm = self._make_lm()
+        fmt = LLMJudge.SCORE_RESPONSE_FORMAT
+        data = lm._prepare_request_data(
+            [ChatMessage(role="user", content="hi")],
+            response_format=fmt,
+        )
+        assert data["response_format"]["type"] == "json_schema"
+        assert data["response_format"]["json_schema"]["strict"] is True


### PR DESCRIPTION
## Summary

- Thread `response_format` parameter through the full API chain (`AbstractOrchestrator` → `LMOrchestrator` → `AbstractLanguageModel` → `OpenAICompatibleLanguageModel`) enabling structured JSON output from OpenAI/vLLM backends
- `LLMJudge` now uses structured outputs by default — the API guarantees valid JSON conforming to a `{"score": <number>, "reasoning": "..."}` schema, eliminating silent fallbacks to default scores
- Add robust JSON extraction (`_extract_json`) as a defensive fallback for backends that don't support structured outputs — handles markdown code blocks, preamble text, and embedded JSON
- `response_format` can be disabled (`response_format=None`) or customized per `LLMJudge` instance

## Context

The previous `LLMJudge._parse_score` did a bare `json.loads()` and silently fell back to a default score of 5.0 on failure. LLMs commonly return JSON wrapped in markdown code blocks, with preamble text, etc. — all of which caused silent score corruption.

Related: an earlier fix ([076b5dd](https://github.com/Red-Hat-AI-Innovation-Team/its_hub/commit/076b5dd85002b9f4c8e38ec8c3c400ee84050074)) addressed this in the old LiteLLM-based `integration/reward_hub.py` using `guided_json`, but that file was removed during the refactor. This PR restores equivalent functionality using the OpenAI-standard `response_format` parameter.

## E2E validation (Qwen3-4B via vLLM)

Tested against a live vLLM endpoint serving `Qwen/Qwen3-4B` and discovered three issues with thinking-mode models:

1. **`content: None` crash**: Qwen3's thinking mode returns `content: None` with reasoning in a separate field — `r.get("content", "")` returned `None` since the key exists. Fixed with `r.get("content") or ""`.
2. **Whitespace-padded JSON**: vLLM's structured output pads JSON with thousands of newlines, breaking `json.loads`. Fixed by stripping whitespace before parsing.
3. **Truncated JSON**: Models exhaust token budget on reasoning, producing incomplete JSON like `{"score": 7.5\n\n...` without a closing brace. Added regex fallback `"score"\s*:\s*([\d.]+)` to extract scores from malformed output.

## Files changed

| File | Change |
|------|--------|
| `its_hub/api/lm.py` | Add `response_format` to docstrings |
| `its_hub/api/orchestrator.py` | Add `response_format` param to `agenerate`/`generate` |
| `its_hub/core/orchestrator.py` | Thread `response_format` to `lm.agenerate_single` |
| `its_hub/core/lms/openai_lm.py` | Add `response_format` to `_prepare_request_data`, `agenerate_single`, `agenerate` |
| `its_hub/core/reward_models/llm_judge.py` | Default `SCORE_RESPONSE_FORMAT` schema, robust `_extract_json` fallback, regex score extraction for truncated JSON |
| `tests/mocks/language_models.py` | Accept `response_format` kwarg in mock LMs |
| `tests/test_llm_judge.py` | 32 new tests covering parsing, config, forwarding, and request data |
| `scripts/test_structured_output.py` | E2E test script for live vLLM validation |

## Test plan

- [x] All 208 unit tests pass (`uv run pytest tests/ --ignore=tests/e2e`)
- [x] Lint clean on all changed files (`uv run ruff check`)
- [x] E2E validated with Qwen3-4B on vLLM (structured output, batch scoring, fallback parsing)
- [x] Verified structured output works with prompt-only mode (`response_format=None`)