### PR TITLE
Refactor error handling for taskgroups

### DIFF
--- a/its_hub/api/errors.py
+++ b/its_hub/api/errors.py
@@ -9,6 +9,11 @@ error messages.
 import json
 from typing import Any
 
+try:
+    from aiohttp import ClientError as AiohttpClientError
+except ImportError:
+    AiohttpClientError = None
+
 
 class APIError(Exception):
     """Base class for API-related errors."""
@@ -61,8 +66,23 @@ class InternalServerError(APIError):
     pass
 
 
-# Retryable error types
-RETRYABLE_ERRORS = (RateLimitError, APIConnectionError, InternalServerError)
+# Retryable error types — includes both API-level and transport-level exceptions.
+# ConnectionError covers socket resets and refused connections.
+# TimeoutError covers asyncio.TimeoutError and socket timeouts.
+# OSError covers low-level network failures (DNS, broken pipe, etc.).
+_RETRYABLE_BASE = (
+    RateLimitError,
+    APIConnectionError,
+    InternalServerError,
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
+RETRYABLE_ERRORS = (
+    (*_RETRYABLE_BASE, AiohttpClientError)
+    if AiohttpClientError is not None
+    else _RETRYABLE_BASE
+)
 
 
 def parse_api_error(status_code: int, error_text: str) -> APIError:

--- a/its_hub/core/lms/openai_lm.py
+++ b/its_hub/core/lms/openai_lm.py
@@ -33,7 +33,7 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         stop: str | None = None,
         max_tokens: int | None = None,
         temperature: float | None = None,
-        max_tries: int = 8,
+        max_tries: int = 3,
         max_concurrency: int = -1,
         replace_error_with_message: str | None = None,
         # SSL configuration

--- a/its_hub/core/orchestrator.py
+++ b/its_hub/core/orchestrator.py
@@ -131,11 +131,22 @@ class LMOrchestrator(AbstractOrchestrator):
                     loop=current_loop,
                 )
 
-        async with asyncio.TaskGroup() as tg:
-            tasks = [
-                tg.create_task(_gen_coro(msgs, temp))
-                for msgs, temp in zip(messages_lst, temperature_list)
-            ]
+        try:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [
+                    tg.create_task(_gen_coro(msgs, temp))
+                    for msgs, temp in zip(messages_lst, temperature_list)
+                ]
+        except ExceptionGroup as eg:
+            error_types = {}
+            for exc in eg.exceptions:
+                name = type(exc).__name__
+                error_types[name] = error_types.get(name, 0) + 1
+            summary = ", ".join(f"{v}x {k}" for k, v in error_types.items())
+            raise RuntimeError(
+                f"LMOrchestrator: {len(eg.exceptions)}/{len(messages_lst)} "
+                f"generation(s) failed ({summary})"
+            ) from eg
 
         # Collect results in order
         responses = [task.result() for task in tasks]

--- a/its_hub/core/orchestrator.py
+++ b/its_hub/core/orchestrator.py
@@ -138,15 +138,18 @@ class LMOrchestrator(AbstractOrchestrator):
                     for msgs, temp in zip(messages_lst, temperature_list)
                 ]
         except ExceptionGroup as eg:
+            cancelled = sum(1 for t in tasks if t.cancelled())
             error_types = {}
             for exc in eg.exceptions:
                 name = type(exc).__name__
                 error_types[name] = error_types.get(name, 0) + 1
             summary = ", ".join(f"{v}x {k}" for k, v in error_types.items())
-            raise RuntimeError(
-                f"LMOrchestrator: {len(eg.exceptions)}/{len(messages_lst)} "
-                f"generation(s) failed ({summary})"
-            ) from eg
+            msg = (
+                f"LMOrchestrator: {len(eg.exceptions)} error(s), "
+                f"{cancelled} cancelled out of {len(messages_lst)} "
+                f"generation(s) ({summary})"
+            )
+            raise RuntimeError(msg) from eg
 
         # Collect results in order
         responses = [task.result() for task in tasks]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -426,24 +426,31 @@ class TestErrorHandling:
     async def test_single_error_propagates(self):
         orch = LMOrchestrator(max_concurrency=4)
         lm = ErrorMockLM(error_indices={2})
