### PR TITLE
docs: add missing pages to sidebar navigation

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,5 +7,7 @@
   - [Best-of-N](algorithms.md#best-of-n)
   - [Beam Search](algorithms.md#beam-search)
   - [Self-Consistency](algorithms.md#self-consistency)
+  - [Planning Wrapper](PLANNING_WRAPPER.md)
+- [Orchestration](orchestration.md)
 - [Benchmarking](benchmarking.md)
 - [Development](development.md)


### PR DESCRIPTION
## Summary

- Add Orchestration page to the Docsify sidebar (top-level entry)
- Add Planning Wrapper page under the Algorithms section

Both `orchestration.md` and `PLANNING_WRAPPER.md` existed in `docs/` but were not linked from `_sidebar.md`, making them unreachable in the doc site.