### PR TITLE
(fix) Install required extras to run e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
         enable-cache: true
 
     - name: Install dependencies
-      run: uv sync --extra dev
+      run: uv sync --extra dev --extra research
 
     - name: Run e2e tests
       run: |


### PR DESCRIPTION
## Summary

e2e workflow returns with error because the e2e tests use math_verify and requires research extra to be installed.

## Changes

Install research extra in the workflow.

## Test Plan

<!-- Describe how you tested these changes -->

- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Linting passes (`uv run ruff check its_hub/`)
- [ ] Formatting passes (`uv run ruff format --check its_hub/`)

## Checklist

- [ ] Tests pass locally (`uv run pytest`)
- [ ] Linting passes (`uv run ruff check its_hub/`)
- [ ] Added/updated tests for new functionality
- [ ] Updated documentation if needed