-        with pytest.raises(ExceptionGroup) as exc_info:
+        with pytest.raises(RuntimeError, match=r"1/5 generation\(s\) failed"):
             await orch.agenerate(lm, _make_batch(5))
-        assert any("Simulated error" in str(e) for e in exc_info.value.exceptions)
 
     @pytest.mark.asyncio
     async def test_all_errors_propagate(self):
         orch = LMOrchestrator(max_concurrency=4)
         lm = ErrorMockLM(error_indices={0, 1, 2})
-        with pytest.raises(ExceptionGroup) as exc_info:
+        with pytest.raises(RuntimeError, match=r"3/3 generation\(s\) failed"):
             await orch.agenerate(lm, _make_batch(3))
-        assert len(exc_info.value.exceptions) == 3
+
+    @pytest.mark.asyncio
+    async def test_error_message_includes_count(self):
+        orch = LMOrchestrator(max_concurrency=4)
+        lm = ErrorMockLM(error_indices={0, 2})
+        with pytest.raises(RuntimeError) as exc_info:
+            await orch.agenerate(lm, _make_batch(4))
+        assert "2/4" in str(exc_info.value)
+        assert exc_info.value.__cause__ is not None
 
     @pytest.mark.asyncio
     async def test_semaphore_released_after_error(self):
         orch = LMOrchestrator(max_concurrency=4)
         lm = ErrorMockLM(error_indices={1})
 
-        with pytest.raises(ExceptionGroup):
+        with pytest.raises(RuntimeError):
             await orch.agenerate(lm, _make_batch(3))
 
         # Semaphore should be fully released
@@ -455,7 +462,7 @@ class TestErrorHandling:
 
         # First batch: errors
         error_lm = ErrorMockLM(error_indices={0})
-        with pytest.raises(ExceptionGroup):
+        with pytest.raises(RuntimeError):
             await orch.agenerate(error_lm, _make_batch(2))
 
         # Second batch: should work fine
@@ -485,7 +492,7 @@ class TestSemaphoreSafety:
         lm = ErrorMockLM(error_indices={0, 1, 2, 3, 4})
 
         initial = _sem_value(orch)
-        with pytest.raises(ExceptionGroup):
+        with pytest.raises(RuntimeError):
             await orch.agenerate(lm, _make_batch(5))
         assert _sem_value(orch) == initial
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -426,14 +426,20 @@ class TestErrorHandling:
     async def test_single_error_propagates(self):
         orch = LMOrchestrator(max_concurrency=4)
         lm = ErrorMockLM(error_indices={2})
-        with pytest.raises(RuntimeError, match=r"1/5 generation\(s\) failed"):
+        with pytest.raises(
+            RuntimeError,
+            match=r"LMOrchestrator:.*error\(s\).*out of 5 generation\(s\).*RuntimeError",
+        ):
             await orch.agenerate(lm, _make_batch(5))
 
     @pytest.mark.asyncio
     async def test_all_errors_propagate(self):
         orch = LMOrchestrator(max_concurrency=4)
         lm = ErrorMockLM(error_indices={0, 1, 2})
-        with pytest.raises(RuntimeError, match=r"3/3 generation\(s\) failed"):
+        with pytest.raises(
+            RuntimeError,
+            match=r"LMOrchestrator:.*error\(s\).*out of 3 generation\(s\).*RuntimeError",
+        ):
             await orch.agenerate(lm, _make_batch(3))
 
     @pytest.mark.asyncio
@@ -442,7 +448,9 @@ class TestErrorHandling:
         lm = ErrorMockLM(error_indices={0, 2})
         with pytest.raises(RuntimeError) as exc_info:
             await orch.agenerate(lm, _make_batch(4))
-        assert "2/4" in str(exc_info.value)
+        msg = str(exc_info.value)
+        assert "out of 4 generation(s)" in msg
+        assert "RuntimeError" in msg
         assert exc_info.value.__cause__ is not None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

These changes improve error handling with TaskGroups.

## Changes

- Label more exceptions as retry-able so that connection issues do not cause all tasks in the task group to be cancelled
- Catch task group exceptions and re-raise with a user friendly error message

## Test Plan

- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Linting passes (`uv run ruff check its_hub/`)
- [x] Formatting passes (`uv run ruff format --check its_hub/`)

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check its_hub/`)
- [x] Added/updated tests for new functionality
- [ ] Updated documentation if needed
