### PR TITLE
Add repository-wide SPEC.md for its_hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,14 @@ print(result)
 - ⚡ **Async Support**: Concurrent generation with limits and error handling
 
 
+## Demo
+
+See the library in action with a walkthrough of inference-time scaling algorithms:
+
+[![Demo walkthrough](https://img.youtube.com/vi/qaXyvmR-YBU/maxresdefault.jpg)](https://www.youtube.com/watch?v=qaXyvmR-YBU)
+
+Try it in your browser: [https://red.ht/its-hub-demo](https://red.ht/its-hub-demo)
+
+To run the demo yourself, see the [demo setup instructions](https://github.com/lukeinglis/its_hub_demo/blob/main/demo_ui/README.md).
+
 For detailed documentation, visit: [https://ai-innovation.team/its_hub](https://ai-innovation.team/its_hub)

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,35 +147,42 @@ This specification defines these conformance profiles:
 2. `Outcome Reward Extension`
    - Scores final candidates for profiles that require outcome evaluation.
 
-3. `Stable SelfConsistency Extension`
+3. `Process Reward Extension`
+   - Scores intermediate reasoning steps for profiles that require process evaluation.
+
+4. `Stable SelfConsistency Extension`
    - Candidate-generation and voting profile.
 
-4. `Stable BestOfN Extension`
+5. `Stable BestOfN Extension`
    - Candidate-generation and outcome-scoring profile.
 
-5. `Experimental Search Extension`
+6. `Experimental Search Extension`
    - Step-wise search family
    - beam search
    - particle methods
    - planning wrapper
 
-6. `Direct Gateway Extension`
+7. `Direct Gateway Extension`
    - Standalone service that terminates client requests and applies ITS directly.
 
-7. `External-Processing Gateway Extension`
+8. `External-Processing Gateway Extension`
    - Intercepting gateway that conditionally applies ITS in front of an upstream API.
 
-8. `Research Toolkit Extension`
+9. `Research Toolkit Extension`
    - Examples, benchmark runners, dataset evaluation tooling.
 
 Composition rules:
 
-- Every conforming implementation MUST satisfy `Core Library Conformance`.
-- Every conforming implementation MUST implement at least one algorithm profile from Section 7 or
-  Section 8.
+- Every implementation that claims any conformance profile from this specification MUST satisfy
+  `Core Library Conformance`.
+- An implementation MAY claim `Core Library Conformance` without implementing a stable or
+  experimental algorithm profile.
+- An implementation MAY claim full algorithm conformance only if it implements at least one stable
+  algorithm profile from Section 7.
 - `Stable BestOfN Extension` requires `Outcome Reward Extension`.
-- `Experimental Search Extension` MAY additionally require process scoring according to the selected
+- `Experimental Search Extension` MAY require `Process Reward Extension` according to the selected
   profile.
+- `Experimental Search Extension` alone is not sufficient for full algorithm conformance.
 - Sections marked OPTIONAL are extension profiles.
 - An implementation MAY support multiple extensions at once.
 
@@ -531,7 +538,14 @@ Process scoring evaluates intermediate reasoning steps.
 Required behavior:
 
 - accept prompt or conversation context plus ordered reasoning steps
-- return per-step scores or an equivalent structure that preserves per-step evaluation meaning
+- return exactly one score per step, or an equivalent structure that preserves one-to-one
+  step-aligned evaluation meaning
+
+Required invariants:
+
+- score cardinality MUST equal step cardinality
+- score ordering MUST remain aligned with step ordering
+- if score cardinality does not match, fail with `invalid_reward_cardinality` or equivalent
 
 The minimal interoperable shape is a list of numeric scores aligned with the step list.
 
@@ -659,7 +673,7 @@ Common characteristics:
 
 - use `StepGenerationConfig`
 - generate partial reasoning trajectories rather than only final answers
-- may depend on process scoring
+- MAY depend on `Process Reward Extension`
 - may rely on prompt-string compatibility paths more than the stable core
 
 ### 8.3 `BeamSearch`
@@ -678,6 +692,8 @@ Budget semantics:
 
 Required documentation:
 
+- whether `Process Reward Extension` is required by the selected beam-search variant
+- the ranking signal used when `Process Reward Extension` is not required
 - frontier-bound policy
 - step stopping criteria
 - score aggregation policy
@@ -706,6 +722,8 @@ Budget semantics:
 
 Required documentation:
 
+- whether `Process Reward Extension` is required by the selected particle variant
+- the weighting or ranking signal used when `Process Reward Extension` is not required
 - update/resampling policy
 - score or weight aggregation policy
 - stopping criteria
@@ -721,6 +739,11 @@ Budget semantics:
 
 - implementation-defined in v1
 - the implementation MUST document how planning cost and downstream execution cost share `budget`
+
+Required documentation:
+
+- whether planning, execution, or both depend on `Outcome Reward Extension` and/or
+  `Process Reward Extension`
 
 ## 9. Gateway Profiles
 
@@ -1364,7 +1387,15 @@ If the `Outcome Reward Extension` is implemented:
 - score cardinality mismatches fail explicitly
 - score ordering remains aligned with candidate ordering
 
-### 14.3 Stable SelfConsistency Extension
+### 14.3 Process Reward Extension
+
+If the `Process Reward Extension` is implemented:
+
+- one score is returned per scored step, or an equivalent step-aligned structure is returned
+- score cardinality mismatches fail explicitly
+- score ordering remains aligned with step ordering
+
+### 14.4 Stable SelfConsistency Extension
 
 If the `Stable SelfConsistency Extension` is implemented:
 
@@ -1374,7 +1405,7 @@ If the `Stable SelfConsistency Extension` is implemented:
 - partial candidate-generation failure follows the stable candidate-availability rule
 - `budget` semantics match Section 7.2
 
-### 14.4 Stable BestOfN Extension
+### 14.5 Stable BestOfN Extension
 
 If the `Stable BestOfN Extension` is implemented:
 
@@ -1384,17 +1415,18 @@ If the `Stable BestOfN Extension` is implemented:
 - result objects or detailed outputs expose the selected response correctly
 - `budget` semantics match Section 7.3
 
-### 14.5 Experimental Search Extension
+### 14.6 Experimental Search Extension
 
 If experimental search is implemented:
 
 - `StepGenerationConfig` validation rules are enforced
+- declared scoring dependencies are documented and consistent with the selected profile
 - beam-search frontier bounds follow the documented policy
 - particle methods follow documented update/resampling policy
 - planning-wrapper budget allocation follows documented policy
 - prompt-fallback behavior is documented where structured-chat fidelity is reduced
 
-### 14.6 Direct Gateway Extension
+### 14.7 Direct Gateway Extension
 
 If the `Direct ITS Gateway` profile is implemented:
 
@@ -1406,7 +1438,7 @@ If the `Direct ITS Gateway` profile is implemented:
 - usage behavior matches documented semantics
 - non-streaming behavior matches documented semantics
 
-### 14.7 External-Processing Gateway Extension
+### 14.8 External-Processing Gateway Extension
 
 If the `External-Processing Gateway` profile is implemented:
 
@@ -1418,7 +1450,7 @@ If the `External-Processing Gateway` profile is implemented:
 - ITS-applied signaling behavior matches documentation
 - usage aggregation behavior matches documentation if usage is exposed
 
-### 14.8 Research Toolkit Extension
+### 14.9 Research Toolkit Extension
 
 If benchmark or research tooling is implemented:
 
@@ -1426,7 +1458,7 @@ If benchmark or research tooling is implemented:
 - dataset and scoring assumptions are documented
 - example code remains consistent with the documented public contract
 
-### 14.9 Real Integration Profile (RECOMMENDED)
+### 14.10 Real Integration Profile (RECOMMENDED)
 
 These checks are RECOMMENDED before production use and MAY be skipped in CI when credentials or
 network access are unavailable.
@@ -1459,9 +1491,14 @@ Use the same validation profiles as Section 14:
 - documentation of failure behavior and trust boundary
 - deterministic tests for supported core behavior
 
+Additional rule for full algorithm conformance:
+
+- implement at least one stable algorithm profile from Section 7
+
 ### 15.2 RECOMMENDED Extensions
 
 - `Outcome Reward Extension`
+- `Process Reward Extension`
 - `Stable SelfConsistency Extension`
 - `Stable BestOfN Extension`
 - `Experimental Search Extension`
@@ -1474,7 +1511,7 @@ Use the same validation profiles as Section 14:
 
 ### 15.3 Operational Validation Before Production
 
-- Run the `Real Integration Profile` from Section 14.9 with valid credentials and network access.
+- Run the `Real Integration Profile` from Section 14.10 with valid credentials and network access.
 - Verify timeout, retry, and fallback behavior under representative failure conditions.
 - Verify budget and concurrency guardrails on the target deployment.
 - Verify secret handling and log redaction behavior on the target environment.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,33 +1,20 @@
 # its_hub Repository Specification
 
-Status: Draft v1
+Status: Draft v1 (language-agnostic)
 
-Purpose: Define the repository-level contract for `its_hub` as a library-first system for
-inference-time scaling (ITS) of LLMs, while also documenting the two concrete gateway
-implementations that currently exist in the repository family:
+Purpose: Define a library-first system for inference-time scaling (ITS) of LLMs.
 
-- the current OpenAI-compatible FastAPI IaaS service in `its_hub/integration/iaas.py`
-- the Envoy external-processing profile implemented on `origin/envoy_ext_proc`
+This specification defines the repository-family contract, including:
 
-Source of truth for this specification version:
+- a reusable core ITS library contract
+- stable and experimental algorithm profiles
+- two OPTIONAL gateway profiles:
+  - `Direct ITS Gateway`
+  - `External-Processing Gateway`
+- documentation, benchmarking, and validation expectations
 
-- `origin/v1`
-  - normative for the core library surface, package layout, and install profiles
-- current repository branch
-  - normative for the current `its-iaas` FastAPI gateway profile
-- `origin/envoy_ext_proc`
-  - normative for the Envoy ext-proc gateway profile
-
-When these sources differ, this specification MUST say which surface is being described.
-
-Interpretation model for this document:
-
-- Sections 3 through 10 define the intended repository-family design target unless they explicitly
-  name a branch or concrete implementation.
-- Sections 11 through 14 map that target onto the current Python repository family and its concrete
-  gateway/runtime profiles.
-- Python module paths in this document are reference mappings for the current Python branches, not
-  mandatory shapes for future non-Python ports such as Rust.
+The intent is that implementations evolve against this specification. A current codebase is one
+possible implementation of the spec, not the source of truth for the spec itself.
 
 ## Normative Language
 
@@ -40,1078 +27,1218 @@ behavior.
 
 ## 1. Problem Statement
 
-`its_hub` is a repository for inference-time scaling techniques that improve model outputs by
-spending more compute during inference rather than by retraining the model.
+`its_hub` is a system for improving LLM outputs by spending more compute at inference time rather
+than by retraining the model.
 
-The repository family currently serves three closely related needs:
+The system addresses four related problems:
 
-1. `Library-first ITS`
-   - reusable algorithms, LM adapters, reward-model abstractions, and orchestration contracts
-
-2. `Gateway integration`
-   - integration into existing serving layers without changing the downstream OpenAI-compatible
-     client contract
-
-3. `Research and evaluation`
-   - examples, benchmarks, and math-oriented evaluation workflows
+- It defines reusable contracts for inference-time scaling algorithms, language-model adapters,
+  orchestration, and reward models.
+- It allows ITS to be integrated into serving systems without redefining the downstream
+  chat-completions client contract.
+- It supports both production-facing gateway integration and research-oriented experimentation.
+- It provides enough common structure that future implementations in other languages can remain
+  behaviorally compatible.
 
 Important boundary:
 
-- the center of gravity for `v1` is the library contract
-- the gateway runtimes are integration profiles layered on top of that library contract
-- no single gateway runtime is required for `v1` core conformance
+- `its_hub` is library-first.
+- Gateways are OPTIONAL integration profiles layered on top of the library contract.
+- The specification defines behavior and interfaces, not one language, one packaging model, or one
+  deployment topology.
+- A conforming implementation can be a library, a gateway, both, or a strict subset according to
+  the capability profiles in Section 3.3.
 
 ## 2. Goals and Non-Goals
 
 ### 2.1 Goals
 
 - Define stable abstractions for:
-  - messages
-  - language models
-  - orchestration
+  - message normalization
+  - language-model generation
+  - orchestration/fanout
   - ITS algorithms
   - reward models
 - Support both string prompts and structured chat messages.
 - Preserve OpenAI-compatible assistant message structure, including tool calls, where supported.
-- Keep the stable core small enough for gateway integrators.
-- Provide built-in implementations for common LM, orchestration, and judging workflows.
-- Support multiple ITS strategies with a shared `budget` vocabulary.
-- Document the current gateway profiles separately so design work can happen in `SPEC.md` before
-  implementation changes land.
+- Provide a shared `budget` vocabulary for compute allocation across ITS algorithms.
+- Support both outcome-based and process-based scoring.
+- Define two interoperable gateway profiles:
+  - a direct service profile
+  - an external-processing interception profile
+- Keep the contract portable across multiple implementations and languages.
+- Support design-first workflow where changes to system behavior are specified before
+  implementation.
 
 ### 2.2 Non-Goals
 
 - Defining the full OpenAI Chat Completions protocol.
-- Requiring one mandatory service runtime for `v1`.
-- Defining training, fine-tuning, or model-hosting internals.
+- Requiring a single mandatory service runtime.
+- Defining model training, fine-tuning, or model-hosting internals.
+- Requiring every implementation to ship every algorithm or gateway profile.
 - Standardizing streaming ITS behavior in this specification version.
-- Guaranteeing that every experimental algorithm has the same stability level as the stable core.
+- Guaranteeing that experimental algorithms have the same stability level as the stable core.
 
-## 3. Repository Model
+## 3. System Overview
 
-### 3.1 Canonical `v1` Layout
-
-The canonical `v1` design target uses a split API/core layout. `origin/v1` is the closest current
-Python branch to that layout, but the diagram below is conceptual rather than a literal exhaustive
-inventory of any single branch:
-
-```text
-its_hub/
-  api/
-    algorithm.py
-    lm.py
-    orchestrator.py
-    types.py
-    reward_models/
-  core/
-    algorithms/
-    lms/
-    reward_models/
-    orchestrator.py
-  algorithms/
-benchmarking/
-examples/
-docs/
-tests/
-README.md
-pyproject.toml
-SPEC.md
-```
-
-Interpretation note:
-
-- the diagram names the intended conceptual homes of repository surfaces
-- supporting files such as `SPEC.md`, `scripts/`, `eval/`, or branch-specific docs MAY be added,
-  omitted, or relocated without changing the core contract
-
-Responsibilities:
-
-- `its_hub/api/`
-  - stable abstract contracts
-- `its_hub/core/`
-  - built-in implementations of those contracts
-- `its_hub/algorithms/`
-  - compatibility-oriented import surface
-- `benchmarking/`, `examples/`, `docs/`, `tests/`
-  - tooling, documentation, validation
-
-### 3.2 Legacy Flat Layout Compatibility
-
-Some active branches, including the current branch and `origin/envoy_ext_proc`, still use the older
-flat layout:
-
-```text
-its_hub/
-  base.py
-  lms.py
-  types.py
-  algorithms/
-  integration/
-```
-
-For this specification version:
-
-- the `origin/v1` split layout is the canonical design target
-- the flat layout branches are treated as equivalent implementations of the same conceptual layers
-- gateway profiles that still live under the flat layout remain part of the repository-family
-  contract until they are retired or migrated
-
-### 3.3 Deliverables
-
-The repository family currently contains these deliverables:
-
-1. `Core library contract`
-   - abstractions and built-in ITS implementations
-
-2. `Gateway profiles`
-   - current FastAPI IaaS service
-   - Envoy ext-proc external processor
-
-3. `Documentation, examples, and benchmarks`
-   - install guides, quick starts, algorithm docs, benchmark tooling
-
-4. `Tests and packaging metadata`
-   - repository validation and distribution metadata
-
-## 4. Distribution and Installation Profiles
-
-### 4.1 `origin/v1` Profiles
-
-The normative `v1` install profiles are:
-
-- default / core
-  - `pip install its_hub`
-  - minimal dependency footprint
-  - intended for integrators who provide their own LM and orchestrator
-
-- `lm`
-  - `pip install its_hub[lm]`
-  - adds built-in OpenAI-compatible LM support, async HTTP dependencies, `LLMJudge`, and
-    `LMOrchestrator`
-
-- `iaas`
-  - `pip install its_hub[iaas]`
-  - adds service-oriented dependencies
-  - in `origin/v1` this is a dependency profile, not a required built-in runtime contract
-
-- `experimental`
-  - `pip install its_hub[experimental]`
-  - adds experimental algorithms and PRM-related dependencies
-
-- `research`
-  - `pip install its_hub[research]`
-  - adds benchmark/evaluation dependencies
-
-- `dev`
-  - `pip install -e ".[dev]"` or `uv sync --extra dev`
-  - adds development and test tooling
-
-### 4.2 Legacy Branch Packaging Notes
-
-The current branch and `origin/envoy_ext_proc` still ship older packaging shapes:
-
-- current branch
-  - includes a built-in `its-iaas` script in `pyproject.toml`
-  - uses extras such as `vllm`, `prm`, `research`, and `cloud`
-  - default dependencies already include a broader runtime/service footprint than the minimal
-    `origin/v1` core profile
-
-- `origin/envoy_ext_proc`
-  - includes both:
-    - `its-iaas`
-    - `envoy-grpc`
-  - default dependencies also include gRPC/runtime packages needed by that gateway profile
-
-These older package shapes are implementation facts for those branches, but they are not the
-normative `origin/v1` packaging model.
-
-## 5. Runtime Entrypoints
-
-### 5.1 `v1` Core Position
-
-`origin/v1` does not require one built-in ITS service runtime as part of core conformance.
-
-### 5.2 Current FastAPI IaaS Profile
-
-The current branch exports:
-
-- `its-iaas`
-  - entrypoint: `its_hub.integration.iaas:main`
-
-This starts the in-process FastAPI IaaS service.
-
-### 5.3 Envoy ext-proc Profile
-
-The `origin/envoy_ext_proc` branch exports:
-
-- `envoy-grpc`
-  - entrypoint: `its_hub.integration.ext_proc.processor:main`
-
-This starts the Envoy external-processor gRPC service.
-
-## 6. System Overview
-
-### 6.1 Main Components
-
-These are conceptual components. A concrete branch or port MAY collapse two or more components into
-one module, service, or type so long as the externally visible behavior remains equivalent.
+### 3.1 Main Components
 
 1. `Message Model`
-   - normalized prompts, chat history, multimodal text-bearing messages, and tool calls
+   - Normalizes prompts, chat history, multimodal content, and tool-call-bearing messages.
 
-2. `Language Model Adapter Layer`
-   - downstream LM call interface
+2. `Language Model Capability`
+   - Produces assistant responses from normalized message inputs.
 
-3. `Orchestrator Layer`
-   - parallel fanout, concurrency control, and argument forwarding
+3. `Orchestration Capability`
+   - Fans out one logical ITS request into multiple LM calls, preserves ordering, and applies
+     concurrency control.
 
-4. `ITS Algorithm Layer`
-   - sampling, voting, scoring, and search logic
+4. `ITS Algorithm Capability`
+   - Implements sampling, voting, scoring, or search logic over one or more LM calls.
 
-5. `Reward Layer`
-   - outcome and process reward models
+5. `Reward Capability`
+   - Scores final candidates and/or intermediate reasoning steps.
 
-6. `Gateway Integration Layer`
-   - service/proxy integrations such as FastAPI IaaS and Envoy ext-proc
+6. `Gateway Adapter` (OPTIONAL)
+   - Exposes or intercepts OpenAI-compatible requests and maps them onto the core library
+     contract.
 
-7. `Research / Tooling Layer`
-   - examples, benchmarks, docs, and tests
+7. `Research / Tooling Surface` (OPTIONAL)
+   - Provides examples, benchmarks, and evaluation helpers.
 
-### 6.2 Abstraction Levels
+8. `Observability Surface` (OPTIONAL)
+   - Exposes logs, metrics, and implementation-defined runtime status.
 
-The repository family is easiest to reason about in these canonical layers. A concrete branch MAY
-collapse or inline some of them:
+### 3.2 Abstraction Levels
 
-1. `Canonical Public API Contracts`
-   - `ChatMessage`, `ChatMessages`
-   - `AbstractLanguageModel`
-   - `AbstractScalingAlgorithm`, `AbstractScalingResult`
-   - `AbstractOutcomeRewardModel`, `AbstractProcessRewardModel`
-   - `AbstractOrchestrator` in the canonical `origin/v1` model
+`its_hub` is easiest to port when kept in these layers:
 
-2. `Canonical Built-in Implementations`
-   - `OpenAICompatibleLanguageModel`
-   - `SelfConsistency`, `BestOfN`
-   - `LMOrchestrator`, `LLMJudge` in `origin/v1`
-   - experimental search algorithms where implemented
+1. `Core Domain Layer`
+   - Messages, candidates, results, budget semantics, step-generation configuration.
 
-3. `Gateway Profiles`
-   - current FastAPI IaaS service
-   - Envoy ext-proc external processor
+2. `Execution Layer`
+   - LM generation, orchestration, reward-model scoring, algorithm execution.
 
-4. `Tooling and Validation`
-   - examples, benchmarks, docs, tests
+3. `Gateway Layer`
+   - Direct or intercepting request handling built on top of the execution layer.
 
-## 7. Core Domain Model
+4. `Research and Tooling Layer`
+   - Documentation, examples, benchmarks, validation assets.
 
-### 7.1 Message Model
+An implementation MAY collapse multiple layers into one module or service so long as the observable
+behavior remains conformant.
 
-#### 7.1.1 `ChatMessage`
+### 3.3 Capability Profiles
 
-`ChatMessage` is the normalized conversation unit used across the repository family.
+This specification defines these conformance profiles:
+
+1. `Core Library Conformance`
+   - Message model
+   - LM capability
+   - orchestration capability or equivalent
+   - scaling algorithm capability
+   - reward capability
+
+2. `Stable Algorithm Extension`
+   - `SelfConsistency`
+   - `BestOfN`
+
+3. `Experimental Search Extension`
+   - Step-wise search family
+   - beam search
+   - particle methods
+   - planning wrapper
+
+4. `Direct Gateway Extension`
+   - Standalone service that terminates client requests and applies ITS directly.
+
+5. `External-Processing Gateway Extension`
+   - Intercepting gateway that conditionally applies ITS in front of an upstream API.
+
+6. `Research Toolkit Extension`
+   - Examples, benchmark runners, dataset evaluation tooling.
+
+Composition rules:
+
+- Every conforming implementation MUST satisfy `Core Library Conformance`.
+- Sections marked OPTIONAL are extension profiles.
+- An implementation MAY support multiple extensions at once.
+
+### 3.4 External Dependencies
+
+Common external dependencies include:
+
+- one or more downstream language-model providers
+- OPTIONAL reward-model services or local scoring runtimes
+- OPTIONAL HTTP, proxy, or gRPC runtime for gateway implementations
+- local filesystem for docs, examples, test fixtures, or benchmark assets
+- host environment authentication and secret management
+
+The specification does not require any one vendor, network topology, or packaging format.
+
+## 4. Core Domain Model
+
+### 4.1 Entities
+
+#### 4.1.1 `ChatMessage`
+
+`ChatMessage` is the normalized conversation unit used throughout the system.
 
 Fields:
 
-- `role`
-  - supported values:
+- `role` (string)
+  - Supported values:
     - `system`
     - `user`
     - `assistant`
     - `tool`
 - `content`
-  - `str` for plain text
-  - `list[dict]` for OpenAI-style multimodal content
+  - `string` for plain text
+  - `list[object]` for structured or multimodal content
   - `null` when the message is represented primarily by tool calls
-- `tool_calls` (OPTIONAL list of dicts)
+- `tool_calls` (OPTIONAL list of structured tool-call records)
 - `tool_call_id` (OPTIONAL string)
 
 Required semantics:
 
-- tool-call-bearing assistant messages MUST preserve `tool_calls` when returned by the LM path
-- multimodal text extraction MUST preserve text parts in order
-- image parts MAY be ignored by text-only flows
-- in the `origin/v1` API, `ChatMessage.from_dict(...)` ignores unknown inbound fields
+- Tool-call-bearing assistant messages MUST preserve `tool_calls` when returned by LM or gateway
+  paths.
+- Text-bearing content MUST preserve text parts in order.
+- Image-bearing content MAY be ignored by text-only flows, but that behavior MUST be documented.
+- Implementations SHOULD tolerate unknown inbound fields for forward compatibility.
 
-#### 7.1.2 `ChatMessages`
+#### 4.1.2 `ChatMessages`
 
-`ChatMessages` wraps either:
+`ChatMessages` is the normalized conversation container.
+
+It wraps either:
 
 - a string prompt
 - a list of `ChatMessage`
-- another `ChatMessages`
+- an implementation-equivalent normalized conversation object
 
 Required behaviors:
 
-- `from_prompt_or_messages(...)`
-- `to_chat_messages()`
-- `to_batch(size)`
-- `to_prompt()`
+- normalize string prompts into structured messages
+- return structured chat messages as the primary representation
+- produce repeated batches of equivalent conversations for parallel generation
+- provide a prompt-string fallback representation for compatibility-oriented paths when needed
 
-Contract notes:
+#### 4.1.3 `ScalingCandidate`
 
-- `to_chat_messages()` is the primary structured representation
-- `to_prompt()` remains important for backward compatibility and experimental algorithms
+One candidate assistant response produced during ITS execution.
 
-### 7.2 Language Model Interface
+Logical fields:
 
-#### 7.2.1 `AbstractLanguageModel`
+- `message`
+  - selected or candidate assistant message
+- `provider_metadata` (OPTIONAL)
+  - provider-native generation metadata
+- `usage` (OPTIONAL)
+  - generation-usage record for this candidate
 
-The normative `origin/v1` contract is async-first.
+`ScalingCandidate` is a logical model; implementations MAY inline it into plain message records so
+long as equivalent information can be expressed.
 
-Legacy flat-layout branches and future ports MAY expose narrower concrete method signatures or
-inline batching logic, but they SHOULD map cleanly onto this async-first contract at the
-specification level.
+#### 4.1.4 `ScalingResult`
 
-Required method:
+The result of one logical ITS execution.
 
-- `agenerate(messages, stop=None, **kwargs)`
+Logical fields:
 
-Important optional method:
-
-- `agenerate_single(messages, stop=None, **kwargs)`
+- `selected`
+  - the chosen assistant response
+- `candidates` (OPTIONAL)
+  - all candidate responses considered by the algorithm
+- `metadata` (OPTIONAL)
+  - algorithm-specific decision metadata such as vote counts, scores, selected index, or traces
+- `usage` (OPTIONAL)
+  - usage aggregated across the logical ITS execution
 
 Required semantics:
 
-- LM adapters SHOULD preserve OpenAI-compatible assistant message dicts, including `tool_calls`
-- LM adapters MAY accept provider-specific kwargs such as:
-  - `max_tokens`
-  - `temperature`
-  - `tools`
-  - `tool_choice`
-  - `response_format`
+- A selected response MUST always be available.
+- Full result objects are OPTIONAL, but implementations SHOULD support an output mode that exposes
+  detailed result metadata for debugging and research.
 
-### 7.3 Orchestrator Interface
+#### 4.1.5 `GenerationUsage`
 
-#### 7.3.1 `AbstractOrchestrator`
+When token usage is exposed, the interoperable shape is:
 
-`AbstractOrchestrator` is a first-class `origin/v1` abstraction.
+- `prompt_tokens`
+- `completion_tokens`
+- `total_tokens`
 
-Legacy branches MAY instead place fanout/concurrency behavior inside LM adapters or gateway-specific
-wrappers rather than exposing a first-class orchestrator symbol.
+All fields are non-negative integers.
 
-Primary method:
+If an implementation cannot determine usage exactly, it MUST document whether usage is omitted,
+estimated, or reported as zero/unknown.
 
-- `agenerate(lm, messages_lst, stop=None, **kwargs)`
+#### 4.1.6 `StepGenerationConfig`
 
-Sync wrapper:
+Configuration used by step-wise search algorithms.
 
-- `generate(...)`
-
-Responsibilities:
-
-- fan out one logical ITS request into multiple LM calls
-- preserve result ordering
-- forward LM-specific parameters such as:
-  - `temperature`
-  - `max_tokens`
-  - `tools`
-  - `tool_choice`
-  - `response_format`
-- enforce implementation-defined concurrency control
-
-### 7.4 Scaling Algorithm Interfaces
-
-#### 7.4.1 `AbstractScalingAlgorithm`
-
-Primary method:
-
-- `ainfer(lm, prompt_or_messages, budget, return_response_only=True, tools=None, tool_choice=None)`
-
-Sync wrapper:
-
-- `infer(...)`
-
-Contract:
-
-- algorithms MUST accept string prompts or normalized chat messages
-- algorithms MUST interpret `budget` according to documented semantics
-- algorithms SHOULD preserve tool-call-bearing assistant messages when the underlying LM does
-- algorithms MAY depend on an orchestrator explicitly or through built-in wiring
-
-#### 7.4.2 `AbstractScalingResult`
-
-Required property:
-
-- `the_one`
-  - returns the selected assistant response dict
-
-### 7.5 Reward Model Interfaces
-
-#### 7.5.1 `AbstractOutcomeRewardModel`
-
-Scores final responses or complete conversations.
-
-Normative `origin/v1` shape:
-
-- `score(messages, **kwargs)`
-- OPTIONAL async method:
-  - `ascore(messages, orchestrator=None, **kwargs)`
-
-Legacy flat-layout branches use an older prompt-plus-response shape in some implementations.
-
-#### 7.5.2 `AbstractProcessRewardModel`
-
-Scores intermediate reasoning steps.
-
-Required methods:
-
-- `score(prompt_or_messages, steps)`
-- `ascore(prompt_or_messages, steps)`
-
-### 7.6 `StepGeneration`
-
-`StepGeneration` is a built-in helper used by experimental step-wise algorithms.
-
-Key fields include:
+Fields:
 
 - `max_steps`
 - exactly one of:
   - `step_token`
   - `tokens_per_step`
-- `stop_token`
-- `temperature`
-- `include_stop_str_in_output`
-- `temperature_switch`
+- `stop_token` (OPTIONAL)
+- `temperature` (OPTIONAL)
+- `include_stop_str_in_output` (OPTIONAL)
+- `temperature_switch` (OPTIONAL)
 
 Invariants:
 
-- exactly one of `step_token` and `tokens_per_step` MUST be set
-- `tokens_per_step` MUST be positive when used
+- Exactly one of `step_token` and `tokens_per_step` MUST be set.
+- `tokens_per_step` MUST be positive when used.
 
-## 8. Built-in Repository Components
+### 4.2 Normalization and Compatibility Rules
 
-### 8.1 Stable `origin/v1` Surfaces
+- A string prompt MUST normalize into one `user` message.
+- Structured chat is the primary cross-implementation contract.
+- Prompt-string fallback MAY exist for compatibility-oriented or experimental paths.
+- Tool-call-bearing assistant messages SHOULD remain attached to candidates and selected results.
+- Implementations MAY accept additional provider-native content parts, but they MUST document how
+  text extraction behaves for those parts.
 
-The stable repository-facing surfaces include:
+## 5. Core Library Contract
 
-- `AbstractLanguageModel`
-- `AbstractOrchestrator`
-- `AbstractScalingAlgorithm`
-- `AbstractOutcomeRewardModel`
-- `AbstractProcessRewardModel`
-- `ChatMessage`, `ChatMessages`
-- `SelfConsistency`
-- `BestOfN`
+### 5.1 Input Normalization
 
-### 8.2 Built-in LM / Orchestration Components
+Algorithms and reward capabilities MUST accept normalized conversation input in one of these forms:
 
-When the `lm` extra is installed on `origin/v1`, the repository provides:
-
-- `OpenAICompatibleLanguageModel`
-- `LMOrchestrator`
-- `LLMJudge`
-- `StepGeneration`
-
-Important `origin/v1` notes:
-
-- `OpenAICompatibleLanguageModel` forwards tools, tool choice, and structured-output arguments
-- `LMOrchestrator` is the default parallel fanout implementation
-- `LLMJudge` is the built-in outcome-judging implementation
-
-### 8.3 Stable Algorithms
-
-#### 8.3.1 `SelfConsistency`
-
-Behavior:
-
-- generate multiple candidate responses
-- project responses into a comparison space
-- select the most common projection, with implementation-defined tie-breaking
-
-Current capabilities across the repository family:
-
-- content-based voting
-- regex-based projection
-- tool-call voting modes:
-  - `tool_name`
-  - `tool_args`
-  - `tool_hierarchical`
-
-#### 8.3.2 `BestOfN`
-
-Behavior:
-
-- generate `N` candidates
-- score them with an outcome reward model or judge
-- select the highest-scoring candidate
-
-Current `origin/v1` note:
-
-- deduplication considers both content and tool-call-bearing structure
-
-### 8.4 Experimental Components
-
-Experimental repository surfaces may include:
-
-- `BeamSearch`
-- `ParticleFiltering`
-- `ParticleGibbs`
-- `EntropicParticleFiltering`
-- `PlanningWrapper`
-- local PRM integration
-
-These are part of the repository family, but they are not part of the same stable contract as
-`SelfConsistency` and `BestOfN`.
-
-### 8.5 Compatibility Surface
-
-`its_hub/algorithms/` remains a compatibility-oriented import surface.
-
-In `origin/v1`, the canonical implementation home is `its_hub/core/algorithms/`.
-
-In legacy flat-layout branches, `its_hub/algorithms/` still contains the live implementations.
-
-## 9. Budget Semantics
-
-`budget` is the repository-wide compute-control vocabulary for one ITS execution.
-
-Current semantics by algorithm:
-
-- `SelfConsistency`
-  - number of candidate generations
-- `BestOfN`
-  - number of candidate generations to score
-- `BeamSearch`
-  - total search effort, constrained by beam width
-- `ParticleFiltering` / related particle methods
-  - number of particles
-- `PlanningWrapper`
-  - planning cost plus downstream execution budget
-
-Important note:
-
-- `budget` is shared vocabulary, not a universal identical implementation detail
-- each algorithm MUST document how it interprets `budget`
-
-## 10. Core Library Contracts
-
-### 10.1 Async-First Semantics
-
-The `origin/v1` core is async-first.
-
-Required behavior:
-
-- primary contracts are async
-- sync methods are convenience wrappers over async behavior
-
-### 10.2 Input Flexibility
-
-Algorithms and reward adapters MUST accept:
-
-- string prompts
-- `list[ChatMessage]`
-- `ChatMessages`
+- string prompt
+- list of normalized messages
+- implementation-equivalent `ChatMessages` wrapper
 
 Normalization MUST occur before algorithm-specific logic.
 
-### 10.3 Tool-Calling Preservation
+### 5.2 Language Model Capability
 
-When assistant messages include tool calls:
+The core contract is async-first.
 
-- LM adapters SHOULD preserve them in returned message dicts
-- algorithms SHOULD keep them attached to candidate responses and selected results
-- comparison or deduplication logic MAY intentionally project tool calls into reduced forms when
-  that is part of the documented algorithm
+A conforming implementation MUST provide asynchronous LM generation behavior equivalent to:
 
-### 10.4 Structured Output Support
+- generate one assistant response from one normalized conversation
 
-The repository's LM and orchestrator contracts MAY forward provider-native structured-output
-arguments, including `response_format`.
+Batch generation can be implemented in either of two ways:
 
-This is part of the extensible LM call surface, not a universal algorithm-level requirement.
+- the LM capability accepts batched inputs directly
+- a separate orchestration capability fans out multiple single-generation LM calls
 
-### 10.5 Prompt Fallback in Experimental Paths
+Required semantics:
 
-Structured chat is the primary contract, but some experimental algorithms still rely on
-`ChatMessages.to_prompt()` in current implementations.
+- LM generation SHOULD return assistant messages in OpenAI-compatible structure where possible.
+- LM generation SHOULD preserve `tool_calls` when the provider returns them.
+- LM generation MAY accept provider-native arguments such as:
+  - `max_tokens`
+  - `temperature`
+  - `tools`
+  - `tool_choice`
+  - `response_format`
+- Retry, backoff, session reuse, and connection pooling are implementation-defined.
 
-Therefore:
+Convenience behavior:
 
-- structured chat is the primary contract
-- exact chat-history fidelity is weaker in some experimental paths than in the stable core
+- A synchronous wrapper MAY be provided.
+- An implementation MAY expose both single-conversation and batched generation operations.
 
-## 11. Gateway Profiles
+### 5.3 Orchestration Capability
 
-### 11.1 Gateway Role in `v1`
+Orchestration is a required behavior, but it does not need to exist as a first-class public type.
 
-In `origin/v1`, a gateway is an integration profile layered over the library contract.
+Responsibilities:
 
-The repository-family contract currently includes two concrete gateway profiles:
+- fan out one logical ITS request into multiple LM calls
+- preserve input/output ordering
+- forward LM-generation arguments consistently
+- apply implementation-defined concurrency control
+- batch requests directly or emulate batching through repeated single calls
 
-1. `Current FastAPI IaaS profile`
-   - implemented on the current branch
-   - request-body-driven ITS
+Required semantics:
 
-2. `Envoy ext-proc profile`
-   - implemented on `origin/envoy_ext_proc`
-   - header-triggered interception in front of an upstream OpenAI-compatible API
+- Orchestration MUST preserve deterministic positional alignment between input conversations and
+  returned assistant responses.
+- Concurrency policy is implementation-defined, but the implementation MUST document whether and how
+  concurrency is bounded.
 
-### 11.2 Current FastAPI IaaS Profile
+### 5.4 Scaling Algorithm Capability
 
-#### 11.2.1 Role
+Every ITS algorithm MUST implement behavior equivalent to:
 
-The current branch implements an in-process FastAPI service in `its_hub/integration/iaas.py`.
+- accept normalized input
+- allocate compute according to `budget`
+- invoke LM generation and, where needed, reward capabilities
+- select a final assistant response
 
-This profile is a real repository-family gateway implementation, even though it is not the
-normative `origin/v1` core deployment model.
+Required semantics:
 
-#### 11.2.2 Entrypoints and Endpoints
+- Algorithms MUST accept both prompt-style and chat-style input.
+- Algorithms MUST document how they interpret `budget`.
+- Algorithms SHOULD preserve tool-call-bearing assistant messages when the LM capability does.
+- Algorithms MAY depend on an explicit orchestration capability or inline equivalent batching/fanout
+  behavior.
+- Algorithms MAY expose either:
+  - selected response only
+  - selected response plus full algorithm result metadata
 
-Entrypoint:
+### 5.5 Outcome Reward Capability
 
-- `its-iaas`
+Outcome reward models score final candidates.
 
-HTTP endpoints:
+Required behavior:
 
-- `POST /configure`
-- `GET /v1/models`
-- `POST /v1/chat/completions`
+- score one or more complete candidates with enough prompt/conversation context to make the score
+  meaningful
+- higher score means better candidate
 
-#### 11.2.3 Runtime Model
+Interface freedom:
 
-The current IaaS profile uses process-global mutable state:
+- An implementation MAY score:
+  - prompt + candidate
+  - full conversation including candidate
+  - batched conversations
+- An implementation MAY expose sync, async, or both, so long as the overall algorithm behavior is
+  conformant
 
-- `LM_DICT`
-  - configured model registry
-- `SCALING_ALG`
-  - currently active algorithm instance
+### 5.6 Process Reward Capability
 
-This means:
+Process reward models score intermediate reasoning steps.
 
-- configuration is in-memory
-- service state is lost on restart
-- the profile is not horizontally scalable without refactoring
+Required behavior:
 
-#### 11.2.4 Configuration Contract
+- accept prompt or conversation context plus ordered reasoning steps
+- return per-step scores or an equivalent structure that preserves per-step evaluation meaning
 
-`POST /configure` selects the active algorithm and model wiring.
+The minimal interoperable shape is a list of numeric scores aligned with the step list.
 
-Current required/important fields include:
+### 5.7 Async-First and Sync Wrappers
 
-- `provider`
-  - current values:
-    - `openai`
-    - `litellm`
-- `endpoint`
-- `api_key`
-  - REQUIRED when `provider == "openai"`
-- `model`
-- `alg`
-  - current supported values:
-    - `self-consistency`
-    - `best-of-n`
-    - `particle-filtering`
-- other current implementation fields include:
-  - `extra_args`
-  - `step_token`
-  - `stop_token`
-  - `rm_device`
-  - `rm_agg_method`
+The specification is async-first.
 
-Algorithm-specific current behavior:
+Required behavior:
 
-- `self-consistency`
-  - currently requires `regex_patterns`
-  - supports:
-    - `tool_vote`
-    - `exclude_tool_args`
-- `best-of-n`
-  - requires `rm_name`
-  - supports `rm_name == "llm-judge"` for LLM-judge scoring
-  - when `rm_name == "llm-judge"`, the current implementation also accepts judge-specific fields
-    such as:
-    - `judge_model`
-    - `judge_base_url`
-    - `judge_criterion`
-    - `judge_mode`
-    - `judge_top_n`
-    - `judge_api_key`
-    - `judge_temperature`
-    - `judge_max_tokens`
-    - `enable_judge_logging`
-- `particle-filtering`
-  - requires reward-model configuration
-  - accepts step-generation-related fields such as `step_token` and `stop_token`
-  - currently combines request-supplied fields with some hardcoded defaults in
-    `its_hub/integration/iaas.py`; exact tuning is implementation-defined in this profile
+- primary execution contracts SHOULD be async
+- synchronous wrappers MAY be provided as convenience layers
 
-#### 11.2.5 Request Contract
+This specification does not require any one event-loop or threading model.
 
-`POST /v1/chat/completions` accepts:
+### 5.8 Structured Output, Tool Calling, and Provider-Native Args
 
-- `model`
-- `messages`
-- `budget`
-- `temperature` (OPTIONAL)
-- `max_tokens` (OPTIONAL; currently accepted by the request schema but not yet forwarded into the
-  algorithm call path)
-- `stream` (OPTIONAL, currently unsupported)
-- `tools` (OPTIONAL)
-- `tool_choice` (OPTIONAL)
-- `return_response_only`
+Structured-output and tool-calling support are part of the extensible LM call surface.
 
-ITS activation in this profile is request-body-driven:
+Required semantics:
 
-- the client sends `budget` in the JSON request body
-- no Envoy-style `X-ITS-*` header protocol is used
+- Implementations that support tool calling MUST preserve returned tool-call structure on assistant
+  messages.
+- Implementations that support provider-native structured output MAY forward arguments such as
+  `response_format`.
+- Algorithms are not required to interpret provider-native structured-output arguments themselves,
+  but they SHOULD forward them when that is part of the documented design.
 
-#### 11.2.6 Response Contract
+### 5.9 Usage and Metadata
 
-The current IaaS profile returns an OpenAI-compatible top-level response shape with:
+Usage and metadata are OPTIONAL parts of the core contract.
+
+If exposed:
+
+- per-candidate usage MUST refer to one LM generation
+- aggregated usage MUST refer to one logical ITS execution
+- algorithm metadata MUST be documented as algorithm-specific, not assumed to be universal
+
+## 6. Stable Algorithm Profiles
+
+### 6.1 Shared `budget` Vocabulary
+
+`budget` is the shared compute-control vocabulary for one ITS execution.
+
+Required semantics:
+
+- `budget` MUST be a positive integer
+- all algorithms MUST document how `budget` maps to compute
+- identical `budget` values across different algorithms do not imply identical cost
+
+### 6.2 `SelfConsistency`
+
+Behavior:
+
+- Generate multiple candidate responses.
+- Project each candidate into a comparison space.
+- Select the most common projection, with implementation-defined tie-breaking.
+
+Projection behavior:
+
+- The default comparison space MAY be exact or normalized text content.
+- Implementations MAY support explicit projection functions, including regex-based projections.
+- If a projection fails to match, the implementation MUST document whether the candidate is ignored,
+  grouped under a null value, or treated as raw content.
+
+Tool-calling behavior:
+
+- Tool-call-bearing responses MAY participate in consistency voting.
+- If tool-call voting is supported, the implementation MUST document the voting modes.
+- Common modes include:
+  - tool identity only
+  - tool arguments only
+  - hierarchical combination of tool identity and arguments
+
+Result metadata MAY include:
+
+- all candidate responses
+- vote counts
+- selected index
+
+Budget semantics:
+
+- `budget` is the number of candidate generations.
+
+### 6.3 `BestOfN`
+
+Behavior:
+
+- Generate `N` candidate responses.
+- Score them with an outcome reward capability.
+- Select the highest-scoring candidate, with implementation-defined tie-breaking.
+
+Scoring behavior:
+
+- Implementations MAY score all candidates directly.
+- Implementations MAY deduplicate semantically equivalent candidates before scoring to reduce cost.
+- If tool-calling is supported, semantic equivalence SHOULD consider both content and
+  tool-call-bearing structure.
+
+Result metadata MAY include:
+
+- all candidate responses
+- scores
+- selected index
+
+Budget semantics:
+
+- `budget` is the number of candidate generations to score.
+
+## 7. Experimental Algorithm Profiles
+
+Experimental algorithms are OPTIONAL extensions.
+
+They are part of the repository-family design, but they are not part of the stable core contract in
+the same way as `SelfConsistency` and `BestOfN`.
+
+### 7.1 Step-Wise Search Family
+
+Common characteristics:
+
+- use `StepGenerationConfig`
+- generate partial reasoning trajectories rather than only final answers
+- may depend on process reward scoring
+- may rely on prompt-string compatibility paths more than the stable core
+
+### 7.2 `BeamSearch`
+
+Behavior:
+
+- expand a bounded set of partial trajectories
+- retain the best partial candidates according to implementation-defined scoring
+- continue until stopping criteria are met
+
+Budget semantics:
+
+- `budget` represents total search effort rather than a universal number of final candidates
+
+Required documentation:
+
+- beam-width policy
+- step stopping criteria
+- score aggregation policy
+
+### 7.3 Particle Methods
+
+This family includes profiles such as:
+
+- `ParticleFiltering`
+- `ParticleGibbs`
+- entropic or annealed particle variants
+
+Behavior:
+
+- maintain multiple evolving trajectories
+- resample or update trajectories according to implementation-defined particle rules
+- use process reward or equivalent scoring to guide evolution
+
+Budget semantics:
+
+- `budget` typically represents number of particles or equivalent total particle effort
+
+Required documentation:
+
+- resampling/update policy
+- score aggregation policy
+- stopping criteria
+
+### 7.4 `PlanningWrapper`
+
+Behavior:
+
+- allocate some compute to planning
+- execute a downstream algorithm conditioned on the planning result
+
+Budget semantics:
+
+- `budget` combines planning cost and downstream execution cost according to a documented policy
+
+## 8. Gateway Profiles
+
+### 8.1 Gateway Role
+
+Gateways are OPTIONAL integration profiles layered over the core library contract.
+
+They do not redefine algorithm behavior. Instead, they:
+
+- accept or intercept client requests
+- map those requests onto the core ITS contract
+- shape results into an OpenAI-compatible response surface
+
+This specification version defines two gateway profiles:
+
+1. `Direct ITS Gateway`
+2. `External-Processing Gateway`
+
+### 8.2 Shared Gateway Requirements
+
+All gateway profiles that claim conformance MUST:
+
+- target an OpenAI-compatible chat-completions-like request/response surface
+- accept a client-visible `model` selection or documented equivalent
+- accept normalized `messages` or a compatible chat body
+- preserve the selected assistant message structure, including `tool_calls` where supported
+- document how downstream LM routing and algorithm wiring are configured
+- document timeout, retry, and failure behavior
+
+Minimum OpenAI-compatible response shape:
 
 - `id`
-- `object = "chat.completion"`
+- `object`
 - `created`
 - `model`
 - `choices`
-- `usage`
-- `metadata` (OPTIONAL, when algorithm metadata is returned)
 
-Current limitations:
+`usage` and `metadata` are OPTIONAL but RECOMMENDED when meaningful.
 
-- streaming returns `501 Not Implemented`
-- token usage is currently hardcoded to zero
-- response metadata is algorithm-specific rather than standardized across all algorithms
+### 8.3 `Direct ITS Gateway` (OPTIONAL)
 
-### 11.3 Envoy ext-proc Profile
+#### 8.3.1 Role
 
-#### 11.3.1 Role
+A direct gateway is a standalone service that terminates client requests and applies ITS directly.
 
-The `origin/envoy_ext_proc` branch implements an Envoy external-processor profile that intercepts
-OpenAI-compatible requests and short-circuits them when ITS applies.
+#### 8.3.2 Activation Model
 
-#### 11.3.2 Components
+ITS activation MUST be explicit in the request payload.
 
-This profile consists of:
+Canonical behavior:
 
-1. `Envoy HTTP Proxy`
-   - front-door listener and routing layer
+- the client includes `budget` or an implementation-equivalent compute-control field in the request
+  body
 
-2. `External Processor Service`
-   - gRPC service implementing Envoy ext-proc callbacks
+The direct gateway profile MUST NOT rely on proxy-only transport metadata as its primary activation
+mechanism.
 
-3. `ITS Orchestrator`
-   - request-scoped config plus long-lived LM client cache
+#### 8.3.3 Configuration Surface
 
-4. `Provider Adapter`
-   - OpenAI-compatible downstream LM client
+A direct gateway MUST provide a documented configuration mechanism for:
 
-5. `Response Shaper`
-   - emits OpenAI-compatible response JSON
+- downstream LM endpoint/provider selection
+- algorithm selection or policy selection
+- reward-model wiring where applicable
+- credentials and secret handling
 
-#### 11.3.3 Interception Target
+The mechanism MAY be:
 
-The intended interception target is OpenAI-compatible chat-completions traffic.
+- static startup configuration
+- a configuration file
+- an admin/control API
+- an external control plane
 
-The current Python implementation recognizes:
+This specification does not require a single configuration topology.
 
-- requests whose `:path` starts with `/v1/chat/completions`
+#### 8.3.4 Request Contract
 
-Requests to other paths pass through untouched.
+A direct gateway MUST accept:
 
-#### 11.3.4 ITS Activation Headers
+- `model`
+- `messages`
 
-ITS activation is currently driven by:
-
-- `X-ITS-Budget`
-  - integer range `1..1000`
-- `X-ITS-Endpoint`
-- `X-ITS-API-Key` (OPTIONAL)
-
-Current branch-specific note:
-
-- per-request algorithm selection is not yet standardized
-- invalid or out-of-range ITS header values fall back to pass-through behavior
-- the ext-proc branch currently uses a fixed self-consistency policy with default content-based
-  voting rather than per-request algorithm/tool-vote configuration
-
-#### 11.3.5 Request-Scoped Config
-
-The ext-proc profile constructs a request-scoped config equivalent to:
+A direct gateway SHOULD accept:
 
 - `budget`
-- `api_endpoint`
-- `model`
-- `api_key` (OPTIONAL)
 
-The branch names this structure `ITSRequestConfig`.
+A direct gateway MAY accept:
 
-Current implementation caveat:
+- `temperature`
+- `max_tokens`
+- `tools`
+- `tool_choice`
+- `stream`
+- implementation-defined metadata fields
 
-- the long-lived LM client cache is keyed by `(api_endpoint, model)`, not by `api_key`
-- therefore per-request API keys are parsed as request inputs, but they are not fully isolated when
-  multiple requests reuse the same endpoint/model pair
+Unsupported optional request fields SHOULD produce explicit documented behavior rather than silent
+reinterpretation.
 
-#### 11.3.6 Request Resolution
+#### 8.3.5 Response Contract
 
-For an intercepted request:
+When ITS is applied, the response MUST be OpenAI-compatible and include:
 
-1. inspect request path and headers
-2. if path does not start with `/v1/chat/completions` -> `pass_through`
-3. if required ITS headers are absent or invalid -> `pass_through`
-4. buffer and parse the request body
-5. read:
-   - `model`
-   - `messages`
-   - `tools`
-   - `tool_choice`
-6. if `model` is absent -> `pass_through`
-7. run the fixed self-consistency orchestrator
-8. return either:
-   - immediate ITS response
-   - or pass-through behavior on failure
+- one selected assistant message in `choices[0].message`
 
-#### 11.3.7 Pass-Through and Short-Circuit Semantics
+The response MAY also include:
+
+- `usage`
+- algorithm-specific `metadata`
+
+If usage is exposed, the implementation MUST document whether it is:
+
+- aggregated across all LM calls used by ITS
+- estimated
+- or otherwise computed
+
+#### 8.3.6 Failure Model
+
+Configuration or wiring failures SHOULD produce explicit service errors.
+
+Generation failures MAY be handled by:
+
+- explicit service error
+- documented fallback behavior
+
+Direct gateways MUST NOT silently forward the request to an unknown upstream unless that behavior is
+an explicit part of the documented design.
+
+#### 8.3.7 State and Scaling Notes
+
+Direct gateways MAY use:
+
+- static configuration
+- in-memory mutable state
+- external configuration/state stores
+
+Restart behavior, persistence, and horizontal scaling are implementation-defined and MUST be
+documented.
+
+### 8.4 `External-Processing Gateway` (OPTIONAL)
+
+#### 8.4.1 Role
+
+An external-processing gateway sits in front of an upstream OpenAI-compatible API and conditionally
+applies ITS.
+
+#### 8.4.2 Activation Model
+
+ITS activation MUST be conveyed out-of-band relative to the standard request body.
+
+Examples include:
+
+- HTTP headers
+- proxy route metadata
+- gRPC metadata
+- implementation-defined request context
+
+Required semantics:
+
+- activation metadata MUST include compute-control information equivalent to `budget`
+- the implementation MUST document all recognized activation fields and validation rules
+
+#### 8.4.3 Outcomes
 
 The profile supports two outcomes:
 
 1. `pass_through`
-   - the original request continues upstream
+   - the original request continues to the upstream service
 
 2. `its_applied`
    - the gateway runs ITS
    - the gateway returns an OpenAI-compatible response directly
-   - the original upstream request is short-circuited
+   - the upstream request is short-circuited
 
-#### 11.3.8 Response Shape
+#### 8.4.4 Request Resolution
+
+For an intercepted request:
+
+1. inspect route and activation metadata
+2. if route is unsupported -> `pass_through`
+3. if activation metadata is absent or invalid -> `pass_through`
+4. buffer or inspect the request body as needed
+5. if required body fields are absent:
+   - `pass_through`, or
+   - fail explicitly according to documented policy
+6. run ITS
+7. on success, return immediate OpenAI-compatible response
+8. on failure, either:
+   - `pass_through`, or
+   - explicit error according to documented policy
+
+#### 8.4.5 Response Contract
 
 When ITS is applied, the response MUST be OpenAI-compatible and include:
 
-- `id`
-- `object = "chat.completion"`
-- `created`
-- `model`
-- `choices`
-  - `choices[0].message` is the selected assistant message
-  - `choices[0].finish_reason` is typically `stop`
-- `usage`
+- the selected assistant message
 
-Additional profile behavior:
+The response SHOULD also include an implementation-defined signal that ITS was applied, such as:
 
-- the response sets `x-its-applied: true`
-- usage is aggregated across the LM calls used by ITS
+- response header
+- response metadata
+- proxy-local observability event
 
-#### 11.3.9 Failure Model
+If usage is exposed, it SHOULD refer to the full logical ITS execution, not only the selected
+candidate.
 
-The current Envoy profile favors safe fallback:
+#### 8.4.6 Failure Model
 
-- invalid or incomplete ITS activation headers -> pass through
-- non-chat-completions routes -> pass through
-- missing `model` in request body -> pass through
-- ITS processing failure after activation -> pass through
+Safe fallback is RECOMMENDED.
 
-### 11.4 Streaming
+If safe fallback is chosen:
+
+- invalid activation metadata -> `pass_through`
+- unsupported route -> `pass_through`
+- missing required request-body fields -> `pass_through`
+- ITS execution failure after activation -> `pass_through`
+
+If explicit errors are chosen instead, the implementation MUST document that policy clearly.
+
+#### 8.4.7 Safety Notes
+
+External-processing gateways SHOULD sanitize or strip internal ITS activation metadata before
+forwarding pass-through requests upstream when that metadata is not intended for upstream services.
+
+### 8.5 Streaming
 
 This specification version does not standardize streaming ITS behavior.
 
-Current profile notes:
+Implementations MAY:
 
-- current FastAPI IaaS profile:
-  - explicit `501 Not Implemented`
-- Envoy ext-proc profile:
-  - request bodies are buffered for interception
-  - response streaming semantics are not standardized here
+- reject streaming explicitly
+- buffer streaming requests and return non-streaming ITS responses
+- support streaming according to an implementation-defined design
 
-## 12. Documentation Surface
+If streaming is not supported, the implementation SHOULD return an explicit documented error rather
+than silently pretending to stream.
 
-The repository-family documentation surface MAY include the documents below. Not every branch is
-required to contain every document at the same path:
+## 9. Documentation, Benchmarking, and Example Surface
 
-- `README.md`
-  - top-level orientation and installation matrix
-- `docs/installation.md`
-  - install profiles and dependency expectations
-- `docs/quick-start.md`
-  - common usage flows
-- `docs/algorithms.md`
-  - algorithm-facing guidance
-- `docs/orchestration.md` (`origin/v1`)
-  - orchestrator contract and built-in orchestrator behavior
-- `docs/benchmarking.md`
-  - benchmark workflow
-- `docs/development.md`
-  - contributor guidance and architecture notes
-- `docs/PLANNING_WRAPPER.md`
-  - planning-wrapper behavior
-- `docs/iaas-service.md`
-  - current FastAPI IaaS profile and related gateway usage
-- `its_hub/integration/iaas.md`
-  - migration/architecture document for the Envoy proxy direction on legacy flat-layout Python
-    branches
-- `docs/usage.md`
-  - optional user-facing usage guidance on some branches, including `origin/envoy_ext_proc`
+### 9.1 Documentation
 
-Documentation is descriptive and user-facing.
+Repository-family documentation SHOULD cover:
 
-This specification is normative for the intended repository contract, but branch-specific code
-remains the source of truth for exact runtime behavior.
+- installation or setup guidance
+- core algorithm concepts
+- gateway profile behavior where implemented
+- development and contribution notes
+- benchmarking and evaluation workflows
 
-## 13. Research, Benchmarks, and Examples
+This specification does not require fixed file paths or one documentation toolchain.
 
-### 13.1 Benchmark Surface
+### 9.2 Benchmarking Surface
 
-The benchmark surface includes dataset-driven evaluation entrypoints under:
+A research-oriented implementation MAY provide benchmark tooling for:
 
-- `benchmarking/` on `origin/v1`
-- `scripts/benchmark.py` on legacy flat-layout branches
+- mathematical reasoning tasks
+- multi-step reasoning tasks
+- quality/cost trade-off measurement across algorithms
 
-Current benchmark datasets include:
+Benchmark datasets, scripts, and storage formats are implementation-defined.
 
-- MATH-500
-- AIME-2024
+If benchmark tooling is shipped, the implementation SHOULD document:
 
-### 13.2 Examples
+- dataset assumptions
+- evaluation procedure
+- reproducibility expectations
 
-The repository family includes runnable examples and notebook-like artifacts, typically under
-`examples/`, `scripts/`, `notebooks/`, or equivalent branch-specific locations, for:
+### 9.3 Examples
 
-- self-consistency usage
-- math-oriented reasoning flows
-- experimental reasoning/search workflows where installed
+Examples MAY be provided for:
 
-## 14. Development, Testing, and Quality
+- `SelfConsistency`
+- `BestOfN`
+- experimental search profiles
+- gateway profile usage
 
-### 14.1 Development Setup
+Examples are descriptive and user-facing, not normative.
 
-The repository supports:
+## 10. Failure Model and Recovery Strategy
 
-- `uv sync --extra dev`
-- `pip install -e ".[dev]"`
+### 10.1 Failure Classes
 
-Python expectations:
+1. `Input / Normalization Failures`
+   - invalid message shape
+   - unsupported content form
+   - malformed tool-call structure
 
-- `origin/v1`: Python `>= 3.11`
-- current branch / `origin/envoy_ext_proc`: Python `>= 3.10`
+2. `LM Generation Failures`
+   - provider/network failure
+   - timeout
+   - provider rejection
+   - malformed provider response
 
-### 14.2 Test Surface
+3. `Orchestration Failures`
+   - batch fanout failure
+   - concurrency-control failure
+   - partial batch failure
 
-Across the repository family, tests and validation assets MAY cover behaviors such as:
+4. `Reward Failures`
+   - reward-service failure
+   - invalid score payload
+   - inconsistent score cardinality
 
-- message and normalization behavior
-- orchestrator behavior and concurrency semantics
-- stable algorithms
-- tool-calling behavior
-- judge behavior
-- planning wrapper / experimental behavior where present
-- gateway-specific behavior for the IaaS profile and, where present, Envoy-related flows
+5. `Gateway Configuration Failures`
+   - missing routing configuration
+   - invalid algorithm wiring
+   - missing credentials
 
-Concrete coverage differs by branch. For example, current Python coverage is centered on the core
-algorithms and the FastAPI IaaS profile, while the Envoy gateway profile currently also relies on
-branch-specific deployment artifacts and script-level validation.
+6. `Gateway Runtime Failures`
+   - request interception failure
+   - body parsing failure
+   - response shaping failure
+   - proxy transport failure
 
-### 14.3 Quality Tooling
+7. `Observability / Tooling Failures`
+   - logging sink failure
+   - benchmark I/O failure
+   - metrics/status reporting failure
 
-Current repository quality tooling includes:
+### 10.2 Recovery Behavior
 
-- `pytest`
-- `ruff`
+- Input/normalization failures:
+  - fail the current request or run attempt explicitly
 
-## 15. Validation Matrix
+- LM or reward transient failures:
+  - MAY be retried according to implementation-defined policy
 
-A conforming implementation or faithful port SHOULD include tests for the behaviors below.
+- Orchestration failures:
+  - SHOULD fail the current logical ITS execution explicitly
+  - MUST NOT silently reorder candidate results
 
-### 15.1 Message and Input Model
+- Direct gateway configuration failures:
+  - SHOULD fail explicitly and operator-visibly
 
-- string prompts normalize into a single `user` message
-- chat histories preserve role/content/tool-call fields
-- multimodal text extraction behaves consistently
-- tool-call-bearing assistant messages preserve tool-call structures
+- External-processing gateway failures:
+  - SHOULD follow the documented fallback or explicit-error policy from Section 8.4.6
 
-### 15.2 LM and Orchestrator Contracts
+- Observability/tooling failures:
+  - SHOULD NOT corrupt the correctness of the core ITS result
 
-- LM adapters return one response per logical request
-- orchestrators preserve input ordering
-- concurrency limits behave as documented
-- tools, tool choice, and `response_format` are forwarded correctly
+### 10.3 Restart and State Notes
 
-### 15.3 Stable Algorithms
+The core library can be stateless.
 
-- self-consistency selects repeated candidates correctly
-- tool-voting modes behave as documented
-- best-of-n uses outcome scoring correctly
-- result objects expose `the_one`
+Gateway implementations MAY maintain:
 
-### 15.4 Experimental Algorithms
+- in-memory configuration
+- client/session caches
+- request-scoped caches
+- externalized state
 
-If experimental algorithms are implemented or installed:
+Persistence across restarts is OPTIONAL and implementation-defined.
 
-- beam search uses step generation and beam width correctly
-- particle methods handle budget semantics correctly
-- prompt-string fallback behavior is documented
+## 11. Security and Operational Safety
 
-### 15.5 Current FastAPI IaaS Profile
+### 11.1 Trust Boundary Assumption
 
-- `/configure` validates supported algorithm and provider shapes
-- `/v1/models` reflects configured models
-- `/v1/chat/completions` requires configured model state
-- request-body `budget` drives ITS execution
-- tool calls are preserved when produced by the selected algorithm path
-- streaming returns `501 Not Implemented`
-- usage behavior matches the current zero-token implementation or later documented replacement
+Implementations SHOULD assume that all of the following may be partially or fully untrusted:
 
-### 15.6 Envoy ext-proc Profile
+- prompts and chat messages
+- tool definitions
+- tool-call arguments
+- activation metadata
+- downstream model outputs
+- benchmark inputs
 
-- requests without ITS activation pass through
-- requests with valid ITS activation may be short-circuited
-- missing-model behavior matches documented fallback
+The specification intentionally does not mandate one trust posture, but implementations MUST
+document their own.
+
+### 11.2 Secret Handling
+
+Implementations SHOULD:
+
+- avoid logging raw credentials or API tokens
+- validate the presence of secrets without printing them
+- document how secrets are supplied and scoped
+
+### 11.3 Tool-Calling and Structured Input Safety
+
+Tool-calling preservation is part of the contract, but actual execution of tools is out of scope for
+this specification unless an implementation explicitly adds such a feature.
+
+Implementations SHOULD:
+
+- preserve tool-call structure faithfully
+- avoid mutating tool-call arguments silently
+- document any normalization applied to structured content or tool calls
+
+### 11.4 Gateway Safety
+
+Gateway implementations SHOULD document:
+
+- authentication model
+- timeout policy
+- retry policy
+- rate limiting or quota behavior
+- whether internal ITS metadata is stripped before upstream forwarding
+
+### 11.5 Resource Exhaustion and Budget Controls
+
+ITS can amplify LM call volume significantly.
+
+Implementations SHOULD document guardrails for:
+
+- maximum accepted `budget`
+- concurrency limits
+- timeout ceilings
+- gateway backpressure behavior
+- reward-model resource limits
+
+## 12. Reference Algorithms (Language-Agnostic)
+
+### 12.1 Normalize Input
+
+```text
+function normalize_input(prompt_or_messages):
+  if input is string:
+    return [ChatMessage(role="user", content=input)]
+
+  if input is already normalized chat container:
+    return input.to_chat_messages()
+
+  if input is list of messages:
+    return input
+
+  raise invalid_input
+```
+
+### 12.2 Self-Consistency
+
+```text
+function self_consistency_infer(lm, prompt_or_messages, budget, projection):
+  messages = normalize_input(prompt_or_messages)
+  batch = repeat(messages, budget)
+
+  responses = orchestrated_generate(lm, batch)
+
+  projected = []
+  for response in responses:
+    projected.append(project(response))
+
+  counts = count_occurrences(projected)
+  winner_index = choose_most_common_with_documented_tiebreak(counts, projected)
+
+  return {
+    selected: responses[winner_index],
+    candidates: responses,
+    metadata: {
+      counts: counts,
+      selected_index: winner_index
+    }
+  }
+```
+
+### 12.3 Best-of-N
+
+```text
+function best_of_n_infer(lm, reward_model, prompt_or_messages, budget):
+  messages = normalize_input(prompt_or_messages)
+  batch = repeat(messages, budget)
+
+  responses = orchestrated_generate(lm, batch)
+
+  unique_responses, inverse_index = maybe_deduplicate(responses)
+  scores = score_with_outcome_model(reward_model, messages, unique_responses)
+  expanded_scores = remap(scores, inverse_index)
+
+  winner_index = index_of_max(expanded_scores)
+
+  return {
+    selected: responses[winner_index],
+    candidates: responses,
+    metadata: {
+      scores: expanded_scores,
+      selected_index: winner_index
+    }
+  }
+```
+
+### 12.4 Direct Gateway Request Handling
+
+```text
+function handle_direct_gateway_request(request):
+  validate_gateway_configuration()
+
+  model = request.body.model
+  messages = request.body.messages
+  budget = request.body.budget
+
+  result = run_selected_algorithm(
+    model=model,
+    messages=messages,
+    budget=budget,
+    tools=request.body.tools,
+    tool_choice=request.body.tool_choice
+  )
+
+  return make_openai_compatible_response(result)
+```
+
+### 12.5 External-Processing Gateway Request Handling
+
+```text
+function handle_external_processing_request(request):
+  if route_is_not_supported(request):
+    return pass_through
+
+  activation = parse_activation_metadata(request)
+  if activation is invalid or absent:
+    return pass_through
+
+  body = parse_request_body(request)
+  if body.model is missing or body.messages is missing:
+    return documented_fallback_or_error()
+
+  result = run_selected_algorithm(
+    model=body.model,
+    messages=body.messages,
+    budget=activation.budget,
+    tools=body.tools,
+    tool_choice=body.tool_choice
+  )
+
+  return short_circuit_with_openai_compatible_response(result)
+```
+
+## 13. Test and Validation Matrix
+
+A conforming implementation SHOULD include tests that cover the behaviors defined in this
+specification.
+
+Validation profiles:
+
+- `Core Conformance`: REQUIRED for all conforming implementations
+- `Extension Conformance`: REQUIRED only for OPTIONAL profiles that an implementation chooses to
+  ship
+- `Real Integration Profile`: RECOMMENDED environment-dependent checks before production use
+
+Unless otherwise noted, Sections 13.1 and 13.2 are `Core Conformance`. Bullets that begin with
+`If ... is implemented` are `Extension Conformance`.
+
+### 13.1 Core Library Conformance
+
+- string prompts normalize into one `user` message
+- normalized chat preserves role/content/tool-call fields
+- text extraction from structured content is consistent
+- tool-call-bearing assistant messages preserve tool-call structure
+- LM capability returns one response per logical input
+- orchestration preserves input ordering
+- orchestration forwards generation arguments consistently
+- outcome reward scoring is aligned with final candidates
+- process reward scoring is aligned with intermediate steps
+
+### 13.2 Stable Algorithm Extension
+
+- `SelfConsistency` selects repeated candidates correctly
+- documented projection behavior is applied consistently
+- tool-call voting behavior matches documentation if implemented
+- `BestOfN` scores candidates correctly
+- deduplication behavior matches documentation if implemented
+- result objects or detailed outputs expose the selected response correctly
+- `budget` semantics match documentation
+
+### 13.3 Experimental Search Extension
+
+If experimental search is implemented:
+
+- step-generation invariants are enforced
+- beam-search expansion/pruning follows documented policy
+- particle methods follow documented resampling/update policy
+- planning-wrapper budget allocation follows documented policy
+- prompt-fallback behavior is documented where structured-chat fidelity is reduced
+
+### 13.4 Direct Gateway Extension
+
+If the `Direct ITS Gateway` profile is implemented:
+
+- request-body activation drives ITS execution
+- gateway rejects or handles unsupported optional fields as documented
+- configuration failures are surfaced explicitly
 - OpenAI-compatible response shaping is correct
-- `x-its-applied: true` is present on ITS responses
-- aggregated usage behavior matches implementation
+- tool calls are preserved when produced by the algorithm path
+- usage behavior matches documented semantics
+- non-streaming behavior matches documented semantics
 
-## 16. Implementation Checklist
+### 13.5 External-Processing Gateway Extension
 
-### 16.1 Core Repository Checklist
+If the `External-Processing Gateway` profile is implemented:
 
-- message normalization layer
-- abstract language-model contract
-- abstract orchestrator contract
-- abstract ITS algorithm contract
-- abstract reward-model contracts
-- stable algorithms (`SelfConsistency`, `BestOfN`)
-- docs and tests for supported core surfaces
+- unsupported routes pass through
+- missing or invalid activation metadata follows documented fallback
+- missing required body fields follow documented fallback or error policy
+- ITS-applied responses short-circuit upstream behavior correctly
+- OpenAI-compatible response shaping is correct
+- ITS-applied signaling behavior matches documentation
+- usage aggregation behavior matches documentation if usage is exposed
 
-### 16.2 Optional Built-in Implementation Checklist
+### 13.6 Research Toolkit Extension
 
-- `OpenAICompatibleLanguageModel`
-- `LMOrchestrator`
-- `LLMJudge`
-- `StepGeneration`
-- experimental algorithms behind the documented optional profiles
+If benchmark or research tooling is implemented:
 
-### 16.3 Gateway Checklist
+- benchmark inputs and outputs are reproducible enough for the documented workflow
+- dataset and scoring assumptions are documented
+- example code remains consistent with the documented public contract
 
-For the current FastAPI IaaS profile:
+### 13.7 Real Integration Profile (RECOMMENDED)
 
-- `/configure` runtime setup
-- `/v1/models` model enumeration
-- OpenAI-compatible chat-completions response shaping
-- request-body `budget` handling
-- documented non-streaming behavior
+These checks are RECOMMENDED before production use and MAY be skipped in CI when credentials or
+network access are unavailable.
 
-For the Envoy ext-proc profile:
+- Run a real downstream LM smoke test with valid credentials.
+- If a reward model is part of the deployment, run a real reward-path smoke test.
+- If a direct gateway is implemented, run an end-to-end chat-completions smoke test.
+- If an external-processing gateway is implemented, test both:
+  - pass-through behavior
+  - ITS-applied short-circuit behavior
+- Report skipped real-integration tests as skipped rather than silently passing them.
 
-- request-scoped ITS config parsing
-- header-driven ITS activation
-- pass-through fallback behavior
-- OpenAI-compatible response shaping
-- documented usage accounting mode
-- documented non-streaming behavior
+## 14. Implementation Checklist (Definition of Done)
 
-## Appendix A. Non-Normative Notes
+Use the same validation profiles as Section 13:
 
-1. `Repository center of gravity`
-   - `origin/v1` is the design baseline for the core library surface.
+- Section 14.1 = `Core Conformance`
+- Section 14.2 = `Extension Conformance`
+- Section 14.3 = `Real Integration Profile`
 
-2. `Why this spec documents multiple branch states`
-   - The repository family currently has a split between the `origin/v1` library refactor and
-     gateway implementations that still live on flat-layout branches.
-   - This specification deliberately keeps the core contract and the gateway profiles separate so
-     future design changes can be made in `SPEC.md` first.
+### 14.1 REQUIRED for Core Conformance
 
-3. `Current gateway inventory`
-   - The current branch still has a concrete FastAPI IaaS service.
-   - `origin/envoy_ext_proc` has a concrete Envoy external-processing gateway profile.
+- normalized message model
+- async-first LM generation capability
+- orchestration behavior or equivalent batch/fanout layer
+- scaling algorithm execution contract
+- documented `budget` semantics
+- outcome and/or process reward capability as required by shipped algorithms
+- tool-call preservation for supported tool-calling providers
+- documentation of failure behavior and trust boundary
+- deterministic tests for supported core behavior
 
-4. `Migration direction`
-   - The long-term design direction is library-first with gateway runtimes treated as integrations,
-     not as the center of the repository contract.
+### 14.2 RECOMMENDED Extensions
+
+- stable algorithms:
+  - `SelfConsistency`
+  - `BestOfN`
+- experimental search family
+- structured-output forwarding support
+- detailed result metadata and usage accounting
+- `Direct ITS Gateway` profile
+- `External-Processing Gateway` profile
+- benchmark and example toolkit
+
+### 14.3 Operational Validation Before Production
+
+- Run the `Real Integration Profile` from Section 13.7 with valid credentials and network access.
+- Verify timeout, retry, and fallback behavior under representative failure conditions.
+- Verify budget and concurrency guardrails on the target deployment.
+- Verify secret handling and log redaction behavior on the target environment.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,10 +1,10 @@
-# its_hub Repository Specification
+# its_hub System Specification
 
 Status: Draft v1 (language-agnostic)
 
 Purpose: Define a library-first system for inference-time scaling (ITS) of LLMs.
 
-This specification defines the repository-family contract, including:
+This specification defines the system contract, including:
 
 - a reusable core ITS library contract
 - stable and experimental algorithm profiles
@@ -33,7 +33,7 @@ than by retraining the model.
 The system addresses four related problems:
 
 - It defines reusable contracts for inference-time scaling algorithms, language-model adapters,
-  orchestration, and reward models.
+  orchestration, and optional scoring capabilities.
 - It allows ITS to be integrated into serving systems without redefining the downstream
   chat-completions client contract.
 - It supports both production-facing gateway integration and research-oriented experimentation.
@@ -58,9 +58,10 @@ Important boundary:
   - language-model generation
   - orchestration/fanout
   - ITS algorithms
-  - reward models
+  - optional scoring capabilities
 - Support both string prompts and structured chat messages.
-- Preserve OpenAI-compatible assistant message structure, including tool calls, where supported.
+- Preserve canonical tool-invocation structure and support lossless mapping to common
+  chat-completions protocols where needed.
 - Provide a shared `budget` vocabulary for compute allocation across ITS algorithms.
 - Support both outcome-based and process-based scoring.
 - Define two interoperable gateway profiles:
@@ -84,10 +85,10 @@ Important boundary:
 ### 3.1 Main Components
 
 1. `Message Model`
-   - Normalizes prompts, chat history, multimodal content, and tool-call-bearing messages.
+   - Normalizes prompts, chat history, structured content, and tool-invocation-bearing messages.
 
 2. `Language Model Capability`
-   - Produces assistant responses from normalized message inputs.
+   - Produces normalized assistant responses from normalized message inputs.
 
 3. `Orchestration Capability`
    - Fans out one logical ITS request into multiple LM calls, preserves ordering, and applies
@@ -96,34 +97,38 @@ Important boundary:
 4. `ITS Algorithm Capability`
    - Implements sampling, voting, scoring, or search logic over one or more LM calls.
 
-5. `Reward Capability`
-   - Scores final candidates and/or intermediate reasoning steps.
+5. `Scoring Capability` (OPTIONAL)
+   - Scores final candidates and/or intermediate reasoning steps for algorithm profiles that require
+     it.
 
 6. `Gateway Adapter` (OPTIONAL)
-   - Exposes or intercepts OpenAI-compatible requests and maps them onto the core library
+   - Exposes or intercepts chat-completions-like requests and maps them onto the core library
      contract.
 
 7. `Research / Tooling Surface` (OPTIONAL)
    - Provides examples, benchmarks, and evaluation helpers.
 
 8. `Observability Surface` (OPTIONAL)
-   - Exposes logs, metrics, and implementation-defined runtime status.
+   - Exposes logs, metrics, traces, or implementation-defined runtime status.
 
 ### 3.2 Abstraction Levels
 
 `its_hub` is easiest to port when kept in these layers:
 
 1. `Core Domain Layer`
-   - Messages, candidates, results, budget semantics, step-generation configuration.
+   - Messages, tool invocations, candidates, results, and budget semantics.
 
 2. `Execution Layer`
-   - LM generation, orchestration, reward-model scoring, algorithm execution.
+   - LM generation, orchestration, and algorithm execution.
 
-3. `Gateway Layer`
+3. `Optional Scoring Layer`
+   - Outcome and process scoring capabilities used only by profiles that require them.
+
+4. `Gateway Layer`
    - Direct or intercepting request handling built on top of the execution layer.
 
-4. `Research and Tooling Layer`
-   - Documentation, examples, benchmarks, validation assets.
+5. `Research and Tooling Layer`
+   - Documentation, observability, examples, benchmarks, validation assets.
 
 An implementation MAY collapse multiple layers into one module or service so long as the observable
 behavior remains conformant.
@@ -134,33 +139,43 @@ This specification defines these conformance profiles:
 
 1. `Core Library Conformance`
    - Message model
+   - generic candidate/result model
    - LM capability
    - orchestration capability or equivalent
-   - scaling algorithm capability
-   - reward capability
+   - scaling algorithm execution contract
 
-2. `Stable Algorithm Extension`
-   - `SelfConsistency`
-   - `BestOfN`
+2. `Outcome Reward Extension`
+   - Scores final candidates for profiles that require outcome evaluation.
 
-3. `Experimental Search Extension`
+3. `Stable SelfConsistency Extension`
+   - Candidate-generation and voting profile.
+
+4. `Stable BestOfN Extension`
+   - Candidate-generation and outcome-scoring profile.
+
+5. `Experimental Search Extension`
    - Step-wise search family
    - beam search
    - particle methods
    - planning wrapper
 
-4. `Direct Gateway Extension`
+6. `Direct Gateway Extension`
    - Standalone service that terminates client requests and applies ITS directly.
 
-5. `External-Processing Gateway Extension`
+7. `External-Processing Gateway Extension`
    - Intercepting gateway that conditionally applies ITS in front of an upstream API.
 
-6. `Research Toolkit Extension`
+8. `Research Toolkit Extension`
    - Examples, benchmark runners, dataset evaluation tooling.
 
 Composition rules:
 
 - Every conforming implementation MUST satisfy `Core Library Conformance`.
+- Every conforming implementation MUST implement at least one algorithm profile from Section 7 or
+  Section 8.
+- `Stable BestOfN Extension` requires `Outcome Reward Extension`.
+- `Experimental Search Extension` MAY additionally require process scoring according to the selected
+  profile.
 - Sections marked OPTIONAL are extension profiles.
 - An implementation MAY support multiple extensions at once.
 
@@ -169,9 +184,9 @@ Composition rules:
 Common external dependencies include:
 
 - one or more downstream language-model providers
-- OPTIONAL reward-model services or local scoring runtimes
+- OPTIONAL scoring services or local scoring runtimes
 - OPTIONAL HTTP, proxy, or gRPC runtime for gateway implementations
-- local filesystem for docs, examples, test fixtures, or benchmark assets
+- local filesystem for docs, examples, test fixtures, benchmark assets, or logs
 - host environment authentication and secret management
 
 The specification does not require any one vendor, network topology, or packaging format.
@@ -180,7 +195,46 @@ The specification does not require any one vendor, network topology, or packagin
 
 ### 4.1 Entities
 
-#### 4.1.1 `ChatMessage`
+#### 4.1.1 `ContentPart`
+
+`ContentPart` is the canonical provider-neutral unit for structured message content.
+
+Fields:
+
+- `type` (string)
+- type-specific payload fields
+
+Minimum standardized shape:
+
+- `type = "text"`
+  - requires `text` (string)
+
+Other content-part types MAY be supported, but implementations MUST document:
+
+- required payload fields
+- text-extraction behavior
+- whether unsupported parts are rejected, ignored, or preserved as opaque metadata
+
+#### 4.1.2 `ToolInvocation`
+
+`ToolInvocation` is the canonical provider-neutral representation of one assistant-initiated tool
+request.
+
+Fields:
+
+- `name` (string)
+- `arguments` (structured value)
+- `invocation_id` (OPTIONAL string)
+- `provider_metadata` (OPTIONAL object)
+
+Required semantics:
+
+- `arguments` SHOULD be structured rather than serialized text when a lossless structured form is
+  available.
+- Implementations MAY preserve provider-native tool-invocation payloads in `provider_metadata`, but
+  the canonical fields remain the interoperability surface.
+
+#### 4.1.3 `ChatMessage`
 
 `ChatMessage` is the normalized conversation unit used throughout the system.
 
@@ -194,20 +248,20 @@ Fields:
     - `tool`
 - `content`
   - `string` for plain text
-  - `list[object]` for structured or multimodal content
-  - `null` when the message is represented primarily by tool calls
-- `tool_calls` (OPTIONAL list of structured tool-call records)
-- `tool_call_id` (OPTIONAL string)
+  - `list[ContentPart]` for structured content
+  - `null` when the message is represented primarily by tool invocations or tool results
+- `tool_invocations` (OPTIONAL list of `ToolInvocation`)
+- `in_reply_to_tool_invocation` (OPTIONAL string)
 
 Required semantics:
 
-- Tool-call-bearing assistant messages MUST preserve `tool_calls` when returned by LM or gateway
-  paths.
+- Assistant messages that request tools MUST preserve `tool_invocations`.
+- Tool-result messages SHOULD identify the invocation they are replying to when that relationship is
+  available.
 - Text-bearing content MUST preserve text parts in order.
-- Image-bearing content MAY be ignored by text-only flows, but that behavior MUST be documented.
 - Implementations SHOULD tolerate unknown inbound fields for forward compatibility.
 
-#### 4.1.2 `ChatMessages`
+#### 4.1.4 `ChatMessages`
 
 `ChatMessages` is the normalized conversation container.
 
@@ -224,7 +278,7 @@ Required behaviors:
 - produce repeated batches of equivalent conversations for parallel generation
 - provide a prompt-string fallback representation for compatibility-oriented paths when needed
 
-#### 4.1.3 `ScalingCandidate`
+#### 4.1.5 `ScalingCandidate`
 
 One candidate assistant response produced during ITS execution.
 
@@ -240,7 +294,7 @@ Logical fields:
 `ScalingCandidate` is a logical model; implementations MAY inline it into plain message records so
 long as equivalent information can be expressed.
 
-#### 4.1.4 `ScalingResult`
+#### 4.1.6 `ScalingResult`
 
 The result of one logical ITS execution.
 
@@ -258,10 +312,10 @@ Logical fields:
 Required semantics:
 
 - A selected response MUST always be available.
-- Full result objects are OPTIONAL, but implementations SHOULD support an output mode that exposes
-  detailed result metadata for debugging and research.
+- Detailed result objects are OPTIONAL, but implementations SHOULD make them available when research,
+  debugging, or observability is an intended use case.
 
-#### 4.1.5 `GenerationUsage`
+#### 4.1.7 `GenerationUsage`
 
 When token usage is exposed, the interoperable shape is:
 
@@ -271,43 +325,32 @@ When token usage is exposed, the interoperable shape is:
 
 All fields are non-negative integers.
 
-If an implementation cannot determine usage exactly, it MUST document whether usage is omitted,
-estimated, or reported as zero/unknown.
+If an implementation cannot determine usage exactly, it MUST do one of the following:
 
-#### 4.1.6 `StepGenerationConfig`
+- omit usage entirely
+- provide a documented estimate
+- provide a documented sentinel representation
 
-Configuration used by step-wise search algorithms.
-
-Fields:
-
-- `max_steps`
-- exactly one of:
-  - `step_token`
-  - `tokens_per_step`
-- `stop_token` (OPTIONAL)
-- `temperature` (OPTIONAL)
-- `include_stop_str_in_output` (OPTIONAL)
-- `temperature_switch` (OPTIONAL)
-
-Invariants:
-
-- Exactly one of `step_token` and `tokens_per_step` MUST be set.
-- `tokens_per_step` MUST be positive when used.
-
-### 4.2 Normalization and Compatibility Rules
+### 4.2 Normalization and Mapping Rules
 
 - A string prompt MUST normalize into one `user` message.
 - Structured chat is the primary cross-implementation contract.
 - Prompt-string fallback MAY exist for compatibility-oriented or experimental paths.
-- Tool-call-bearing assistant messages SHOULD remain attached to candidates and selected results.
-- Implementations MAY accept additional provider-native content parts, but they MUST document how
-  text extraction behaves for those parts.
+- Tool-invocation-bearing assistant messages SHOULD remain attached to candidates and selected
+  results.
+- Provider-native fields MAY be preserved in metadata, but canonical fields remain authoritative.
+- Implementations that map to or from OpenAI-compatible payloads SHOULD map:
+  - `tool_calls` -> `tool_invocations`
+  - `tool_call_id` -> `in_reply_to_tool_invocation`
+- Structured content parts MUST either:
+  - match a documented content-part shape, or
+  - fail with an explicit validation error
 
 ## 5. Core Library Contract
 
 ### 5.1 Input Normalization
 
-Algorithms and reward capabilities MUST accept normalized conversation input in one of these forms:
+Algorithms MUST accept normalized conversation input in one of these forms:
 
 - string prompt
 - list of normalized messages
@@ -317,9 +360,7 @@ Normalization MUST occur before algorithm-specific logic.
 
 ### 5.2 Language Model Capability
 
-The core contract is async-first.
-
-A conforming implementation MUST provide asynchronous LM generation behavior equivalent to:
+A conforming implementation MUST provide LM generation behavior equivalent to:
 
 - generate one assistant response from one normalized conversation
 
@@ -330,20 +371,10 @@ Batch generation can be implemented in either of two ways:
 
 Required semantics:
 
-- LM generation SHOULD return assistant messages in OpenAI-compatible structure where possible.
-- LM generation SHOULD preserve `tool_calls` when the provider returns them.
-- LM generation MAY accept provider-native arguments such as:
-  - `max_tokens`
-  - `temperature`
-  - `tools`
-  - `tool_choice`
-  - `response_format`
+- LM generation MUST return normalized assistant messages.
+- Implementations SHOULD preserve canonical tool-invocation structure when the underlying provider
+  supports tool use.
 - Retry, backoff, session reuse, and connection pooling are implementation-defined.
-
-Convenience behavior:
-
-- A synchronous wrapper MAY be provided.
-- An implementation MAY expose both single-conversation and batched generation operations.
 
 ### 5.3 Orchestration Capability
 
@@ -353,7 +384,7 @@ Responsibilities:
 
 - fan out one logical ITS request into multiple LM calls
 - preserve input/output ordering
-- forward LM-generation arguments consistently
+- forward generation arguments consistently
 - apply implementation-defined concurrency control
 - batch requests directly or emulate batching through repeated single calls
 
@@ -370,29 +401,120 @@ Every ITS algorithm MUST implement behavior equivalent to:
 
 - accept normalized input
 - allocate compute according to `budget`
-- invoke LM generation and, where needed, reward capabilities
+- invoke LM generation and, where needed, optional scoring extensions
 - select a final assistant response
 
 Required semantics:
 
 - Algorithms MUST accept both prompt-style and chat-style input.
 - Algorithms MUST document how they interpret `budget`.
-- Algorithms SHOULD preserve tool-call-bearing assistant messages when the LM capability does.
+- Algorithms SHOULD preserve tool-invocation-bearing assistant messages when the LM capability does.
 - Algorithms MAY depend on an explicit orchestration capability or inline equivalent batching/fanout
   behavior.
 - Algorithms MAY expose either:
   - selected response only
   - selected response plus full algorithm result metadata
 
-### 5.5 Outcome Reward Capability
+### 5.5 Concurrency and Convenience Interfaces
 
-Outcome reward models score final candidates.
+This specification is concurrency-oriented, not tied to one language's async model.
 
 Required behavior:
 
-- score one or more complete candidates with enough prompt/conversation context to make the score
+- Implementations MUST support concurrent execution of multiple independent LM calls, either in the
+  LM capability itself or through orchestration.
+- Synchronous blocking interfaces MAY be provided as convenience layers.
+
+This specification does not require any one event-loop, thread-pool, callback, future, or coroutine
+model.
+
+### 5.6 Provider-Native Argument Forwarding and Invocation Mapping
+
+Provider-native generation arguments are OPTIONAL parts of the extensible execution surface.
+
+Implementations MAY support arguments such as:
+
+- `max_tokens`
+- `temperature`
+- tool-availability hints
+- tool-selection hints
+- structured-output hints
+
+Required semantics:
+
+- If provider-native tool-use structures are supported, the implementation MUST map them onto the
+  canonical `ToolInvocation` model without silent semantic loss.
+- If structured-output features are supported, the implementation MUST document whether algorithms
+  merely forward those features or interpret them directly.
+
+### 5.7 Usage and Detailed Result Reporting
+
+Usage and detailed result reporting are OPTIONAL parts of the core contract.
+
+If exposed:
+
+- per-candidate usage MUST refer to one LM generation
+- aggregated usage MUST refer to one logical ITS execution
+- algorithm metadata MUST be documented as algorithm-specific, not assumed to be universal
+
+### 5.8 Configuration Surface
+
+Every conforming implementation MUST document how the following are configured:
+
+- downstream model or provider selection
+- algorithm-profile selection
+- concurrency policy
+- timeout policy
+- budget defaults and ceilings
+- scoring configuration for profiles that require scoring
+- which values are supplied:
+  - at initialization time
+  - per execution/request
+  - or by an external control surface
+
+Configuration model:
+
+- Configuration MAY be static, dynamic, file-based, API-based, embedded in the caller, or supplied
+  by an external control plane.
+- Dynamic reload is OPTIONAL.
+- Invalid configuration MUST be detected no later than:
+  - initialization time, or
+  - request acceptance for the affected execution path
+
+### 5.9 Validation and Required Failure Signaling
+
+Implementations MUST validate:
+
+- message normalization inputs
+- `budget`
+- provider-native generation arguments that they claim to support
+- candidate/result cardinality assumptions
+- scoring cardinality assumptions for profiles that use scoring
+
+Required semantics:
+
+- Invalid input MUST produce an explicit failure.
+- Unsupported optional provider-native arguments MAY be rejected explicitly.
+- Malformed provider responses MUST produce an explicit failure.
+- A gateway profile MAY choose fallback only when the gateway profile explicitly permits fallback.
+
+## 6. Optional Scoring Extensions
+
+### 6.1 `Outcome Reward Extension`
+
+Outcome scoring evaluates final candidates.
+
+Required behavior:
+
+- score one or more complete candidates with enough prompt or conversation context to make the score
   meaningful
 - higher score means better candidate
+- return exactly one score per scored candidate
+
+Required invariants:
+
+- score cardinality MUST equal scored candidate cardinality
+- if score cardinality does not match, fail with `invalid_reward_cardinality` or equivalent
 
 Interface freedom:
 
@@ -400,12 +522,11 @@ Interface freedom:
   - prompt + candidate
   - full conversation including candidate
   - batched conversations
-- An implementation MAY expose sync, async, or both, so long as the overall algorithm behavior is
-  conformant
+- An implementation MAY expose blocking, non-blocking, or both
 
-### 5.6 Process Reward Capability
+### 6.2 `Process Reward Extension`
 
-Process reward models score intermediate reasoning steps.
+Process scoring evaluates intermediate reasoning steps.
 
 Required behavior:
 
@@ -414,53 +535,27 @@ Required behavior:
 
 The minimal interoperable shape is a list of numeric scores aligned with the step list.
 
-### 5.7 Async-First and Sync Wrappers
+## 7. Stable Algorithm Profiles
 
-The specification is async-first.
-
-Required behavior:
-
-- primary execution contracts SHOULD be async
-- synchronous wrappers MAY be provided as convenience layers
-
-This specification does not require any one event-loop or threading model.
-
-### 5.8 Structured Output, Tool Calling, and Provider-Native Args
-
-Structured-output and tool-calling support are part of the extensible LM call surface.
-
-Required semantics:
-
-- Implementations that support tool calling MUST preserve returned tool-call structure on assistant
-  messages.
-- Implementations that support provider-native structured output MAY forward arguments such as
-  `response_format`.
-- Algorithms are not required to interpret provider-native structured-output arguments themselves,
-  but they SHOULD forward them when that is part of the documented design.
-
-### 5.9 Usage and Metadata
-
-Usage and metadata are OPTIONAL parts of the core contract.
-
-If exposed:
-
-- per-candidate usage MUST refer to one LM generation
-- aggregated usage MUST refer to one logical ITS execution
-- algorithm metadata MUST be documented as algorithm-specific, not assumed to be universal
-
-## 6. Stable Algorithm Profiles
-
-### 6.1 Shared `budget` Vocabulary
+### 7.1 Shared `budget` Vocabulary
 
 `budget` is the shared compute-control vocabulary for one ITS execution.
 
 Required semantics:
 
 - `budget` MUST be a positive integer
-- all algorithms MUST document how `budget` maps to compute
+- stable algorithms MUST specify their `budget` semantics in this section
 - identical `budget` values across different algorithms do not imply identical cost
 
-### 6.2 `SelfConsistency`
+Candidate availability policy for stable candidate-set algorithms:
+
+- If one or more candidate generations succeed, the algorithm MUST continue using the successful
+  subset.
+- If zero candidate generations succeed, the algorithm MUST fail with `insufficient_candidates` or
+  equivalent.
+- Implementations MUST NOT synthesize placeholder candidates for failed generations.
+
+### 7.2 `SelfConsistency`
 
 Behavior:
 
@@ -472,13 +567,15 @@ Projection behavior:
 
 - The default comparison space MAY be exact or normalized text content.
 - Implementations MAY support explicit projection functions, including regex-based projections.
-- If a projection fails to match, the implementation MUST document whether the candidate is ignored,
-  grouped under a null value, or treated as raw content.
+- If a projection fails to match, the implementation MUST document whether the candidate is:
+  - ignored
+  - grouped under a null value
+  - or treated as raw content
 
-Tool-calling behavior:
+Tool-invocation behavior:
 
-- Tool-call-bearing responses MAY participate in consistency voting.
-- If tool-call voting is supported, the implementation MUST document the voting modes.
+- Invocation-bearing responses MAY participate in consistency voting.
+- If invocation-based voting is supported, the implementation MUST document the voting modes.
 - Common modes include:
   - tool identity only
   - tool arguments only
@@ -492,22 +589,27 @@ Result metadata MAY include:
 
 Budget semantics:
 
-- `budget` is the number of candidate generations.
+- `budget` is the number of candidate generations attempted.
 
-### 6.3 `BestOfN`
+### 7.3 `BestOfN`
 
 Behavior:
 
 - Generate `N` candidate responses.
-- Score them with an outcome reward capability.
+- Score the successful candidate set with the `Outcome Reward Extension`.
 - Select the highest-scoring candidate, with implementation-defined tie-breaking.
 
 Scoring behavior:
 
 - Implementations MAY score all candidates directly.
 - Implementations MAY deduplicate semantically equivalent candidates before scoring to reduce cost.
-- If tool-calling is supported, semantic equivalence SHOULD consider both content and
-  tool-call-bearing structure.
+- If invocation support is present, semantic equivalence SHOULD consider both content and canonical
+  tool-invocation structure.
+
+Required invariants:
+
+- every scored candidate MUST receive exactly one score
+- if scoring of the surviving candidate set is incomplete, the execution MUST fail explicitly
 
 Result metadata MAY include:
 
@@ -517,43 +619,70 @@ Result metadata MAY include:
 
 Budget semantics:
 
-- `budget` is the number of candidate generations to score.
+- `budget` is the number of candidate generations attempted.
 
-## 7. Experimental Algorithm Profiles
+## 8. Experimental Algorithm Profiles
 
 Experimental algorithms are OPTIONAL extensions.
 
-They are part of the repository-family design, but they are not part of the stable core contract in
-the same way as `SelfConsistency` and `BestOfN`.
+Cross-implementation conformance for experimental profiles is intentionally limited in v1:
 
-### 7.1 Step-Wise Search Family
+- the explicit invariants in this section are normative
+- behavior beyond those invariants is implementation-defined and MUST be documented
+- experimental profile support does not imply cross-implementation behavioral interchangeability in
+  the same way as the stable profiles in Section 7
+
+### 8.1 `StepGenerationConfig`
+
+`StepGenerationConfig` is used by step-wise search profiles.
+
+Fields:
+
+- `max_steps` (positive integer)
+- exactly one of:
+  - `step_token` (string literal marking step boundaries in generated text)
+  - `tokens_per_step` (positive integer, maximum generated tokens per step)
+- `stop_token` (OPTIONAL string)
+- `temperature` (OPTIONAL numeric value)
+- `include_stop_str_in_output` (OPTIONAL boolean)
+- `temperature_switch` (OPTIONAL implementation-defined temperature-switch rule)
+
+Validation rules:
+
+- If both `step_token` and `tokens_per_step` are set, fail with explicit validation error.
+- If neither `step_token` nor `tokens_per_step` is set, fail with explicit validation error.
+- `tokens_per_step` MUST be positive when used.
+
+### 8.2 Step-Wise Search Family
 
 Common characteristics:
 
 - use `StepGenerationConfig`
 - generate partial reasoning trajectories rather than only final answers
-- may depend on process reward scoring
+- may depend on process scoring
 - may rely on prompt-string compatibility paths more than the stable core
 
-### 7.2 `BeamSearch`
+### 8.3 `BeamSearch`
 
-Behavior:
+Minimum invariants:
 
-- expand a bounded set of partial trajectories
-- retain the best partial candidates according to implementation-defined scoring
-- continue until stopping criteria are met
+- maintain a bounded frontier of partial trajectories
+- expand frontier members in repeated search rounds
+- score or rank expanded partial trajectories according to a documented policy
+- retain no more than the documented frontier bound after each pruning step
 
 Budget semantics:
 
-- `budget` represents total search effort rather than a universal number of final candidates
+- implementation-defined in v1
+- the implementation MUST document how `budget` bounds total search effort
 
 Required documentation:
 
-- beam-width policy
+- frontier-bound policy
 - step stopping criteria
 - score aggregation policy
 
-### 7.3 Particle Methods
+### 8.4 Particle Methods
 
 This family includes profiles such as:
 
@@ -561,36 +690,41 @@ This family includes profiles such as:
 - `ParticleGibbs`
 - entropic or annealed particle variants
 
-Behavior:
+Minimum invariants:
 
 - maintain multiple evolving trajectories
-- resample or update trajectories according to implementation-defined particle rules
-- use process reward or equivalent scoring to guide evolution
+- update or resample trajectories according to a documented particle policy
+- use a documented scoring or weighting policy to guide evolution
 
 Budget semantics:
 
-- `budget` typically represents number of particles or equivalent total particle effort
+- implementation-defined in v1
+- the implementation MUST document whether `budget` represents:
+  - particle count
+  - total particle effort
+  - or another documented particle-control quantity
 
 Required documentation:
 
-- resampling/update policy
-- score aggregation policy
+- update/resampling policy
+- score or weight aggregation policy
 - stopping criteria
 
-### 7.4 `PlanningWrapper`
+### 8.5 `PlanningWrapper`
 
-Behavior:
+Minimum invariants:
 
 - allocate some compute to planning
 - execute a downstream algorithm conditioned on the planning result
 
 Budget semantics:
 
-- `budget` combines planning cost and downstream execution cost according to a documented policy
+- implementation-defined in v1
+- the implementation MUST document how planning cost and downstream execution cost share `budget`
 
-## 8. Gateway Profiles
+## 9. Gateway Profiles
 
-### 8.1 Gateway Role
+### 9.1 Gateway Role
 
 Gateways are OPTIONAL integration profiles layered over the core library contract.
 
@@ -605,14 +739,15 @@ This specification version defines two gateway profiles:
 1. `Direct ITS Gateway`
 2. `External-Processing Gateway`
 
-### 8.2 Shared Gateway Requirements
+### 9.2 Shared Gateway Requirements
 
 All gateway profiles that claim conformance MUST:
 
 - target an OpenAI-compatible chat-completions-like request/response surface
 - accept a client-visible `model` selection or documented equivalent
 - accept normalized `messages` or a compatible chat body
-- preserve the selected assistant message structure, including `tool_calls` where supported
+- preserve selected assistant-message content and tool invocation structure when mapped into the
+  gateway protocol
 - document how downstream LM routing and algorithm wiring are configured
 - document timeout, retry, and failure behavior
 
@@ -624,15 +759,15 @@ Minimum OpenAI-compatible response shape:
 - `model`
 - `choices`
 
-`usage` and `metadata` are OPTIONAL but RECOMMENDED when meaningful.
+`usage` and algorithm-specific `metadata` are OPTIONAL but RECOMMENDED when meaningful.
 
-### 8.3 `Direct ITS Gateway` (OPTIONAL)
+### 9.3 `Direct ITS Gateway` (OPTIONAL)
 
-#### 8.3.1 Role
+#### 9.3.1 Role
 
 A direct gateway is a standalone service that terminates client requests and applies ITS directly.
 
-#### 8.3.2 Activation Model
+#### 9.3.2 Activation Model
 
 ITS activation MUST be explicit in the request payload.
 
@@ -644,13 +779,13 @@ Canonical behavior:
 The direct gateway profile MUST NOT rely on proxy-only transport metadata as its primary activation
 mechanism.
 
-#### 8.3.3 Configuration Surface
+#### 9.3.3 Configuration Surface
 
 A direct gateway MUST provide a documented configuration mechanism for:
 
-- downstream LM endpoint/provider selection
+- downstream LM routing
 - algorithm selection or policy selection
-- reward-model wiring where applicable
+- scoring wiring where applicable
 - credentials and secret handling
 
 The mechanism MAY be:
@@ -660,9 +795,7 @@ The mechanism MAY be:
 - an admin/control API
 - an external control plane
 
-This specification does not require a single configuration topology.
-
-#### 8.3.4 Request Contract
+#### 9.3.4 Request Contract
 
 A direct gateway MUST accept:
 
@@ -675,21 +808,41 @@ A direct gateway SHOULD accept:
 
 A direct gateway MAY accept:
 
-- `temperature`
-- `max_tokens`
-- `tools`
-- `tool_choice`
+- generation-control fields such as maximum token count or temperature
+- tool-availability hints
+- tool-selection hints
 - `stream`
 - implementation-defined metadata fields
 
 Unsupported optional request fields SHOULD produce explicit documented behavior rather than silent
 reinterpretation.
 
-#### 8.3.5 Response Contract
+#### 9.3.5 Response Contract
 
 When ITS is applied, the response MUST be OpenAI-compatible and include:
 
 - one selected assistant message in `choices[0].message`
+
+Example minimum response body:
+
+```json
+{
+  "id": "its-req-123",
+  "object": "chat.completion",
+  "created": 1730000000,
+  "model": "example-model",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "example output"
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}
+```
 
 The response MAY also include:
 
@@ -702,7 +855,7 @@ If usage is exposed, the implementation MUST document whether it is:
 - estimated
 - or otherwise computed
 
-#### 8.3.6 Failure Model
+#### 9.3.6 Failure Model
 
 Configuration or wiring failures SHOULD produce explicit service errors.
 
@@ -714,7 +867,7 @@ Generation failures MAY be handled by:
 Direct gateways MUST NOT silently forward the request to an unknown upstream unless that behavior is
 an explicit part of the documented design.
 
-#### 8.3.7 State and Scaling Notes
+#### 9.3.7 State and Scaling Notes
 
 Direct gateways MAY use:
 
@@ -725,14 +878,14 @@ Direct gateways MAY use:
 Restart behavior, persistence, and horizontal scaling are implementation-defined and MUST be
 documented.
 
-### 8.4 `External-Processing Gateway` (OPTIONAL)
+### 9.4 `External-Processing Gateway` (OPTIONAL)
 
-#### 8.4.1 Role
+#### 9.4.1 Role
 
 An external-processing gateway sits in front of an upstream OpenAI-compatible API and conditionally
 applies ITS.
 
-#### 8.4.2 Activation Model
+#### 9.4.2 Activation Model
 
 ITS activation MUST be conveyed out-of-band relative to the standard request body.
 
@@ -748,7 +901,7 @@ Required semantics:
 - activation metadata MUST include compute-control information equivalent to `budget`
 - the implementation MUST document all recognized activation fields and validation rules
 
-#### 8.4.3 Outcomes
+#### 9.4.3 Outcomes
 
 The profile supports two outcomes:
 
@@ -760,7 +913,7 @@ The profile supports two outcomes:
    - the gateway returns an OpenAI-compatible response directly
    - the upstream request is short-circuited
 
-#### 8.4.4 Request Resolution
+#### 9.4.4 Request Resolution
 
 For an intercepted request:
 
@@ -777,11 +930,32 @@ For an intercepted request:
    - `pass_through`, or
    - explicit error according to documented policy
 
-#### 8.4.5 Response Contract
+#### 9.4.5 Response Contract
 
 When ITS is applied, the response MUST be OpenAI-compatible and include:
 
 - the selected assistant message
+
+Example minimum response body:
+
+```json
+{
+  "id": "its-req-123",
+  "object": "chat.completion",
+  "created": 1730000000,
+  "model": "example-model",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "example output"
+      },
+      "finish_reason": "stop"
+    }
+  ]
+}
+```
 
 The response SHOULD also include an implementation-defined signal that ITS was applied, such as:
 
@@ -792,7 +966,7 @@ The response SHOULD also include an implementation-defined signal that ITS was a
 If usage is exposed, it SHOULD refer to the full logical ITS execution, not only the selected
 candidate.
 
-#### 8.4.6 Failure Model
+#### 9.4.6 Failure Model
 
 Safe fallback is RECOMMENDED.
 
@@ -805,12 +979,12 @@ If safe fallback is chosen:
 
 If explicit errors are chosen instead, the implementation MUST document that policy clearly.
 
-#### 8.4.7 Safety Notes
+#### 9.4.7 Safety Notes
 
 External-processing gateways SHOULD sanitize or strip internal ITS activation metadata before
 forwarding pass-through requests upstream when that metadata is not intended for upstream services.
 
-### 8.5 Streaming
+### 9.5 Streaming
 
 This specification version does not standardize streaming ITS behavior.
 
@@ -823,11 +997,11 @@ Implementations MAY:
 If streaming is not supported, the implementation SHOULD return an explicit documented error rather
 than silently pretending to stream.
 
-## 9. Documentation, Benchmarking, and Example Surface
+## 10. Documentation, Observability, Benchmarking, and Example Surface
 
-### 9.1 Documentation
+### 10.1 Documentation
 
-Repository-family documentation SHOULD cover:
+Documentation SHOULD cover:
 
 - installation or setup guidance
 - core algorithm concepts
@@ -837,7 +1011,26 @@ Repository-family documentation SHOULD cover:
 
 This specification does not require fixed file paths or one documentation toolchain.
 
-### 9.2 Benchmarking Surface
+### 10.2 Observability
+
+If observability is implemented, the implementation SHOULD expose structured information for each
+logical ITS execution such as:
+
+- execution identifier
+- algorithm profile
+- `budget`
+- candidate count
+- selected index when detailed outputs are available
+- duration or latency
+- usage, if available
+- failure code, if the execution failed
+- gateway outcome (`pass_through` or `its_applied`) for gateway profiles
+
+Observability outputs MAY be logs, traces, metrics, snapshots, or another documented surface.
+
+Observability failures MUST NOT change the correctness of the ITS result.
+
+### 10.3 Benchmarking Surface
 
 A research-oriented implementation MAY provide benchmark tooling for:
 
@@ -853,7 +1046,7 @@ If benchmark tooling is shipped, the implementation SHOULD document:
 - evaluation procedure
 - reproducibility expectations
 
-### 9.3 Examples
+### 10.4 Examples
 
 Examples MAY be provided for:
 
@@ -864,17 +1057,42 @@ Examples MAY be provided for:
 
 Examples are descriptive and user-facing, not normative.
 
-## 10. Failure Model and Recovery Strategy
+## 11. Failure Model and Recovery Strategy
 
-### 10.1 Failure Classes
+### 11.1 Shared Error Vocabulary
+
+Implementations SHOULD use or map onto a shared error vocabulary that includes codes such as:
+
+- `invalid_input`
+- `invalid_message`
+- `invalid_content_part`
+- `invalid_tool_invocation`
+- `invalid_budget`
+- `unsupported_generation_argument`
+- `lm_generation_failed`
+- `malformed_lm_response`
+- `orchestration_failed`
+- `partial_generation_failure`
+- `insufficient_candidates`
+- `reward_failed`
+- `invalid_reward_cardinality`
+- `gateway_configuration_error`
+- `gateway_request_invalid`
+- `gateway_interception_failed`
+- `gateway_response_shaping_failed`
+
+The exact public error envelope is implementation-defined, but the implementation SHOULD document a
+stable mapping from its error surface to these concepts.
+
+### 11.2 Failure Classes
 
 1. `Input / Normalization Failures`
    - invalid message shape
    - unsupported content form
-   - malformed tool-call structure
+   - malformed tool invocation structure
 
 2. `LM Generation Failures`
-   - provider/network failure
+   - provider or network failure
    - timeout
    - provider rejection
    - malformed provider response
@@ -882,10 +1100,10 @@ Examples are descriptive and user-facing, not normative.
 3. `Orchestration Failures`
    - batch fanout failure
    - concurrency-control failure
-   - partial batch failure
+   - partial candidate-generation failure
 
-4. `Reward Failures`
-   - reward-service failure
+4. `Scoring Failures`
+   - scoring-service failure
    - invalid score payload
    - inconsistent score cardinality
 
@@ -905,28 +1123,45 @@ Examples are descriptive and user-facing, not normative.
    - benchmark I/O failure
    - metrics/status reporting failure
 
-### 10.2 Recovery Behavior
+### 11.3 Recovery Behavior
 
-- Input/normalization failures:
+- Input and normalization failures:
   - fail the current request or run attempt explicitly
 
-- LM or reward transient failures:
-  - MAY be retried according to implementation-defined policy
+- LM transient failures:
+  - MAY be retried according to documented policy before a candidate is treated as failed
 
 - Orchestration failures:
-  - SHOULD fail the current logical ITS execution explicitly
   - MUST NOT silently reorder candidate results
 
 - Direct gateway configuration failures:
   - SHOULD fail explicitly and operator-visibly
 
 - External-processing gateway failures:
-  - SHOULD follow the documented fallback or explicit-error policy from Section 8.4.6
+  - MUST follow the documented fallback-or-error policy from Section 9.4.6
 
-- Observability/tooling failures:
-  - SHOULD NOT corrupt the correctness of the core ITS result
+- Observability and tooling failures:
+  - MUST NOT corrupt the correctness of the core ITS result
 
-### 10.3 Restart and State Notes
+### 11.4 Partial Failure Rules
+
+Stable candidate-set algorithms MUST follow these rules:
+
+- If one or more candidate generations succeed, proceed using the successful subset only.
+- If zero candidate generations succeed, fail with `insufficient_candidates` or equivalent.
+- Synthetic filler candidates are forbidden.
+
+Scoring-related partial failures:
+
+- If a scored profile requires one score per surviving candidate, incomplete scoring MUST fail
+  explicitly.
+- Implementations MAY retry scoring failures according to documented policy before failing.
+
+Gateway partial-failure rule:
+
+- `pass_through` is a documented gateway outcome, not an internal library success state.
+
+### 11.5 Restart and State Notes
 
 The core library can be stateless.
 
@@ -939,15 +1174,15 @@ Gateway implementations MAY maintain:
 
 Persistence across restarts is OPTIONAL and implementation-defined.
 
-## 11. Security and Operational Safety
+## 12. Security and Operational Safety
 
-### 11.1 Trust Boundary Assumption
+### 12.1 Trust Boundary Assumption
 
 Implementations SHOULD assume that all of the following may be partially or fully untrusted:
 
 - prompts and chat messages
-- tool definitions
-- tool-call arguments
+- structured content parts
+- tool invocations and their arguments
 - activation metadata
 - downstream model outputs
 - benchmark inputs
@@ -955,7 +1190,7 @@ Implementations SHOULD assume that all of the following may be partially or full
 The specification intentionally does not mandate one trust posture, but implementations MUST
 document their own.
 
-### 11.2 Secret Handling
+### 12.2 Secret Handling
 
 Implementations SHOULD:
 
@@ -963,18 +1198,18 @@ Implementations SHOULD:
 - validate the presence of secrets without printing them
 - document how secrets are supplied and scoped
 
-### 11.3 Tool-Calling and Structured Input Safety
+### 12.3 Tool Invocation and Structured Input Safety
 
-Tool-calling preservation is part of the contract, but actual execution of tools is out of scope for
-this specification unless an implementation explicitly adds such a feature.
+Preservation of tool invocation structure is part of the contract, but actual execution of tools is
+out of scope unless an implementation explicitly adds such a feature.
 
 Implementations SHOULD:
 
-- preserve tool-call structure faithfully
-- avoid mutating tool-call arguments silently
-- document any normalization applied to structured content or tool calls
+- preserve tool invocation structure faithfully
+- avoid mutating invocation arguments silently
+- document any normalization applied to structured content or invocations
 
-### 11.4 Gateway Safety
+### 12.4 Gateway Safety
 
 Gateway implementations SHOULD document:
 
@@ -984,7 +1219,7 @@ Gateway implementations SHOULD document:
 - rate limiting or quota behavior
 - whether internal ITS metadata is stripped before upstream forwarding
 
-### 11.5 Resource Exhaustion and Budget Controls
+### 12.5 Resource Exhaustion and Budget Controls
 
 ITS can amplify LM call volume significantly.
 
@@ -994,15 +1229,17 @@ Implementations SHOULD document guardrails for:
 - concurrency limits
 - timeout ceilings
 - gateway backpressure behavior
-- reward-model resource limits
+- scoring-service resource limits
 
-## 12. Reference Procedures (Language-Agnostic)
+## 13. Non-Normative Reference Procedures
 
-This section is intentionally non-executable. It describes reference procedures that illustrate the
-intended behavior of a conforming implementation without prescribing any programming language,
-runtime, or internal representation.
+This section is NON-NORMATIVE.
 
-### 12.1 Input Normalization Procedure
+It illustrates one conforming family of procedures, but it does not add requirements beyond
+Sections 4 through 12. If any procedure in this section appears to conflict with a normative
+section, the normative section controls.
+
+### 13.1 Input Normalization Procedure
 
 Input:
 
@@ -1010,20 +1247,14 @@ Input:
 - normalized message list, or
 - implementation-equivalent chat container
 
-Required procedure:
+Illustrative procedure:
 
-1. If the input is a string prompt, convert it into a single `user` message.
-2. If the input is already a normalized chat container, extract its structured message
-   representation.
-3. If the input is already a normalized message list, use it unchanged.
-4. If the input cannot be interpreted as one of the supported forms, fail with an explicit
-   input-normalization error.
+1. Convert string input into one `user` message.
+2. Extract structured messages from any normalized chat container.
+3. Pass through already-normalized message lists unchanged.
+4. Reject unsupported input forms explicitly.
 
-Required outcome:
-
-- downstream algorithm logic receives a normalized structured message sequence
-
-### 12.2 Self-Consistency Reference Procedure
+### 13.2 Self-Consistency Reference Procedure
 
 Input:
 
@@ -1032,80 +1263,52 @@ Input:
 - `budget`
 - documented projection rule
 
-Required procedure:
+Illustrative procedure:
 
 1. Normalize the input conversation.
-2. Create `budget` equivalent candidate-generation requests from that normalized conversation.
-3. Generate one assistant response for each candidate-generation request.
-4. Project each candidate response into the documented comparison space.
-5. Count how many times each projected value occurs.
-6. Select the winning projected value using the documented tie-break policy.
-7. Return the candidate associated with the winning projected value as the selected response.
+2. Attempt candidate generation `budget` times.
+3. Discard failed candidates according to the stable candidate-availability rule.
+4. Project surviving candidates into the comparison space.
+5. Count projections.
+6. Select the winning projection according to the documented tie-break policy.
+7. Return the associated candidate as the selected response.
 
-Recommended detailed output:
-
-- selected response
-- all candidate responses
-- vote counts
-- selected index
-
-### 12.3 Best-of-N Reference Procedure
+### 13.3 Best-of-N Reference Procedure
 
 Input:
 
 - normalized or normalizable conversation input
 - LM capability
-- outcome reward capability
+- outcome scoring extension
 - `budget`
 
-Required procedure:
+Illustrative procedure:
 
 1. Normalize the input conversation.
-2. Create `budget` equivalent candidate-generation requests from that normalized conversation.
-3. Generate one assistant response for each candidate-generation request.
-4. If the implementation documents candidate deduplication, collapse semantically equivalent
-   candidates before scoring.
-5. Score each candidate, or each unique candidate, using the outcome reward capability.
-6. If deduplication was used, map scores back onto the original candidate set.
-7. Select the candidate with the highest score using the documented tie-break policy.
-8. Return that candidate as the selected response.
+2. Attempt candidate generation `budget` times.
+3. Discard failed candidates according to the stable candidate-availability rule.
+4. Optionally deduplicate semantically equivalent surviving candidates if the implementation
+   documents such behavior.
+5. Score the surviving candidate set.
+6. Fail if score cardinality is incomplete.
+7. Select the highest-scoring candidate according to the documented tie-break policy.
 
-Recommended detailed output:
-
-- selected response
-- all candidate responses
-- per-candidate scores
-- selected index
-
-### 12.4 Direct Gateway Reference Procedure
+### 13.4 Direct Gateway Reference Procedure
 
 Input:
 
 - OpenAI-compatible chat-completions-like request
 - direct gateway configuration
 
-Required procedure:
+Illustrative procedure:
 
-1. Validate that the gateway has enough configuration to route LM requests and apply the selected
-   ITS policy.
-2. Read the client-visible request fields required by the direct gateway profile, including at
-   minimum:
-   - `model`
-   - `messages`
-   - request-body compute control equivalent to `budget`, when the profile requires explicit ITS
-     activation
-3. Forward supported optional generation fields such as tools or tool choice according to the
-   documented gateway behavior.
-4. Run the configured ITS algorithm against the normalized request.
+1. Validate gateway configuration.
+2. Read the request's model selection, messages, and compute-control field.
+3. Forward supported optional generation fields.
+4. Run the configured ITS profile.
 5. Shape the result into an OpenAI-compatible response.
 
-Required outcome:
-
-- one direct gateway response representing either:
-  - successful ITS application, or
-  - a documented explicit error
-
-### 12.5 External-Processing Gateway Reference Procedure
+### 13.5 External-Processing Gateway Reference Procedure
 
 Input:
 
@@ -1113,29 +1316,20 @@ Input:
 - activation metadata
 - external-processing gateway configuration
 
-Required procedure:
+Illustrative procedure:
 
-1. Determine whether the intercepted route is eligible for ITS handling.
+1. Determine whether the route is eligible for ITS handling.
 2. If the route is not eligible, choose `pass_through`.
-3. Parse activation metadata from the documented out-of-band channel.
+3. Parse activation metadata.
 4. If activation metadata is absent or invalid, choose `pass_through`.
-5. Read or buffer the request body as needed to obtain the required chat-completions fields.
-6. If the required body fields are unavailable, follow the documented fallback-or-error policy.
-7. If ITS should be applied, run the configured ITS algorithm using:
-   - the upstream request's logical model selection
-   - the request messages
-   - the activation metadata's compute-control value
-   - any forwarded optional fields such as tools or tool choice
-8. If ITS succeeds, return an OpenAI-compatible immediate response and short-circuit the upstream
+5. Read or buffer the request body.
+6. If required request-body fields are unavailable, follow the documented fallback-or-error policy.
+7. If ITS should be applied, run the configured ITS profile.
+8. If ITS succeeds, return an immediate OpenAI-compatible response and short-circuit the upstream
    request.
-9. If ITS fails after activation, follow the documented fallback-or-error policy.
+9. If ITS fails, follow the documented fallback-or-error policy.
 
-Required outcomes:
-
-- `pass_through`, or
-- `its_applied`
-
-## 13. Test and Validation Matrix
+## 14. Test and Validation Matrix
 
 A conforming implementation SHOULD include tests that cover the behaviors defined in this
 specification.
@@ -1147,54 +1341,72 @@ Validation profiles:
   ship
 - `Real Integration Profile`: RECOMMENDED environment-dependent checks before production use
 
-Unless otherwise noted, Sections 13.1 and 13.2 are `Core Conformance`. Bullets that begin with
-`If ... is implemented` are `Extension Conformance`.
+Unless otherwise noted, Section 14.1 is `Core Conformance`. Bullets that begin with `If ... is
+implemented` are `Extension Conformance`.
 
-### 13.1 Core Library Conformance
+### 14.1 Core Library Conformance
 
 - string prompts normalize into one `user` message
-- normalized chat preserves role/content/tool-call fields
-- text extraction from structured content is consistent
-- tool-call-bearing assistant messages preserve tool-call structure
+- normalized chat preserves role/content/invocation fields
+- structured content validation behaves as documented
+- canonical tool invocation mapping is preserved
 - LM capability returns one response per logical input
 - orchestration preserves input ordering
-- orchestration forwards generation arguments consistently
-- outcome reward scoring is aligned with final candidates
-- process reward scoring is aligned with intermediate steps
+- orchestration forwards documented generation arguments consistently
+- invalid input and invalid `budget` are rejected explicitly
+- malformed provider responses fail explicitly
 
-### 13.2 Stable Algorithm Extension
+### 14.2 Outcome Reward Extension
 
-- `SelfConsistency` selects repeated candidates correctly
+If the `Outcome Reward Extension` is implemented:
+
+- one score is returned per scored candidate
+- score cardinality mismatches fail explicitly
+- score ordering remains aligned with candidate ordering
+
+### 14.3 Stable SelfConsistency Extension
+
+If the `Stable SelfConsistency Extension` is implemented:
+
+- repeated candidates are selected correctly
 - documented projection behavior is applied consistently
-- tool-call voting behavior matches documentation if implemented
-- `BestOfN` scores candidates correctly
-- deduplication behavior matches documentation if implemented
-- result objects or detailed outputs expose the selected response correctly
-- `budget` semantics match documentation
+- invocation-based voting behavior matches documentation if implemented
+- partial candidate-generation failure follows the stable candidate-availability rule
+- `budget` semantics match Section 7.2
 
-### 13.3 Experimental Search Extension
+### 14.4 Stable BestOfN Extension
+
+If the `Stable BestOfN Extension` is implemented:
+
+- successful candidates are scored correctly
+- deduplication behavior matches documentation if implemented
+- incomplete scoring fails explicitly
+- result objects or detailed outputs expose the selected response correctly
+- `budget` semantics match Section 7.3
+
+### 14.5 Experimental Search Extension
 
 If experimental search is implemented:
 
-- step-generation invariants are enforced
-- beam-search expansion/pruning follows documented policy
-- particle methods follow documented resampling/update policy
+- `StepGenerationConfig` validation rules are enforced
+- beam-search frontier bounds follow the documented policy
+- particle methods follow documented update/resampling policy
 - planning-wrapper budget allocation follows documented policy
 - prompt-fallback behavior is documented where structured-chat fidelity is reduced
 
-### 13.4 Direct Gateway Extension
+### 14.6 Direct Gateway Extension
 
 If the `Direct ITS Gateway` profile is implemented:
 
 - request-body activation drives ITS execution
-- gateway rejects or handles unsupported optional fields as documented
+- the gateway rejects or handles unsupported optional fields as documented
 - configuration failures are surfaced explicitly
 - OpenAI-compatible response shaping is correct
-- tool calls are preserved when produced by the algorithm path
+- canonical tool invocation mapping is preserved when tool use is exposed through the gateway
 - usage behavior matches documented semantics
 - non-streaming behavior matches documented semantics
 
-### 13.5 External-Processing Gateway Extension
+### 14.7 External-Processing Gateway Extension
 
 If the `External-Processing Gateway` profile is implemented:
 
@@ -1206,7 +1418,7 @@ If the `External-Processing Gateway` profile is implemented:
 - ITS-applied signaling behavior matches documentation
 - usage aggregation behavior matches documentation if usage is exposed
 
-### 13.6 Research Toolkit Extension
+### 14.8 Research Toolkit Extension
 
 If benchmark or research tooling is implemented:
 
@@ -1214,54 +1426,82 @@ If benchmark or research tooling is implemented:
 - dataset and scoring assumptions are documented
 - example code remains consistent with the documented public contract
 
-### 13.7 Real Integration Profile (RECOMMENDED)
+### 14.9 Real Integration Profile (RECOMMENDED)
 
 These checks are RECOMMENDED before production use and MAY be skipped in CI when credentials or
 network access are unavailable.
 
 - Run a real downstream LM smoke test with valid credentials.
-- If a reward model is part of the deployment, run a real reward-path smoke test.
+- If an outcome scoring extension is part of the deployment, run a real scoring-path smoke test.
 - If a direct gateway is implemented, run an end-to-end chat-completions smoke test.
 - If an external-processing gateway is implemented, test both:
   - pass-through behavior
   - ITS-applied short-circuit behavior
 - Report skipped real-integration tests as skipped rather than silently passing them.
 
-## 14. Implementation Checklist (Definition of Done)
+## 15. Implementation Checklist (Definition of Done)
 
-Use the same validation profiles as Section 13:
+Use the same validation profiles as Section 14:
 
-- Section 14.1 = `Core Conformance`
-- Section 14.2 = `Extension Conformance`
-- Section 14.3 = `Real Integration Profile`
+- Section 15.1 = `Core Conformance`
+- Section 15.2 = `Extension Conformance`
+- Section 15.3 = `Real Integration Profile`
 
-### 14.1 REQUIRED for Core Conformance
+### 15.1 REQUIRED for Core Conformance
 
-- normalized message model
-- async-first LM generation capability
+- normalized message model with canonical tool invocation fields
+- generic candidate, result, and usage model
+- LM generation capability
 - orchestration behavior or equivalent batch/fanout layer
 - scaling algorithm execution contract
 - documented `budget` semantics
-- outcome and/or process reward capability as required by shipped algorithms
-- tool-call preservation for supported tool-calling providers
+- configuration and validation surface
 - documentation of failure behavior and trust boundary
 - deterministic tests for supported core behavior
 
-### 14.2 RECOMMENDED Extensions
+### 15.2 RECOMMENDED Extensions
 
-- stable algorithms:
-  - `SelfConsistency`
-  - `BestOfN`
-- experimental search family
+- `Outcome Reward Extension`
+- `Stable SelfConsistency Extension`
+- `Stable BestOfN Extension`
+- `Experimental Search Extension`
 - structured-output forwarding support
 - detailed result metadata and usage accounting
 - `Direct ITS Gateway` profile
 - `External-Processing Gateway` profile
+- observability surface
 - benchmark and example toolkit
 
-### 14.3 Operational Validation Before Production
+### 15.3 Operational Validation Before Production
 
-- Run the `Real Integration Profile` from Section 13.7 with valid credentials and network access.
+- Run the `Real Integration Profile` from Section 14.9 with valid credentials and network access.
 - Verify timeout, retry, and fallback behavior under representative failure conditions.
 - Verify budget and concurrency guardrails on the target deployment.
 - Verify secret handling and log redaction behavior on the target environment.
+
+## Appendix A. Spec Evolution
+
+### A.1 Versioning and Breaking Changes
+
+This specification is versioned by draft/release label.
+
+Breaking changes include:
+
+- removing or renaming canonical fields
+- changing required behaviors for an existing conformance profile
+- changing gateway activation or response requirements incompatibly
+
+Minor or additive changes include:
+
+- adding OPTIONAL fields
+- adding OPTIONAL extension profiles
+- tightening documentation requirements without changing behavior
+
+### A.2 Experimental Graduation
+
+Experimental profiles MAY graduate to stable in a future version when:
+
+- their budget semantics are specified normatively
+- their invariants are strong enough for cross-implementation conformance testing
+- their failure behavior and validation rules are specified precisely enough for independent
+  implementations to converge

--- a/SPEC.md
+++ b/SPEC.md
@@ -163,7 +163,7 @@ This specification defines these conformance profiles:
    - planning wrapper
 
 7. `Direct Gateway Extension`
-   - Standalone service that terminates client requests and applies ITS directly.
+   - Standalone service that accepts and handles client requests directly with ITS.
 
 8. `External-Processing Gateway Extension`
    - Intercepting gateway that conditionally applies ITS in front of an upstream API.
@@ -359,6 +359,8 @@ If an implementation cannot determine usage exactly, it MUST do one of the follo
 - Tool-invocation-bearing assistant messages SHOULD remain attached to candidates and selected
   results.
 - Provider-native fields MAY be preserved in metadata, but canonical fields remain authoritative.
+- The field names defined in this specification are canonical and provider-neutral. Provider-specific
+  names such as OpenAI `tool_calls` are mapping targets, not the normative vocabulary.
 - Implementations that map to or from OpenAI-compatible payloads SHOULD map:
   - `tool_calls` -> `tool_invocations`
   - `tool_call_id` -> `in_reply_to_tool_invocation`
@@ -370,13 +372,15 @@ If an implementation cannot determine usage exactly, it MUST do one of the follo
 
 ### 5.1 Input Normalization
 
-Algorithms MUST accept normalized conversation input in one of these forms:
+Algorithm-facing entrypoints MUST support one or more documented public input forms, which MAY
+include:
 
 - string prompt
 - list of normalized messages
 - implementation-equivalent `ChatMessages` wrapper
 
-Normalization MUST occur before algorithm-specific logic.
+Any supported public input form MUST normalize into the canonical message model before
+algorithm-specific logic.
 
 ### 5.2 Language Model Capability
 
@@ -426,7 +430,8 @@ Every ITS algorithm MUST implement behavior equivalent to:
 
 Required semantics:
 
-- Algorithms MUST accept both prompt-style and chat-style input.
+- Public algorithm-facing entrypoints MAY accept prompt-style and/or chat-style input. Regardless of
+  surface shape, normalization MUST occur before algorithm-specific logic.
 - Algorithms MUST document how they interpret `budget`.
 - Algorithms SHOULD preserve tool-invocation-bearing assistant messages when the LM capability does.
 - Algorithms MAY depend on an explicit orchestration capability or inline equivalent batching/fanout
@@ -454,7 +459,7 @@ Provider-native generation arguments are OPTIONAL parts of the extensible execut
 
 Implementations MAY support arguments such as:
 
-- `max_tokens`
+- maximum output length
 - `temperature`
 - tool-availability hints
 - tool-selection hints
@@ -581,8 +586,9 @@ Required semantics:
 
 Candidate availability policy for stable candidate-set algorithms:
 
-- If one or more candidate generations succeed, the algorithm MUST continue using the successful
-  subset.
+- Implementations MUST document whether candidate-generation failure causes:
+  - fail-fast failure of the full logical ITS execution, or
+  - continued execution over the successful subset
 - If zero candidate generations succeed, the algorithm MUST fail with `insufficient_candidates` or
   equivalent.
 - Implementations MUST NOT synthesize placeholder candidates for failed generations.
@@ -806,7 +812,7 @@ Minimum OpenAI-compatible response shape:
 
 #### 9.3.1 Role
 
-A direct gateway is a standalone service that terminates client requests and applies ITS directly.
+A direct gateway is a standalone service that accepts and handles client requests directly with ITS.
 
 #### 9.3.2 Activation Model
 
@@ -849,7 +855,7 @@ A direct gateway SHOULD accept:
 
 A direct gateway MAY accept:
 
-- generation-control fields such as maximum token count or temperature
+- generation-control fields such as maximum output length or temperature
 - tool-availability hints
 - tool-selection hints
 - `stream`
@@ -1188,8 +1194,10 @@ stable mapping from its error surface to these concepts.
 
 Stable candidate-set algorithms MUST follow these rules:
 
-- If one or more candidate generations succeed, proceed using the successful subset only.
+- If one or more candidate generations fail, follow the documented candidate-availability policy.
 - If zero candidate generations succeed, fail with `insufficient_candidates` or equivalent.
+- If the implementation chooses successful-subset continuation, proceed using only the successful
+  subset.
 - Synthetic filler candidates are forbidden.
 
 Scoring-related partial failures:

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,1389 @@
+# its_hub Repository Specification
+
+Status: Draft v1 (language-agnostic repository contract)
+
+Purpose: Define the repository-level contract for `its_hub` as a library-first system for
+inference-time scaling (ITS) of LLMs, including:
+
+- the core Python package and its abstractions
+- built-in algorithms, model adapters, and reward-model integrations
+- the repository's benchmarking and example tooling
+- the gateway/serving contract used by both direct-service and intercepting implementations
+
+This specification is intentionally broader than the gateway. The gateway is one part of the
+repository and is specified here as a subsystem.
+
+## Normative Language
+
+The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and
+`OPTIONAL` in this document are to be interpreted as described in RFC 2119.
+
+`Implementation-defined` means the behavior is part of the implementation contract, but this
+specification does not prescribe one universal policy. Implementations MUST document the selected
+behavior.
+
+## 1. Problem Statement
+
+`its_hub` is a repository for runtime techniques that improve LLM outputs by spending more compute
+during inference rather than by retraining the model. It is especially oriented toward:
+
+- mathematical reasoning
+- multi-step reasoning
+- tool-calling reliability
+- benchmarking the quality/computation trade-off across ITS algorithms
+
+The repository is not only a Python library. It also contains:
+
+- provider adapters for OpenAI-compatible and LiteLLM-backed inference
+- reward-model integrations
+- a serving/gateway layer for OpenAI-compatible chat completions
+- benchmark and example scripts
+- repository documentation describing installation, usage, and development workflows
+
+Important boundary:
+
+- `its_hub` is a runtime orchestration library and accompanying tooling.
+- It is not a training framework.
+- It does not require one model vendor, one reward-model runtime, or one gateway framework.
+- The repository's public behavior is defined by abstractions and contracts, not by one specific web
+  stack or proxy runtime.
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+- Define clean interfaces between language models, ITS algorithms, and reward models.
+- Support both string-prompt and chat-message inputs, including tool-calling flows.
+- Support sync and async execution from the same conceptual algorithm surface.
+- Preserve OpenAI-compatible message structures where possible.
+- Support multiple ITS strategies with a shared `budget` concept.
+- Support both outcome-based and process-based scoring.
+- Expose an OpenAI-compatible gateway contract for serving ITS.
+- Provide benchmarking and example tooling for math-focused evaluation.
+- Keep the repository portable enough that future implementations in other languages can follow the
+  same conceptual contract.
+
+### 2.2 Non-Goals
+
+- Defining the full OpenAI Chat Completions protocol.
+- Standardizing one deployment topology for gateway/service implementations.
+- Requiring streaming ITS responses in this version.
+- Requiring one persistent configuration store or control plane.
+- Requiring all exported classes to be equally stable or production-ready.
+- Defining training, fine-tuning, or model-hosting internals.
+
+## 3. Repository Overview
+
+### 3.1 Deliverables
+
+The repository contains six main deliverables:
+
+1. `Core Package`
+   - The `its_hub` Python package.
+   - Defines abstractions, implementations, and utilities for inference-time scaling.
+
+2. `Integrations`
+   - Reward-model adapters.
+   - Gateway/serving implementations and related architecture.
+
+3. `Scripts`
+   - Benchmark tooling.
+   - Example scripts for manual evaluation and local testing.
+
+4. `Documentation`
+   - Installation, quick-start, algorithm, gateway, benchmarking, and development guides.
+
+5. `Tests`
+   - Unit and integration-style tests for algorithms, language models, tooling, and wrappers.
+
+6. `Packaging Metadata`
+   - Project metadata, extras, CLI entrypoints, and dependency profiles.
+
+### 3.2 Canonical Repository Layout
+
+The repository is organized around these top-level surfaces:
+
+```text
+its_hub/
+  base.py
+  types.py
+  lms.py
+  utils.py
+  error_handling.py
+  algorithms/
+  integration/
+docs/
+scripts/
+tests/
+README.md
+pyproject.toml
+SPEC.md
+```
+
+Logical responsibilities:
+
+- `its_hub/base.py`
+  - abstract interfaces
+- `its_hub/types.py`
+  - normalized message and tool-call types
+- `its_hub/lms.py`
+  - language-model adapters and stepwise generation helpers
+- `its_hub/algorithms/`
+  - ITS algorithm implementations
+- `its_hub/integration/`
+  - reward-model integration and serving/gateway integration
+- `its_hub/utils.py`
+  - prompts and helper utilities
+- `docs/`
+  - user-facing documentation
+- `scripts/`
+  - research, benchmarking, and example entrypoints
+- `tests/`
+  - validation of the above surfaces
+
+### 3.3 Distribution and Installation Profiles
+
+The repository defines multiple installation profiles through package extras.
+
+Current profiles:
+
+- `core`
+  - installed by `pip install its_hub`
+  - intended for self-consistency, best-of-n, OpenAI-compatible inference, and LLM-judge usage
+- `prm`
+  - installed by `pip install its_hub[prm]`
+  - adds process-reward-model dependencies for stepwise reasoning algorithms
+- `cloud`
+  - installed by `pip install its_hub[cloud]`
+  - adds cloud-provider SDK support such as Bedrock and Vertex AI
+- `research`
+  - installed by `pip install its_hub[research]`
+  - adds benchmark/evaluation dependencies
+- `dev`
+  - installed by `pip install -e ".[dev]"` or `uv sync --extra dev`
+  - adds testing, linting, notebook, and contributor tooling
+
+### 3.4 CLI Entrypoints
+
+The repository currently defines this package CLI entrypoint in the main branch:
+
+- `its-iaas`
+  - starts the direct HTTP gateway/service profile
+
+Additional gateway entrypoints MAY exist in other implementation profiles or active development
+branches. This specification defines the gateway contract independently of one entrypoint name.
+
+## 4. System Overview
+
+### 4.1 Main Components
+
+1. `Message Model`
+   - Represents prompts, chat history, tool calls, and normalized conversation batches.
+
+2. `Language Model Adapter Layer`
+   - Adapts downstream LLM APIs to a shared generation interface.
+
+3. `ITS Algorithm Layer`
+   - Implements sampling, voting, search, and selection logic.
+
+4. `Reward Layer`
+   - Scores either final answers or intermediate reasoning steps.
+
+5. `Integration Layer`
+   - Bridges the core package to external systems such as reward runtimes and gateways.
+
+6. `Gateway Layer`
+   - Exposes ITS as an OpenAI-compatible serving surface.
+
+7. `Research / Tooling Layer`
+   - Benchmarks algorithms on standardized datasets and provides example scripts.
+
+8. `Documentation and Quality Layer`
+   - Explains usage, tests behavior, and enforces repository quality.
+
+### 4.2 Abstraction Levels
+
+The repository is easiest to reason about when kept in these layers:
+
+1. `Input Normalization Layer`
+   - `ChatMessage`, `ChatMessages`
+
+2. `Provider Layer`
+   - `AbstractLanguageModel` and concrete model adapters
+
+3. `Algorithm Layer`
+   - `AbstractScalingAlgorithm`, `AbstractScalingResult`, concrete ITS implementations
+
+4. `Scoring Layer`
+   - `AbstractOutcomeRewardModel`, `AbstractProcessRewardModel`, concrete adapters
+
+5. `Serving Layer`
+   - configuration and transport surfaces that turn ITS into an API
+
+6. `Evaluation Layer`
+   - benchmark datasets, evaluation logic, and research scripts
+
+### 4.3 Portability Boundary
+
+The repository is implemented in Python, but the conceptual architecture is portable because:
+
+- algorithms depend on abstract model and reward interfaces
+- chat/message normalization is explicit
+- the gateway is described in terms of transport-agnostic execution config
+- the benchmark layer depends on algorithm behavior rather than one server implementation
+
+## 5. Core Domain Model
+
+### 5.1 Message Model
+
+#### 5.1.1 ChatMessage
+
+`ChatMessage` is the normalized conversation unit used across the repository.
+
+Fields:
+
+- `role` (enum/string)
+  - current supported values:
+    - `system`
+    - `user`
+    - `assistant`
+    - `tool`
+- `content` (string, list of content parts, or null)
+  - string for plain text
+  - list of dicts for OpenAI-style multimodal content
+  - null when the message is represented primarily by tool calls
+- `tool_calls` (OPTIONAL list of dicts)
+- `tool_call_id` (OPTIONAL string)
+
+Semantics:
+
+- The repository MUST preserve tool calls in assistant messages when they are part of the selected
+  response.
+- Multimodal content is represented structurally, but most current reasoning paths extract and use
+  text content only.
+
+#### 5.1.2 ChatMessages
+
+`ChatMessages` is a wrapper that normalizes either:
+
+- a string prompt
+- a list of `ChatMessage`
+- another `ChatMessages`
+
+into one internal representation.
+
+Required behaviors:
+
+- `from_prompt_or_messages(...)`
+  - normalize strings, message lists, or wrapper instances
+- `to_prompt()`
+  - produce a string representation of the conversation
+- `to_chat_messages()`
+  - produce a list of normalized messages
+- `to_batch(size)`
+  - duplicate one logical request into `size` parallel candidate requests
+
+Important compatibility note:
+
+- String prompts are normalized as a single `user` message.
+- `to_prompt()` exists for compatibility and utility flows. It is not the preferred representation
+  for chat-native or tool-native execution paths.
+
+#### 5.1.3 Text Extraction
+
+For multimodal message content:
+
+- text parts are concatenated for text-only reasoning paths
+- image parts may be ignored by text-only internal flows
+- unsupported content part types MAY raise an error
+
+This behavior is current repository behavior, not a universal multimodal standard.
+
+### 5.2 Language Model Interfaces
+
+#### 5.2.1 AbstractLanguageModel
+
+`AbstractLanguageModel` is the base contract for downstream model adapters.
+
+Required methods:
+
+- `agenerate(messages, stop=None, ...)`
+- `generate(messages, stop=None, ...)`
+
+Optional method:
+
+- `evaluate(prompt, generation)`
+
+Expected semantics:
+
+- input may be one conversation or a batch of conversations
+- output may be one response or a list of responses
+- the response shape SHOULD preserve OpenAI-compatible assistant message structure when available
+
+### 5.3 Scaling Algorithm Interfaces
+
+#### 5.3.1 AbstractScalingAlgorithm
+
+`AbstractScalingAlgorithm` is the base contract for ITS algorithms.
+
+Primary method:
+
+- `ainfer(lm, prompt_or_messages, budget, return_response_only=True, tools=None, tool_choice=None)`
+
+Sync wrapper:
+
+- `infer(...)`
+  - conceptually wraps the async implementation
+
+Contract:
+
+- algorithms MUST accept either string prompts or normalized chat messages
+- algorithms MUST interpret `budget` according to their documented semantics
+- algorithms MAY support tool-calling inputs by forwarding `tools` and `tool_choice`
+
+#### 5.3.2 AbstractScalingResult
+
+`AbstractScalingResult` defines the result-object surface for algorithms that return structured
+state instead of only the selected message.
+
+Required property:
+
+- `the_one`
+  - returns the selected response
+
+### 5.4 Reward Model Interfaces
+
+#### 5.4.1 AbstractOutcomeRewardModel
+
+Scores final responses.
+
+Required methods:
+
+- `ascore(prompt_or_messages, response)`
+- `score(prompt_or_messages, response)`
+
+#### 5.4.2 AbstractProcessRewardModel
+
+Scores intermediate reasoning steps.
+
+Required methods:
+
+- `ascore(prompt_or_messages, steps)`
+- `score(prompt_or_messages, steps)`
+
+### 5.5 StepGeneration
+
+`StepGeneration` is the repository's step-wise generation helper for algorithms that build or score
+responses incrementally.
+
+Key fields:
+
+- `max_steps`
+- `step_token` or `tokens_per_step`
+- `stop_token`
+- `temperature`
+- `include_stop_str_in_output`
+- `temperature_switch`
+
+Invariants:
+
+- exactly one of `step_token` and `tokens_per_step` MUST be set
+- `tokens_per_step` MUST be positive when used
+
+Behavior:
+
+- generates one or many next-step continuations
+- reconstructs current assistant reasoning state from prior steps
+- stops when `max_steps` or `stop_token` conditions are met
+
+## 6. Core Library Contracts
+
+### 6.1 Sync and Async Semantics
+
+The repository is async-first conceptually.
+
+Required behavior:
+
+- concrete implementations SHOULD treat async methods as the primary execution path
+- sync methods MAY be thin wrappers around async implementations
+
+Caller guidance:
+
+- async callers SHOULD use async methods directly
+- sync wrappers are a convenience layer and may rely on `asyncio.run()`
+
+### 6.2 Input Flexibility
+
+Algorithms and reward adapters MUST accept:
+
+- string prompts
+- `list[ChatMessage]`
+- `ChatMessages`
+
+Normalization MUST occur before algorithm-specific logic.
+
+### 6.3 Tool-Calling Preservation
+
+When assistant messages include tool calls:
+
+- tool calls MUST remain attached to message objects during candidate generation and selection
+- algorithms MUST NOT flatten tool calls into plain text unless that behavior is explicitly part of
+  a documented projection or comparison strategy
+
+### 6.4 Provider Adapter Expectations
+
+A concrete language-model adapter SHOULD provide:
+
+- batched generation
+- retry handling for transient provider failures
+- concurrency control where supported
+- propagation of request features such as:
+  - stop conditions
+  - max tokens
+  - temperature
+  - tools
+  - tool choice
+
+### 6.5 Error Handling Boundary
+
+Provider adapters are responsible for:
+
+- transport interaction with downstream providers
+- retry classification where implemented
+- mapping malformed or non-success upstream behavior into repository-level errors
+
+Algorithms are responsible for:
+
+- handling candidate sets and selection logic
+- surfacing algorithm-level failures when valid selection is impossible
+
+## 7. Built-in Library Components
+
+### 7.1 Language Model Implementations
+
+#### 7.1.1 OpenAICompatibleLanguageModel
+
+Primary documented provider adapter for:
+
+- OpenAI-compatible APIs
+- local vLLM-style chat-completion endpoints
+
+Current repository behaviors include:
+
+- OpenAI-compatible request shaping
+- support for system prompts
+- retry/backoff and error parsing
+- concurrency control for async generation
+- support for tool definitions and tool choice
+- configurable SSL verification behavior
+
+#### 7.1.2 LiteLLMLanguageModel
+
+Adapter for provider access through LiteLLM.
+
+Purpose:
+
+- unify multiple downstream providers behind a common generation surface
+- enable cloud/provider routing without changing algorithm code
+
+#### 7.1.3 Other Model Classes
+
+`its_hub/lms.py` also contains additional classes such as:
+
+- `LocalVLLMLanguageModel`
+- `TransformersLanguageModel`
+
+Current note:
+
+- the repository's primary documented and actively described model surfaces are
+  `OpenAICompatibleLanguageModel` and `LiteLLMLanguageModel`
+- other classes MAY be experimental, utility, or less central to the public contract
+
+### 7.2 Utility Prompts and Helpers
+
+The repository includes prompt and helper utilities in `its_hub/utils.py`.
+
+Important current examples:
+
+- `SAL_STEP_BY_STEP_SYSTEM_PROMPT`
+- `QWEN_SYSTEM_PROMPT`
+
+These are repository utilities for reasoning workflows, especially math tasks. They are not protocol
+requirements for algorithm correctness.
+
+### 7.3 Reward Model Integrations
+
+#### 7.3.1 LocalVllmProcessRewardModel
+
+Adapter around `reward_hub` process-reward-model support.
+
+Purpose:
+
+- score step-wise reasoning trajectories
+- support algorithms such as beam search and particle filtering
+
+Current dependencies:
+
+- local reward runtime via `reward_hub`
+- device selection
+- aggregation method selection
+
+#### 7.3.2 LLMJudgeRewardModel
+
+Adapter around `reward_hub` LLM-judge support.
+
+Purpose:
+
+- score complete candidate responses
+- enable best-of-n without a local process reward model
+
+Current judge concepts:
+
+- `pointwise`
+- `groupwise`
+
+### 7.4 Algorithm Implementations
+
+#### 7.4.1 SelfConsistency
+
+Behavior:
+
+- generate multiple candidate responses
+- project each candidate into a comparison space
+- select the most common projection, with implementation-defined tie-breaking
+
+Supported comparison modes:
+
+- default exact-content projection
+- regex-based projection
+- tool-call voting modes:
+  - `tool_name`
+  - `tool_args`
+  - `tool_hierarchical`
+
+Current use cases:
+
+- tool-calling consistency
+- math answers with structured final-answer extraction
+
+#### 7.4.2 BestOfN
+
+Behavior:
+
+- generate `N` candidates
+- score them with an outcome reward model or LLM judge
+- select the highest-scoring candidate
+
+Current use cases:
+
+- quality-focused selection with a judge/scorer
+- cloud-API scenarios that do not require a local PRM
+
+#### 7.4.3 BeamSearch
+
+Behavior:
+
+- perform step-wise generation with fixed beam width
+- score partial trajectories using a process reward model
+
+Current use cases:
+
+- structured multi-step reasoning
+- problems where partial trajectories are meaningful and scoreable
+
+#### 7.4.4 ParticleGibbs Family
+
+The repository includes a particle-based family in `its_hub/algorithms/particle_gibbs.py`.
+
+Important public classes:
+
+- `ParticleGibbs`
+- `ParticleFiltering`
+- `EntropicParticleFiltering`
+
+Shared conceptual behavior:
+
+- maintain multiple reasoning trajectories
+- resample or retain trajectories according to algorithm-specific selection rules
+- use step-wise scoring for long-horizon reasoning
+
+Current emphasis in docs and examples is on:
+
+- `ParticleFiltering`
+- `EntropicParticleFiltering`
+
+#### 7.4.5 PlanningWrapper
+
+`PlanningWrapper` is a repository utility that adds a planning phase to another ITS algorithm.
+
+Behavior:
+
+- use one generation to propose several approaches
+- allocate remaining budget across approaches
+- run the wrapped algorithm for each approach
+- select the best approach/result using result-level heuristics
+
+Current note:
+
+- this is part of the repository surface
+- it is a wrapper utility rather than one of the foundational ITS primitives
+
+### 7.5 Result Object Semantics
+
+Algorithm result objects generally:
+
+- preserve candidate responses or trajectories
+- expose the selected response through `the_one`
+- MAY include algorithm-specific fields such as:
+  - response counts
+  - scores
+  - selected index
+  - path/particle state
+  - planning metadata
+
+### 7.6 Experimental or Incomplete Surfaces
+
+`its_hub/algorithms/__init__.py` currently exports `MetropolisHastings`, but the implementation is
+not yet complete and raises `NotImplementedError`.
+
+Therefore:
+
+- it is part of the repository surface area
+- it is not a required stable algorithm contract in this specification version
+
+## 8. Budget Semantics
+
+`budget` is the repository-wide compute control for one ITS execution.
+
+Current semantics by algorithm:
+
+- `SelfConsistency`
+  - number of parallel generations to compare
+- `BestOfN`
+  - number of candidate responses to score
+- `BeamSearch`
+  - total search effort; commonly interpreted as `beam_width * effective_depth`
+- `ParticleFiltering`
+  - number of particles maintained
+- `EntropicParticleFiltering`
+  - number of particles maintained
+- `PlanningWrapper`
+  - spends one unit on planning, then distributes the remainder across approaches
+
+Important note:
+
+- `budget` is shared vocabulary, not a universal identical implementation detail.
+- Each algorithm MUST document how it interprets `budget`.
+
+## 9. Integration Layer
+
+### 9.1 reward_hub Integration Contract
+
+The repository integrates with `reward_hub` rather than re-implementing all reward-model logic.
+
+Required repository behavior:
+
+- adapt reward-hub interfaces to the abstract outcome/process reward model contracts
+- normalize prompt/message inputs into the format expected by reward-hub clients
+- preserve algorithm-facing interfaces regardless of reward-hub internals
+
+### 9.2 Serving and Gateway Integration
+
+The repository includes a serving layer that turns ITS into an OpenAI-compatible chat-completions
+surface.
+
+This serving layer is specified in Section 10 as a subsystem of the repository, not as the entire
+repository contract.
+
+## 10. Gateway Specification
+
+### 10.1 Gateway Role
+
+The gateway exposes inference-time scaling behind an OpenAI-compatible chat-completions interface.
+
+It does more than proxy one upstream request. It may:
+
+- make multiple downstream model calls
+- run voting or reward-based selection
+- aggregate usage across multiple calls
+- return either a selected final response or pass the original request through
+
+### 10.2 Gateway Profiles
+
+This specification defines two gateway profiles.
+
+#### 10.2.1 Configured Gateway Service Profile
+
+A direct HTTP service that:
+
+- exposes OpenAI-compatible endpoints itself
+- accepts runtime ITS configuration through a management endpoint
+- stores effective policy in process-local state
+- applies ITS directly inside `/v1/chat/completions`
+
+This profile matches the current direct-service implementation style.
+
+#### 10.2.2 Intercepting Gateway Profile
+
+A proxy-integrated or callback-based service that:
+
+- inspects requests headed to an upstream OpenAI-compatible chat endpoint
+- decides per request whether ITS should be applied
+- either returns a final ITS response immediately or lets the original request continue upstream
+
+This profile matches the current proxy/ext-proc implementation style.
+
+### 10.3 Gateway Components
+
+1. `Transport Adapter`
+   - HTTP handler, proxy hook, ext-proc handler, or equivalent
+
+2. `Configuration Resolver`
+   - resolves profile-specific inputs into one normalized execution config
+
+3. `Model / Provider Registry`
+   - OPTIONAL depending on profile
+   - stores long-lived provider registrations
+
+4. `ITS Orchestrator`
+   - executes one normalized ITS request
+
+5. `Algorithm Registry`
+   - resolves algorithm names to implementations
+
+6. `Provider Adapter`
+   - performs downstream OpenAI-compatible or provider-backed calls
+
+7. `Response Shaper`
+   - emits an OpenAI-compatible response envelope
+
+8. `Observability`
+   - logs and OPTIONAL metrics/traces
+
+### 10.4 Gateway ExecutionConfig
+
+The gateway MUST normalize serving inputs into a request-scoped `ExecutionConfig`.
+
+Fields:
+
+- `model` (string)
+- `algorithm` (string)
+- `budget` (integer, `1..1000`)
+- `provider` (object)
+  - `kind`
+  - `endpoint`
+  - `api_key`
+  - `extra_args` (OPTIONAL)
+- `algorithm_config` (object or null)
+- `reward_config` (object or null)
+- `response_mode`
+  - `selected_message_only`
+  - `selected_message_with_metadata`
+
+### 10.5 Base Protocol Contract
+
+The OpenAI-compatible Chat Completions API is the source of truth for the base wire schema.
+
+This repository specification defines only the ITS-related extensions and handling rules.
+
+#### 10.5.1 Required ITS Response Shape
+
+When the gateway returns an ITS-generated response, it MUST be OpenAI-compatible and include:
+
+- `id`
+- `object = "chat.completion"`
+- `created`
+- `model`
+- `choices`
+  - `choices[0].message` is the selected assistant message
+  - `choices[0].finish_reason` is implementation-defined but typically `stop`
+- `usage`
+
+Tool-call preservation:
+
+- if the selected response is a tool call, the tool-call structure MUST remain present in
+  `choices[0].message`
+
+#### 10.5.2 Gateway Extensions
+
+Current standardized repository extensions:
+
+- configured-service request body fields:
+  - `budget`
+  - `return_response_only`
+- configured-service response body field:
+  - `metadata`
+- intercepting-profile request headers:
+  - `X-ITS-Budget`
+  - `X-ITS-Endpoint`
+  - `X-ITS-API-Key` (OPTIONAL)
+- intercepting-profile diagnostic response header:
+  - `x-its-applied: true` (OPTIONAL)
+
+#### 10.5.3 Streaming
+
+This specification version standardizes non-streaming ITS behavior only.
+
+- handling of `stream=true` is implementation-defined
+- implementations MUST document whether they reject, ignore, downgrade, or pass through streaming
+  requests
+
+### 10.6 Configured Gateway Service Profile
+
+#### 10.6.1 Required Endpoints
+
+Required endpoints:
+
+1. `POST /configure`
+2. `POST /v1/chat/completions`
+
+Optional but expected endpoint:
+
+3. `GET /v1/models`
+
+#### 10.6.2 Configuration Payload
+
+The configuration surface MUST support these core fields:
+
+- `provider`
+- `endpoint`
+- `api_key`
+- `model`
+- `alg`
+
+It MAY also support algorithm-specific fields such as:
+
+- self-consistency:
+  - `regex_patterns`
+  - `tool_vote`
+  - `exclude_tool_args`
+- step-wise / PRM algorithms:
+  - `step_token`
+  - `stop_token`
+  - `rm_name`
+  - `rm_device`
+  - `rm_agg_method`
+- LLM judge:
+  - `judge_model`
+  - `judge_base_url`
+  - `judge_criterion`
+  - `judge_mode`
+  - `judge_top_n`
+  - `judge_api_key`
+  - `judge_temperature`
+  - `judge_max_tokens`
+  - `enable_judge_logging`
+- provider-specific:
+  - `extra_args`
+
+#### 10.6.3 Effective Behavior
+
+On successful configuration:
+
+- the gateway registers or updates a model/provider mapping
+- the gateway replaces the active ITS policy for subsequent requests
+- the effective configuration is local to the process and not required to persist across restart
+
+Important current repository constraint:
+
+- the configured-service profile maintains a model registry but only one active ITS algorithm policy
+  at a time
+
+#### 10.6.4 Request Resolution
+
+For `POST /v1/chat/completions`, execution config is resolved from:
+
+1. request body:
+   - `model`
+   - `messages`
+   - `budget`
+   - `tools`
+   - `tool_choice`
+   - `return_response_only`
+2. active gateway policy:
+   - algorithm
+   - provider mapping
+   - reward config
+   - algorithm-specific config
+
+Expected error classes:
+
+- unknown model
+- missing active service configuration
+- invalid `budget`
+- empty `messages`
+
+### 10.7 Intercepting Gateway Profile
+
+#### 10.7.1 Interception Target
+
+The intercepting profile MUST at minimum recognize:
+
+- `POST /v1/chat/completions`
+
+Requests to other paths MAY be passed through untouched.
+
+#### 10.7.2 ITS Activation Headers
+
+In this specification version, ITS activation is driven by:
+
+- `X-ITS-Budget`
+- `X-ITS-Endpoint`
+- `X-ITS-API-Key` (OPTIONAL)
+
+Current note:
+
+- per-request algorithm selection is not standardized in the intercepting profile in this version
+- current prototype behavior uses a fixed/default self-consistency policy once ITS is activated
+
+#### 10.7.3 Request Resolution
+
+For an intercepted request:
+
+1. parse headers
+2. if required ITS headers are absent or invalid -> `pass_through`
+3. otherwise parse the request body
+4. read:
+   - `model`
+   - `messages`
+   - `tools`
+   - `tool_choice`
+5. resolve the profile's default/fixed algorithm policy
+6. build `ExecutionConfig`
+
+If `model` is absent from the request body, the gateway MAY:
+
+- pass through
+- or return an explicit error
+
+The implementation MUST document which behavior it chooses.
+
+#### 10.7.4 Pass-Through and Short-Circuit Semantics
+
+The intercepting profile supports two outcomes:
+
+1. `pass_through`
+   - the original request continues upstream
+
+2. `its_applied`
+   - the gateway runs ITS
+   - the gateway returns an OpenAI-compatible response directly
+   - the original upstream call is short-circuited
+
+### 10.8 Gateway Orchestration Contract
+
+For one ITS-applied request, the gateway orchestrator MUST:
+
+1. validate the normalized execution config
+2. build or reuse a downstream provider client
+3. build or reuse any required reward/judge client
+4. normalize messages into the algorithm's expected input representation
+5. run the selected algorithm with:
+   - provider client
+   - messages
+   - budget
+   - tools
+   - tool choice
+6. select the final assistant message
+7. aggregate or synthesize usage
+8. shape the final OpenAI-compatible response
+
+### 10.9 Usage Accounting
+
+Current repository family supports two usage-accounting modes:
+
+1. `aggregated_actual`
+   - usage reflects the sum of all downstream calls used by ITS
+
+2. `placeholder`
+   - usage fields are present but populated with placeholder values such as zero
+
+Implementations MUST document which mode they use.
+
+### 10.10 Gateway Failure Model
+
+Failure classes:
+
+1. `Request Validation Failures`
+   - empty `messages`
+   - invalid `budget`
+   - missing `model`
+
+2. `Gateway Configuration Failures`
+   - unknown model registration
+   - missing active policy
+   - unsupported algorithm
+
+3. `Provider Failures`
+   - transport failure
+   - non-success upstream status
+   - malformed payload
+
+4. `Reward Failures`
+   - missing reward runtime
+   - judge call failure
+   - scorer integration failure
+
+5. `Algorithm Execution Failures`
+   - selection failure
+   - invalid candidate set after filtering
+
+Configured-service profile:
+
+- SHOULD return explicit errors for invalid or unconfigured requests
+
+Intercepting profile:
+
+- MUST support pass-through when ITS is not activated
+- MUST document whether activated ITS failures pass through, return explicit errors, or vary by
+  error class
+
+## 11. Research, Benchmarking, and Example Tooling
+
+### 11.1 Benchmark Script
+
+`scripts/benchmark.py` is the repository's primary research/benchmark entrypoint.
+
+Current responsibilities:
+
+- load benchmark datasets
+- instantiate a selected algorithm and model adapter
+- run across one or more budgets
+- optionally evaluate results
+- save and display outputs
+
+Current benchmark datasets include:
+
+- MATH-500
+- AIME-2024
+
+Current benchmark-facing algorithm set includes:
+
+- self-consistency
+- beam-search
+- particle-filtering
+- entropic-particle-filtering
+
+### 11.2 Example Script
+
+`scripts/test_math_example.py` is a runnable example showing:
+
+- local OpenAI-compatible/vLLM inference
+- step generation
+- a process reward model
+- particle filtering on math prompts
+
+### 11.3 Research Dependencies
+
+The `research` extra adds repository tooling for:
+
+- dataset loading
+- answer verification
+- visualization and result analysis
+
+## 12. Documentation Surface
+
+### 12.1 Documentation Paths
+
+The repository's documentation surface includes:
+
+- `README.md`
+  - top-level orientation
+- `docs/installation.md`
+  - installation profiles and dependency expectations
+- `docs/quick-start.md`
+  - common usage flows
+- `docs/algorithms.md`
+  - algorithm-level user guidance
+- `docs/benchmarking.md`
+  - research and evaluation workflow
+- `docs/iaas-service.md`
+  - gateway/service usage
+- `docs/development.md`
+  - contributor guidance
+- `docs/PLANNING_WRAPPER.md`
+  - planning-wrapper usage and behavior
+
+### 12.2 Documentation Contract
+
+Documentation is descriptive and user-facing.
+
+This specification is normative for the repository contract when the docs and implementation differ
+at a conceptual level, but implementation details remain the ultimate source of truth for exact
+runtime behavior.
+
+## 13. Development, Testing, and Quality
+
+### 13.1 Development Setup
+
+The repository supports:
+
+- `uv sync --extra dev`
+- `pip install -e ".[dev]"`
+
+Python version expectations:
+
+- Python `>= 3.10`
+
+### 13.2 Test Surface
+
+Tests live under `tests/` and cover core repository behaviors such as:
+
+- algorithms
+- language-model adapters
+- tool-calling behavior
+- planning wrapper
+- reward-model integration
+- gateway/service behavior
+
+### 13.3 Code Quality
+
+Current repository quality tooling:
+
+- `pytest`
+- `ruff check`
+- `ruff format`
+
+### 13.4 Notebooks and Examples
+
+Development and research workflows MAY include notebooks and synced notebook artifacts. Their exact
+presence is repository-version-dependent and not part of the core conformance contract.
+
+## 14. Test and Validation Matrix
+
+A conforming repository implementation or faithful port SHOULD include tests for the behaviors below.
+
+### 14.1 Message and Input Model
+
+- string prompts normalize into a single `user` message
+- chat histories preserve role/content/tool-call fields
+- multimodal text extraction behaves consistently
+- tool-call-bearing assistant messages preserve tool-call structures
+
+### 14.2 Provider Adapters
+
+- OpenAI-compatible request shaping is valid
+- batched generation returns one response per candidate
+- tool definitions and tool choice are forwarded correctly
+- transient provider failures are handled according to documented retry policy
+
+### 14.3 Algorithms
+
+- self-consistency selects from repeated candidates correctly
+- tool-voting modes behave as documented
+- best-of-n uses outcome scoring correctly
+- beam search uses step generation and beam width correctly
+- particle-filtering family handles particle budget semantics correctly
+- planning wrapper allocates budget across approaches correctly
+- exported incomplete algorithms are either clearly disabled or tested as intentionally unimplemented
+
+### 14.4 Reward Integrations
+
+- outcome reward adapters accept prompt/message inputs
+- process reward adapters accept step-wise inputs
+- reward-hub integration preserves expected score shapes
+
+### 14.5 Gateway Profiles
+
+- configured-service profile:
+  - `/configure` applies the active policy
+  - `/v1/chat/completions` resolves request + policy into execution config
+  - tool-call responses are preserved
+  - error cases behave as documented
+- intercepting profile:
+  - requests without ITS activation pass through
+  - requests with ITS activation may be short-circuited
+  - missing-model and ITS-failure fallback behavior matches documentation
+
+### 14.6 Benchmark and Tooling
+
+- benchmark dataset loading succeeds for supported datasets
+- benchmark CLI parses budgets and algorithm names correctly
+- example scripts instantiate documented components correctly
+
+## 15. Implementation Checklist
+
+### 15.1 Core Repository Checklist
+
+- message normalization layer
+- abstract language-model contract
+- abstract ITS algorithm contract
+- abstract reward-model contracts
+- step-wise generation helper
+- at least one concrete model adapter
+- at least one concrete ITS algorithm
+- at least one reward-model integration
+- docs and tests for supported surfaces
+
+### 15.2 Current Repository-Family Checklist
+
+- `OpenAICompatibleLanguageModel`
+- `LiteLLMLanguageModel`
+- `SelfConsistency`
+- `BestOfN`
+- `BeamSearch`
+- particle-filtering family
+- `reward_hub` integration
+- direct-service gateway profile
+- benchmark and example scripts
+
+### 15.3 Gateway Checklist
+
+- normalized gateway execution config
+- OpenAI-compatible response shaping
+- configured-service profile support
+- intercepting-profile contract support if that profile is implemented
+- documented streaming behavior
+- documented usage-accounting mode
+- documented ITS failure behavior
+
+## 16. Reference Algorithms (Language-Agnostic)
+
+### 16.1 Generic ITS Execution
+
+```text
+function run_its_request(lm, algorithm, prompt_or_messages, budget, tools, tool_choice):
+  normalized_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
+
+  result = algorithm.ainfer(
+    lm=lm,
+    prompt_or_messages=normalized_messages,
+    budget=budget,
+    return_response_only=false,
+    tools=tools,
+    tool_choice=tool_choice
+  )
+
+  return result.the_one
+```
+
+### 16.2 Configured-Service Gateway Handling
+
+```text
+function handle_configured_chat_completion(request):
+  validate request.messages is non-empty
+  validate request.budget in 1..1000
+
+  if active_gateway_policy is missing:
+    return error("service_not_configured")
+
+  provider_config = active_gateway_policy.registered_models[request.model]
+  if provider_config is missing:
+    return error("unknown_model")
+
+  execution_config = {
+    model: request.model,
+    algorithm: active_gateway_policy.active_algorithm,
+    budget: request.budget,
+    provider: provider_config,
+    algorithm_config: active_gateway_policy.active_algorithm_config,
+    reward_config: active_gateway_policy.active_reward_config,
+    response_mode: request.return_response_only
+      ? "selected_message_only"
+      : "selected_message_with_metadata"
+  }
+
+  result = orchestrator.run(
+    execution_config,
+    messages=request.messages,
+    tools=request.tools,
+    tool_choice=request.tool_choice
+  )
+
+  return shape_openai_response(result)
+```
+
+### 16.3 Intercepting Gateway Handling
+
+```text
+function handle_intercepted_chat_completion(request_path, headers, body):
+  if request_path is not "/v1/chat/completions":
+    return pass_through()
+
+  budget = parse_int(headers["x-its-budget"])
+  endpoint = headers["x-its-endpoint"]
+  api_key = headers["x-its-api-key"]
+
+  if budget invalid or endpoint missing:
+    return pass_through()
+
+  request = parse_json(body)
+  if request.model missing:
+    return documented_fallback_for_missing_model()
+
+  execution_config = {
+    model: request.model,
+    algorithm: interceptor_default_algorithm,
+    budget: budget,
+    provider: {
+      kind: interceptor_provider_kind,
+      endpoint: endpoint,
+      api_key: api_key
+    },
+    algorithm_config: interceptor_algorithm_config,
+    reward_config: interceptor_reward_config,
+    response_mode: "selected_message_only"
+  }
+
+  result = orchestrator.run(
+    execution_config,
+    messages=request.messages,
+    tools=request.tools,
+    tool_choice=request.tool_choice
+  )
+
+  if result succeeded:
+    return immediate_openai_response(result, headers={"x-its-applied": "true"})
+
+  return documented_fallback_for_its_failure()
+```
+
+### 16.4 Benchmark Execution
+
+```text
+function run_benchmark(dataset, algorithm_name, model, budgets):
+  problems = load_dataset(dataset)
+
+  for budget in budgets:
+    algorithm = init_algorithm(algorithm_name, ...)
+
+    for problem in problems:
+      response = algorithm.infer(model, problem.prompt, budget)
+      record_result(problem, budget, response)
+
+  return aggregate_results()
+```
+
+## Appendix A. Non-Normative Side Notes
+
+These notes are intentionally outside the conformance requirements. They identify areas where the
+current repository implementation family may evolve in a future revision.
+
+1. `Gateway-only vs repository-wide scope`
+   - This `SPEC.md` is intentionally repository-wide.
+   - The gateway specification is included here as one subsystem rather than standing alone.
+
+2. `Configured-service policy granularity`
+   - The current configured-service style keeps one active ITS policy for all requests, even though
+     it also keeps a model registry.
+   - A future revision may define per-model or per-route policies.
+
+3. `Configured-service validation drift`
+   - Current configured-service examples and exact implementation validation rules are not perfectly
+     aligned in every case.
+   - This specification captures the conceptual contract rather than every accidental detail.
+
+4. `Intercepting profile algorithm selection`
+   - The current intercepting profile activates ITS through headers but does not yet standardize full
+     per-request algorithm selection.
+
+5. `Usage accounting`
+   - Current repository-family implementations differ between placeholder usage and aggregated actual
+     usage.
+
+6. `Streaming`
+   - Streaming ITS semantics are not standardized in this version.
+
+7. `Incomplete exported surfaces`
+   - Some exported classes are intentionally incomplete or experimental.
+   - Future revisions may separate stable and experimental exports more explicitly.

--- a/SPEC.md
+++ b/SPEC.md
@@ -996,121 +996,144 @@ Implementations SHOULD document guardrails for:
 - gateway backpressure behavior
 - reward-model resource limits
 
-## 12. Reference Algorithms (Language-Agnostic)
+## 12. Reference Procedures (Language-Agnostic)
 
-### 12.1 Normalize Input
+This section is intentionally non-executable. It describes reference procedures that illustrate the
+intended behavior of a conforming implementation without prescribing any programming language,
+runtime, or internal representation.
 
-```text
-function normalize_input(prompt_or_messages):
-  if input is string:
-    return [ChatMessage(role="user", content=input)]
+### 12.1 Input Normalization Procedure
 
-  if input is already normalized chat container:
-    return input.to_chat_messages()
+Input:
 
-  if input is list of messages:
-    return input
+- string prompt, or
+- normalized message list, or
+- implementation-equivalent chat container
 
-  raise invalid_input
-```
+Required procedure:
 
-### 12.2 Self-Consistency
+1. If the input is a string prompt, convert it into a single `user` message.
+2. If the input is already a normalized chat container, extract its structured message
+   representation.
+3. If the input is already a normalized message list, use it unchanged.
+4. If the input cannot be interpreted as one of the supported forms, fail with an explicit
+   input-normalization error.
 
-```text
-function self_consistency_infer(lm, prompt_or_messages, budget, projection):
-  messages = normalize_input(prompt_or_messages)
-  batch = repeat(messages, budget)
+Required outcome:
 
-  responses = orchestrated_generate(lm, batch)
+- downstream algorithm logic receives a normalized structured message sequence
 
-  projected = []
-  for response in responses:
-    projected.append(project(response))
+### 12.2 Self-Consistency Reference Procedure
 
-  counts = count_occurrences(projected)
-  winner_index = choose_most_common_with_documented_tiebreak(counts, projected)
+Input:
 
-  return {
-    selected: responses[winner_index],
-    candidates: responses,
-    metadata: {
-      counts: counts,
-      selected_index: winner_index
-    }
-  }
-```
+- normalized or normalizable conversation input
+- LM capability
+- `budget`
+- documented projection rule
 
-### 12.3 Best-of-N
+Required procedure:
 
-```text
-function best_of_n_infer(lm, reward_model, prompt_or_messages, budget):
-  messages = normalize_input(prompt_or_messages)
-  batch = repeat(messages, budget)
+1. Normalize the input conversation.
+2. Create `budget` equivalent candidate-generation requests from that normalized conversation.
+3. Generate one assistant response for each candidate-generation request.
+4. Project each candidate response into the documented comparison space.
+5. Count how many times each projected value occurs.
+6. Select the winning projected value using the documented tie-break policy.
+7. Return the candidate associated with the winning projected value as the selected response.
 
-  responses = orchestrated_generate(lm, batch)
+Recommended detailed output:
 
-  unique_responses, inverse_index = maybe_deduplicate(responses)
-  scores = score_with_outcome_model(reward_model, messages, unique_responses)
-  expanded_scores = remap(scores, inverse_index)
+- selected response
+- all candidate responses
+- vote counts
+- selected index
 
-  winner_index = index_of_max(expanded_scores)
+### 12.3 Best-of-N Reference Procedure
 
-  return {
-    selected: responses[winner_index],
-    candidates: responses,
-    metadata: {
-      scores: expanded_scores,
-      selected_index: winner_index
-    }
-  }
-```
+Input:
 
-### 12.4 Direct Gateway Request Handling
+- normalized or normalizable conversation input
+- LM capability
+- outcome reward capability
+- `budget`
 
-```text
-function handle_direct_gateway_request(request):
-  validate_gateway_configuration()
+Required procedure:
 
-  model = request.body.model
-  messages = request.body.messages
-  budget = request.body.budget
+1. Normalize the input conversation.
+2. Create `budget` equivalent candidate-generation requests from that normalized conversation.
+3. Generate one assistant response for each candidate-generation request.
+4. If the implementation documents candidate deduplication, collapse semantically equivalent
+   candidates before scoring.
+5. Score each candidate, or each unique candidate, using the outcome reward capability.
+6. If deduplication was used, map scores back onto the original candidate set.
+7. Select the candidate with the highest score using the documented tie-break policy.
+8. Return that candidate as the selected response.
 
-  result = run_selected_algorithm(
-    model=model,
-    messages=messages,
-    budget=budget,
-    tools=request.body.tools,
-    tool_choice=request.body.tool_choice
-  )
+Recommended detailed output:
 
-  return make_openai_compatible_response(result)
-```
+- selected response
+- all candidate responses
+- per-candidate scores
+- selected index
 
-### 12.5 External-Processing Gateway Request Handling
+### 12.4 Direct Gateway Reference Procedure
 
-```text
-function handle_external_processing_request(request):
-  if route_is_not_supported(request):
-    return pass_through
+Input:
 
-  activation = parse_activation_metadata(request)
-  if activation is invalid or absent:
-    return pass_through
+- OpenAI-compatible chat-completions-like request
+- direct gateway configuration
 
-  body = parse_request_body(request)
-  if body.model is missing or body.messages is missing:
-    return documented_fallback_or_error()
+Required procedure:
 
-  result = run_selected_algorithm(
-    model=body.model,
-    messages=body.messages,
-    budget=activation.budget,
-    tools=body.tools,
-    tool_choice=body.tool_choice
-  )
+1. Validate that the gateway has enough configuration to route LM requests and apply the selected
+   ITS policy.
+2. Read the client-visible request fields required by the direct gateway profile, including at
+   minimum:
+   - `model`
+   - `messages`
+   - request-body compute control equivalent to `budget`, when the profile requires explicit ITS
+     activation
+3. Forward supported optional generation fields such as tools or tool choice according to the
+   documented gateway behavior.
+4. Run the configured ITS algorithm against the normalized request.
+5. Shape the result into an OpenAI-compatible response.
 
-  return short_circuit_with_openai_compatible_response(result)
-```
+Required outcome:
+
+- one direct gateway response representing either:
+  - successful ITS application, or
+  - a documented explicit error
+
+### 12.5 External-Processing Gateway Reference Procedure
+
+Input:
+
+- intercepted upstream request
+- activation metadata
+- external-processing gateway configuration
+
+Required procedure:
+
+1. Determine whether the intercepted route is eligible for ITS handling.
+2. If the route is not eligible, choose `pass_through`.
+3. Parse activation metadata from the documented out-of-band channel.
+4. If activation metadata is absent or invalid, choose `pass_through`.
+5. Read or buffer the request body as needed to obtain the required chat-completions fields.
+6. If the required body fields are unavailable, follow the documented fallback-or-error policy.
+7. If ITS should be applied, run the configured ITS algorithm using:
+   - the upstream request's logical model selection
+   - the request messages
+   - the activation metadata's compute-control value
+   - any forwarded optional fields such as tools or tool choice
+8. If ITS succeeds, return an OpenAI-compatible immediate response and short-circuit the upstream
+   request.
+9. If ITS fails after activation, follow the documented fallback-or-error policy.
+
+Required outcomes:
+
+- `pass_through`, or
+- `its_applied`
 
 ## 13. Test and Validation Matrix
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -46,8 +46,8 @@ Important boundary:
 - Gateways are OPTIONAL integration profiles layered on top of the library contract.
 - The specification defines behavior and interfaces, not one language, one packaging model, or one
   deployment topology.
-- A conforming implementation can be a library, a gateway, both, or a strict subset according to
-  the capability profiles in Section 3.3.
+- A conforming implementation can be core-library-only, or core-library-plus-optional extensions,
+  according to the capability profiles in Section 3.3.
 
 ## 2. Goals and Non-Goals
 
@@ -349,7 +349,8 @@ If an implementation cannot determine usage exactly, it MUST do one of the follo
 
 - omit usage entirely
 - provide a documented estimate
-- provide a documented sentinel representation
+- provide a documented placeholder representation that still uses non-negative integers for all
+  fields (for example, zero values)
 
 ### 4.2 Normalization and Mapping Rules
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,17 +1,33 @@
 # its_hub Repository Specification
 
-Status: Draft v1 (language-agnostic repository contract)
+Status: Draft v1
 
 Purpose: Define the repository-level contract for `its_hub` as a library-first system for
-inference-time scaling (ITS) of LLMs, including:
+inference-time scaling (ITS) of LLMs, while also documenting the two concrete gateway
+implementations that currently exist in the repository family:
 
-- the core Python package and its abstractions
-- built-in algorithms, model adapters, and reward-model integrations
-- the repository's benchmarking and example tooling
-- the gateway/serving contract used by both direct-service and intercepting implementations
+- the current OpenAI-compatible FastAPI IaaS service in `its_hub/integration/iaas.py`
+- the Envoy external-processing profile implemented on `origin/envoy_ext_proc`
 
-This specification is intentionally broader than the gateway. The gateway is one part of the
-repository and is specified here as a subsystem.
+Source of truth for this specification version:
+
+- `origin/v1`
+  - normative for the core library surface, package layout, and install profiles
+- current repository branch
+  - normative for the current `its-iaas` FastAPI gateway profile
+- `origin/envoy_ext_proc`
+  - normative for the Envoy ext-proc gateway profile
+
+When these sources differ, this specification MUST say which surface is being described.
+
+Interpretation model for this document:
+
+- Sections 3 through 10 define the intended repository-family design target unless they explicitly
+  name a branch or concrete implementation.
+- Sections 11 through 14 map that target onto the current Python repository family and its concrete
+  gateway/runtime profiles.
+- Python module paths in this document are reference mappings for the current Python branches, not
+  mandatory shapes for future non-Python ports such as Rust.
 
 ## Normative Language
 
@@ -24,307 +40,378 @@ behavior.
 
 ## 1. Problem Statement
 
-`its_hub` is a repository for runtime techniques that improve LLM outputs by spending more compute
-during inference rather than by retraining the model. It is especially oriented toward:
+`its_hub` is a repository for inference-time scaling techniques that improve model outputs by
+spending more compute during inference rather than by retraining the model.
 
-- mathematical reasoning
-- multi-step reasoning
-- tool-calling reliability
-- benchmarking the quality/computation trade-off across ITS algorithms
+The repository family currently serves three closely related needs:
 
-The repository is not only a Python library. It also contains:
+1. `Library-first ITS`
+   - reusable algorithms, LM adapters, reward-model abstractions, and orchestration contracts
 
-- provider adapters for OpenAI-compatible and LiteLLM-backed inference
-- reward-model integrations
-- a serving/gateway layer for OpenAI-compatible chat completions
-- benchmark and example scripts
-- repository documentation describing installation, usage, and development workflows
+2. `Gateway integration`
+   - integration into existing serving layers without changing the downstream OpenAI-compatible
+     client contract
+
+3. `Research and evaluation`
+   - examples, benchmarks, and math-oriented evaluation workflows
 
 Important boundary:
 
-- `its_hub` is a runtime orchestration library and accompanying tooling.
-- It is not a training framework.
-- It does not require one model vendor, one reward-model runtime, or one gateway framework.
-- The repository's public behavior is defined by abstractions and contracts, not by one specific web
-  stack or proxy runtime.
+- the center of gravity for `v1` is the library contract
+- the gateway runtimes are integration profiles layered on top of that library contract
+- no single gateway runtime is required for `v1` core conformance
 
 ## 2. Goals and Non-Goals
 
 ### 2.1 Goals
 
-- Define clean interfaces between language models, ITS algorithms, and reward models.
-- Support both string-prompt and chat-message inputs, including tool-calling flows.
-- Support sync and async execution from the same conceptual algorithm surface.
-- Preserve OpenAI-compatible message structures where possible.
-- Support multiple ITS strategies with a shared `budget` concept.
-- Support both outcome-based and process-based scoring.
-- Expose an OpenAI-compatible gateway contract for serving ITS.
-- Provide benchmarking and example tooling for math-focused evaluation.
-- Keep the repository portable enough that future implementations in other languages can follow the
-  same conceptual contract.
+- Define stable abstractions for:
+  - messages
+  - language models
+  - orchestration
+  - ITS algorithms
+  - reward models
+- Support both string prompts and structured chat messages.
+- Preserve OpenAI-compatible assistant message structure, including tool calls, where supported.
+- Keep the stable core small enough for gateway integrators.
+- Provide built-in implementations for common LM, orchestration, and judging workflows.
+- Support multiple ITS strategies with a shared `budget` vocabulary.
+- Document the current gateway profiles separately so design work can happen in `SPEC.md` before
+  implementation changes land.
 
 ### 2.2 Non-Goals
 
 - Defining the full OpenAI Chat Completions protocol.
-- Standardizing one deployment topology for gateway/service implementations.
-- Requiring streaming ITS responses in this version.
-- Requiring one persistent configuration store or control plane.
-- Requiring all exported classes to be equally stable or production-ready.
+- Requiring one mandatory service runtime for `v1`.
 - Defining training, fine-tuning, or model-hosting internals.
+- Standardizing streaming ITS behavior in this specification version.
+- Guaranteeing that every experimental algorithm has the same stability level as the stable core.
 
-## 3. Repository Overview
+## 3. Repository Model
 
-### 3.1 Deliverables
+### 3.1 Canonical `v1` Layout
 
-The repository contains six main deliverables:
-
-1. `Core Package`
-   - The `its_hub` Python package.
-   - Defines abstractions, implementations, and utilities for inference-time scaling.
-
-2. `Integrations`
-   - Reward-model adapters.
-   - Gateway/serving implementations and related architecture.
-
-3. `Scripts`
-   - Benchmark tooling.
-   - Example scripts for manual evaluation and local testing.
-
-4. `Documentation`
-   - Installation, quick-start, algorithm, gateway, benchmarking, and development guides.
-
-5. `Tests`
-   - Unit and integration-style tests for algorithms, language models, tooling, and wrappers.
-
-6. `Packaging Metadata`
-   - Project metadata, extras, CLI entrypoints, and dependency profiles.
-
-### 3.2 Canonical Repository Layout
-
-The repository is organized around these top-level surfaces:
+The canonical `v1` design target uses a split API/core layout. `origin/v1` is the closest current
+Python branch to that layout, but the diagram below is conceptual rather than a literal exhaustive
+inventory of any single branch:
 
 ```text
 its_hub/
-  base.py
-  types.py
-  lms.py
-  utils.py
-  error_handling.py
+  api/
+    algorithm.py
+    lm.py
+    orchestrator.py
+    types.py
+    reward_models/
+  core/
+    algorithms/
+    lms/
+    reward_models/
+    orchestrator.py
   algorithms/
-  integration/
+benchmarking/
+examples/
 docs/
-scripts/
 tests/
 README.md
 pyproject.toml
 SPEC.md
 ```
 
-Logical responsibilities:
+Interpretation note:
 
-- `its_hub/base.py`
-  - abstract interfaces
-- `its_hub/types.py`
-  - normalized message and tool-call types
-- `its_hub/lms.py`
-  - language-model adapters and stepwise generation helpers
+- the diagram names the intended conceptual homes of repository surfaces
+- supporting files such as `SPEC.md`, `scripts/`, `eval/`, or branch-specific docs MAY be added,
+  omitted, or relocated without changing the core contract
+
+Responsibilities:
+
+- `its_hub/api/`
+  - stable abstract contracts
+- `its_hub/core/`
+  - built-in implementations of those contracts
 - `its_hub/algorithms/`
-  - ITS algorithm implementations
-- `its_hub/integration/`
-  - reward-model integration and serving/gateway integration
-- `its_hub/utils.py`
-  - prompts and helper utilities
-- `docs/`
-  - user-facing documentation
-- `scripts/`
-  - research, benchmarking, and example entrypoints
-- `tests/`
-  - validation of the above surfaces
+  - compatibility-oriented import surface
+- `benchmarking/`, `examples/`, `docs/`, `tests/`
+  - tooling, documentation, validation
 
-### 3.3 Distribution and Installation Profiles
+### 3.2 Legacy Flat Layout Compatibility
 
-The repository defines multiple installation profiles through package extras.
+Some active branches, including the current branch and `origin/envoy_ext_proc`, still use the older
+flat layout:
 
-Current profiles:
+```text
+its_hub/
+  base.py
+  lms.py
+  types.py
+  algorithms/
+  integration/
+```
 
-- `core`
-  - installed by `pip install its_hub`
-  - intended for self-consistency, best-of-n, OpenAI-compatible inference, and LLM-judge usage
-- `prm`
-  - installed by `pip install its_hub[prm]`
-  - adds process-reward-model dependencies for stepwise reasoning algorithms
-- `cloud`
-  - installed by `pip install its_hub[cloud]`
-  - adds cloud-provider SDK support such as Bedrock and Vertex AI
+For this specification version:
+
+- the `origin/v1` split layout is the canonical design target
+- the flat layout branches are treated as equivalent implementations of the same conceptual layers
+- gateway profiles that still live under the flat layout remain part of the repository-family
+  contract until they are retired or migrated
+
+### 3.3 Deliverables
+
+The repository family currently contains these deliverables:
+
+1. `Core library contract`
+   - abstractions and built-in ITS implementations
+
+2. `Gateway profiles`
+   - current FastAPI IaaS service
+   - Envoy ext-proc external processor
+
+3. `Documentation, examples, and benchmarks`
+   - install guides, quick starts, algorithm docs, benchmark tooling
+
+4. `Tests and packaging metadata`
+   - repository validation and distribution metadata
+
+## 4. Distribution and Installation Profiles
+
+### 4.1 `origin/v1` Profiles
+
+The normative `v1` install profiles are:
+
+- default / core
+  - `pip install its_hub`
+  - minimal dependency footprint
+  - intended for integrators who provide their own LM and orchestrator
+
+- `lm`
+  - `pip install its_hub[lm]`
+  - adds built-in OpenAI-compatible LM support, async HTTP dependencies, `LLMJudge`, and
+    `LMOrchestrator`
+
+- `iaas`
+  - `pip install its_hub[iaas]`
+  - adds service-oriented dependencies
+  - in `origin/v1` this is a dependency profile, not a required built-in runtime contract
+
+- `experimental`
+  - `pip install its_hub[experimental]`
+  - adds experimental algorithms and PRM-related dependencies
+
 - `research`
-  - installed by `pip install its_hub[research]`
+  - `pip install its_hub[research]`
   - adds benchmark/evaluation dependencies
+
 - `dev`
-  - installed by `pip install -e ".[dev]"` or `uv sync --extra dev`
-  - adds testing, linting, notebook, and contributor tooling
+  - `pip install -e ".[dev]"` or `uv sync --extra dev`
+  - adds development and test tooling
 
-### 3.4 CLI Entrypoints
+### 4.2 Legacy Branch Packaging Notes
 
-The repository currently defines this package CLI entrypoint in the main branch:
+The current branch and `origin/envoy_ext_proc` still ship older packaging shapes:
+
+- current branch
+  - includes a built-in `its-iaas` script in `pyproject.toml`
+  - uses extras such as `vllm`, `prm`, `research`, and `cloud`
+  - default dependencies already include a broader runtime/service footprint than the minimal
+    `origin/v1` core profile
+
+- `origin/envoy_ext_proc`
+  - includes both:
+    - `its-iaas`
+    - `envoy-grpc`
+  - default dependencies also include gRPC/runtime packages needed by that gateway profile
+
+These older package shapes are implementation facts for those branches, but they are not the
+normative `origin/v1` packaging model.
+
+## 5. Runtime Entrypoints
+
+### 5.1 `v1` Core Position
+
+`origin/v1` does not require one built-in ITS service runtime as part of core conformance.
+
+### 5.2 Current FastAPI IaaS Profile
+
+The current branch exports:
 
 - `its-iaas`
-  - starts the direct HTTP gateway/service profile
+  - entrypoint: `its_hub.integration.iaas:main`
 
-Additional gateway entrypoints MAY exist in other implementation profiles or active development
-branches. This specification defines the gateway contract independently of one entrypoint name.
+This starts the in-process FastAPI IaaS service.
 
-## 4. System Overview
+### 5.3 Envoy ext-proc Profile
 
-### 4.1 Main Components
+The `origin/envoy_ext_proc` branch exports:
+
+- `envoy-grpc`
+  - entrypoint: `its_hub.integration.ext_proc.processor:main`
+
+This starts the Envoy external-processor gRPC service.
+
+## 6. System Overview
+
+### 6.1 Main Components
+
+These are conceptual components. A concrete branch or port MAY collapse two or more components into
+one module, service, or type so long as the externally visible behavior remains equivalent.
 
 1. `Message Model`
-   - Represents prompts, chat history, tool calls, and normalized conversation batches.
+   - normalized prompts, chat history, multimodal text-bearing messages, and tool calls
 
 2. `Language Model Adapter Layer`
-   - Adapts downstream LLM APIs to a shared generation interface.
+   - downstream LM call interface
 
-3. `ITS Algorithm Layer`
-   - Implements sampling, voting, search, and selection logic.
+3. `Orchestrator Layer`
+   - parallel fanout, concurrency control, and argument forwarding
 
-4. `Reward Layer`
-   - Scores either final answers or intermediate reasoning steps.
+4. `ITS Algorithm Layer`
+   - sampling, voting, scoring, and search logic
 
-5. `Integration Layer`
-   - Bridges the core package to external systems such as reward runtimes and gateways.
+5. `Reward Layer`
+   - outcome and process reward models
 
-6. `Gateway Layer`
-   - Exposes ITS as an OpenAI-compatible serving surface.
+6. `Gateway Integration Layer`
+   - service/proxy integrations such as FastAPI IaaS and Envoy ext-proc
 
 7. `Research / Tooling Layer`
-   - Benchmarks algorithms on standardized datasets and provides example scripts.
+   - examples, benchmarks, docs, and tests
 
-8. `Documentation and Quality Layer`
-   - Explains usage, tests behavior, and enforces repository quality.
+### 6.2 Abstraction Levels
 
-### 4.2 Abstraction Levels
+The repository family is easiest to reason about in these canonical layers. A concrete branch MAY
+collapse or inline some of them:
 
-The repository is easiest to reason about when kept in these layers:
-
-1. `Input Normalization Layer`
+1. `Canonical Public API Contracts`
    - `ChatMessage`, `ChatMessages`
+   - `AbstractLanguageModel`
+   - `AbstractScalingAlgorithm`, `AbstractScalingResult`
+   - `AbstractOutcomeRewardModel`, `AbstractProcessRewardModel`
+   - `AbstractOrchestrator` in the canonical `origin/v1` model
 
-2. `Provider Layer`
-   - `AbstractLanguageModel` and concrete model adapters
+2. `Canonical Built-in Implementations`
+   - `OpenAICompatibleLanguageModel`
+   - `SelfConsistency`, `BestOfN`
+   - `LMOrchestrator`, `LLMJudge` in `origin/v1`
+   - experimental search algorithms where implemented
 
-3. `Algorithm Layer`
-   - `AbstractScalingAlgorithm`, `AbstractScalingResult`, concrete ITS implementations
+3. `Gateway Profiles`
+   - current FastAPI IaaS service
+   - Envoy ext-proc external processor
 
-4. `Scoring Layer`
-   - `AbstractOutcomeRewardModel`, `AbstractProcessRewardModel`, concrete adapters
+4. `Tooling and Validation`
+   - examples, benchmarks, docs, tests
 
-5. `Serving Layer`
-   - configuration and transport surfaces that turn ITS into an API
+## 7. Core Domain Model
 
-6. `Evaluation Layer`
-   - benchmark datasets, evaluation logic, and research scripts
+### 7.1 Message Model
 
-### 4.3 Portability Boundary
+#### 7.1.1 `ChatMessage`
 
-The repository is implemented in Python, but the conceptual architecture is portable because:
-
-- algorithms depend on abstract model and reward interfaces
-- chat/message normalization is explicit
-- the gateway is described in terms of transport-agnostic execution config
-- the benchmark layer depends on algorithm behavior rather than one server implementation
-
-## 5. Core Domain Model
-
-### 5.1 Message Model
-
-#### 5.1.1 ChatMessage
-
-`ChatMessage` is the normalized conversation unit used across the repository.
+`ChatMessage` is the normalized conversation unit used across the repository family.
 
 Fields:
 
-- `role` (enum/string)
-  - current supported values:
+- `role`
+  - supported values:
     - `system`
     - `user`
     - `assistant`
     - `tool`
-- `content` (string, list of content parts, or null)
-  - string for plain text
-  - list of dicts for OpenAI-style multimodal content
-  - null when the message is represented primarily by tool calls
+- `content`
+  - `str` for plain text
+  - `list[dict]` for OpenAI-style multimodal content
+  - `null` when the message is represented primarily by tool calls
 - `tool_calls` (OPTIONAL list of dicts)
 - `tool_call_id` (OPTIONAL string)
 
-Semantics:
+Required semantics:
 
-- The repository MUST preserve tool calls in assistant messages when they are part of the selected
-  response.
-- Multimodal content is represented structurally, but most current reasoning paths extract and use
-  text content only.
+- tool-call-bearing assistant messages MUST preserve `tool_calls` when returned by the LM path
+- multimodal text extraction MUST preserve text parts in order
+- image parts MAY be ignored by text-only flows
+- in the `origin/v1` API, `ChatMessage.from_dict(...)` ignores unknown inbound fields
 
-#### 5.1.2 ChatMessages
+#### 7.1.2 `ChatMessages`
 
-`ChatMessages` is a wrapper that normalizes either:
+`ChatMessages` wraps either:
 
 - a string prompt
 - a list of `ChatMessage`
 - another `ChatMessages`
 
-into one internal representation.
-
 Required behaviors:
 
 - `from_prompt_or_messages(...)`
-  - normalize strings, message lists, or wrapper instances
-- `to_prompt()`
-  - produce a string representation of the conversation
 - `to_chat_messages()`
-  - produce a list of normalized messages
 - `to_batch(size)`
-  - duplicate one logical request into `size` parallel candidate requests
+- `to_prompt()`
 
-Important compatibility note:
+Contract notes:
 
-- String prompts are normalized as a single `user` message.
-- `to_prompt()` exists for compatibility and utility flows. It is not the preferred representation
-  for chat-native or tool-native execution paths.
+- `to_chat_messages()` is the primary structured representation
+- `to_prompt()` remains important for backward compatibility and experimental algorithms
 
-#### 5.1.3 Text Extraction
+### 7.2 Language Model Interface
 
-For multimodal message content:
+#### 7.2.1 `AbstractLanguageModel`
 
-- text parts are concatenated for text-only reasoning paths
-- image parts may be ignored by text-only internal flows
-- unsupported content part types MAY raise an error
+The normative `origin/v1` contract is async-first.
 
-This behavior is current repository behavior, not a universal multimodal standard.
+Legacy flat-layout branches and future ports MAY expose narrower concrete method signatures or
+inline batching logic, but they SHOULD map cleanly onto this async-first contract at the
+specification level.
 
-### 5.2 Language Model Interfaces
+Required method:
 
-#### 5.2.1 AbstractLanguageModel
+- `agenerate(messages, stop=None, **kwargs)`
 
-`AbstractLanguageModel` is the base contract for downstream model adapters.
+Important optional method:
 
-Required methods:
+- `agenerate_single(messages, stop=None, **kwargs)`
 
-- `agenerate(messages, stop=None, ...)`
-- `generate(messages, stop=None, ...)`
+Required semantics:
 
-Optional method:
+- LM adapters SHOULD preserve OpenAI-compatible assistant message dicts, including `tool_calls`
+- LM adapters MAY accept provider-specific kwargs such as:
+  - `max_tokens`
+  - `temperature`
+  - `tools`
+  - `tool_choice`
+  - `response_format`
 
-- `evaluate(prompt, generation)`
+### 7.3 Orchestrator Interface
 
-Expected semantics:
+#### 7.3.1 `AbstractOrchestrator`
 
-- input may be one conversation or a batch of conversations
-- output may be one response or a list of responses
-- the response shape SHOULD preserve OpenAI-compatible assistant message structure when available
+`AbstractOrchestrator` is a first-class `origin/v1` abstraction.
 
-### 5.3 Scaling Algorithm Interfaces
+Legacy branches MAY instead place fanout/concurrency behavior inside LM adapters or gateway-specific
+wrappers rather than exposing a first-class orchestrator symbol.
 
-#### 5.3.1 AbstractScalingAlgorithm
+Primary method:
 
-`AbstractScalingAlgorithm` is the base contract for ITS algorithms.
+- `agenerate(lm, messages_lst, stop=None, **kwargs)`
+
+Sync wrapper:
+
+- `generate(...)`
+
+Responsibilities:
+
+- fan out one logical ITS request into multiple LM calls
+- preserve result ordering
+- forward LM-specific parameters such as:
+  - `temperature`
+  - `max_tokens`
+  - `tools`
+  - `tool_choice`
+  - `response_format`
+- enforce implementation-defined concurrency control
+
+### 7.4 Scaling Algorithm Interfaces
+
+#### 7.4.1 `AbstractScalingAlgorithm`
 
 Primary method:
 
@@ -333,53 +420,54 @@ Primary method:
 Sync wrapper:
 
 - `infer(...)`
-  - conceptually wraps the async implementation
 
 Contract:
 
-- algorithms MUST accept either string prompts or normalized chat messages
-- algorithms MUST interpret `budget` according to their documented semantics
-- algorithms MAY support tool-calling inputs by forwarding `tools` and `tool_choice`
+- algorithms MUST accept string prompts or normalized chat messages
+- algorithms MUST interpret `budget` according to documented semantics
+- algorithms SHOULD preserve tool-call-bearing assistant messages when the underlying LM does
+- algorithms MAY depend on an orchestrator explicitly or through built-in wiring
 
-#### 5.3.2 AbstractScalingResult
-
-`AbstractScalingResult` defines the result-object surface for algorithms that return structured
-state instead of only the selected message.
+#### 7.4.2 `AbstractScalingResult`
 
 Required property:
 
 - `the_one`
-  - returns the selected response
+  - returns the selected assistant response dict
 
-### 5.4 Reward Model Interfaces
+### 7.5 Reward Model Interfaces
 
-#### 5.4.1 AbstractOutcomeRewardModel
+#### 7.5.1 `AbstractOutcomeRewardModel`
 
-Scores final responses.
+Scores final responses or complete conversations.
 
-Required methods:
+Normative `origin/v1` shape:
 
-- `ascore(prompt_or_messages, response)`
-- `score(prompt_or_messages, response)`
+- `score(messages, **kwargs)`
+- OPTIONAL async method:
+  - `ascore(messages, orchestrator=None, **kwargs)`
 
-#### 5.4.2 AbstractProcessRewardModel
+Legacy flat-layout branches use an older prompt-plus-response shape in some implementations.
+
+#### 7.5.2 `AbstractProcessRewardModel`
 
 Scores intermediate reasoning steps.
 
 Required methods:
 
-- `ascore(prompt_or_messages, steps)`
 - `score(prompt_or_messages, steps)`
+- `ascore(prompt_or_messages, steps)`
 
-### 5.5 StepGeneration
+### 7.6 `StepGeneration`
 
-`StepGeneration` is the repository's step-wise generation helper for algorithms that build or score
-responses incrementally.
+`StepGeneration` is a built-in helper used by experimental step-wise algorithms.
 
-Key fields:
+Key fields include:
 
 - `max_steps`
-- `step_token` or `tokens_per_step`
+- exactly one of:
+  - `step_token`
+  - `tokens_per_step`
 - `stop_token`
 - `temperature`
 - `include_stop_str_in_output`
@@ -390,29 +478,123 @@ Invariants:
 - exactly one of `step_token` and `tokens_per_step` MUST be set
 - `tokens_per_step` MUST be positive when used
 
+## 8. Built-in Repository Components
+
+### 8.1 Stable `origin/v1` Surfaces
+
+The stable repository-facing surfaces include:
+
+- `AbstractLanguageModel`
+- `AbstractOrchestrator`
+- `AbstractScalingAlgorithm`
+- `AbstractOutcomeRewardModel`
+- `AbstractProcessRewardModel`
+- `ChatMessage`, `ChatMessages`
+- `SelfConsistency`
+- `BestOfN`
+
+### 8.2 Built-in LM / Orchestration Components
+
+When the `lm` extra is installed on `origin/v1`, the repository provides:
+
+- `OpenAICompatibleLanguageModel`
+- `LMOrchestrator`
+- `LLMJudge`
+- `StepGeneration`
+
+Important `origin/v1` notes:
+
+- `OpenAICompatibleLanguageModel` forwards tools, tool choice, and structured-output arguments
+- `LMOrchestrator` is the default parallel fanout implementation
+- `LLMJudge` is the built-in outcome-judging implementation
+
+### 8.3 Stable Algorithms
+
+#### 8.3.1 `SelfConsistency`
+
 Behavior:
 
-- generates one or many next-step continuations
-- reconstructs current assistant reasoning state from prior steps
-- stops when `max_steps` or `stop_token` conditions are met
+- generate multiple candidate responses
+- project responses into a comparison space
+- select the most common projection, with implementation-defined tie-breaking
 
-## 6. Core Library Contracts
+Current capabilities across the repository family:
 
-### 6.1 Sync and Async Semantics
+- content-based voting
+- regex-based projection
+- tool-call voting modes:
+  - `tool_name`
+  - `tool_args`
+  - `tool_hierarchical`
 
-The repository is async-first conceptually.
+#### 8.3.2 `BestOfN`
+
+Behavior:
+
+- generate `N` candidates
+- score them with an outcome reward model or judge
+- select the highest-scoring candidate
+
+Current `origin/v1` note:
+
+- deduplication considers both content and tool-call-bearing structure
+
+### 8.4 Experimental Components
+
+Experimental repository surfaces may include:
+
+- `BeamSearch`
+- `ParticleFiltering`
+- `ParticleGibbs`
+- `EntropicParticleFiltering`
+- `PlanningWrapper`
+- local PRM integration
+
+These are part of the repository family, but they are not part of the same stable contract as
+`SelfConsistency` and `BestOfN`.
+
+### 8.5 Compatibility Surface
+
+`its_hub/algorithms/` remains a compatibility-oriented import surface.
+
+In `origin/v1`, the canonical implementation home is `its_hub/core/algorithms/`.
+
+In legacy flat-layout branches, `its_hub/algorithms/` still contains the live implementations.
+
+## 9. Budget Semantics
+
+`budget` is the repository-wide compute-control vocabulary for one ITS execution.
+
+Current semantics by algorithm:
+
+- `SelfConsistency`
+  - number of candidate generations
+- `BestOfN`
+  - number of candidate generations to score
+- `BeamSearch`
+  - total search effort, constrained by beam width
+- `ParticleFiltering` / related particle methods
+  - number of particles
+- `PlanningWrapper`
+  - planning cost plus downstream execution budget
+
+Important note:
+
+- `budget` is shared vocabulary, not a universal identical implementation detail
+- each algorithm MUST document how it interprets `budget`
+
+## 10. Core Library Contracts
+
+### 10.1 Async-First Semantics
+
+The `origin/v1` core is async-first.
 
 Required behavior:
 
-- concrete implementations SHOULD treat async methods as the primary execution path
-- sync methods MAY be thin wrappers around async implementations
+- primary contracts are async
+- sync methods are convenience wrappers over async behavior
 
-Caller guidance:
-
-- async callers SHOULD use async methods directly
-- sync wrappers are a convenience layer and may rely on `asyncio.run()`
-
-### 6.2 Input Flexibility
+### 10.2 Input Flexibility
 
 Algorithms and reward adapters MUST accept:
 
@@ -422,545 +604,266 @@ Algorithms and reward adapters MUST accept:
 
 Normalization MUST occur before algorithm-specific logic.
 
-### 6.3 Tool-Calling Preservation
+### 10.3 Tool-Calling Preservation
 
 When assistant messages include tool calls:
 
-- tool calls MUST remain attached to message objects during candidate generation and selection
-- algorithms MUST NOT flatten tool calls into plain text unless that behavior is explicitly part of
-  a documented projection or comparison strategy
+- LM adapters SHOULD preserve them in returned message dicts
+- algorithms SHOULD keep them attached to candidate responses and selected results
+- comparison or deduplication logic MAY intentionally project tool calls into reduced forms when
+  that is part of the documented algorithm
 
-### 6.4 Provider Adapter Expectations
+### 10.4 Structured Output Support
 
-A concrete language-model adapter SHOULD provide:
+The repository's LM and orchestrator contracts MAY forward provider-native structured-output
+arguments, including `response_format`.
 
-- batched generation
-- retry handling for transient provider failures
-- concurrency control where supported
-- propagation of request features such as:
-  - stop conditions
-  - max tokens
-  - temperature
-  - tools
-  - tool choice
+This is part of the extensible LM call surface, not a universal algorithm-level requirement.
 
-### 6.5 Error Handling Boundary
+### 10.5 Prompt Fallback in Experimental Paths
 
-Provider adapters are responsible for:
-
-- transport interaction with downstream providers
-- retry classification where implemented
-- mapping malformed or non-success upstream behavior into repository-level errors
-
-Algorithms are responsible for:
-
-- handling candidate sets and selection logic
-- surfacing algorithm-level failures when valid selection is impossible
-
-## 7. Built-in Library Components
-
-### 7.1 Language Model Implementations
-
-#### 7.1.1 OpenAICompatibleLanguageModel
-
-Primary documented provider adapter for:
-
-- OpenAI-compatible APIs
-- local vLLM-style chat-completion endpoints
-
-Current repository behaviors include:
-
-- OpenAI-compatible request shaping
-- support for system prompts
-- retry/backoff and error parsing
-- concurrency control for async generation
-- support for tool definitions and tool choice
-- configurable SSL verification behavior
-
-#### 7.1.2 LiteLLMLanguageModel
-
-Adapter for provider access through LiteLLM.
-
-Purpose:
-
-- unify multiple downstream providers behind a common generation surface
-- enable cloud/provider routing without changing algorithm code
-
-#### 7.1.3 Other Model Classes
-
-`its_hub/lms.py` also contains additional classes such as:
-
-- `LocalVLLMLanguageModel`
-- `TransformersLanguageModel`
-
-Current note:
-
-- the repository's primary documented and actively described model surfaces are
-  `OpenAICompatibleLanguageModel` and `LiteLLMLanguageModel`
-- other classes MAY be experimental, utility, or less central to the public contract
-
-### 7.2 Utility Prompts and Helpers
-
-The repository includes prompt and helper utilities in `its_hub/utils.py`.
-
-Important current examples:
-
-- `SAL_STEP_BY_STEP_SYSTEM_PROMPT`
-- `QWEN_SYSTEM_PROMPT`
-
-These are repository utilities for reasoning workflows, especially math tasks. They are not protocol
-requirements for algorithm correctness.
-
-### 7.3 Reward Model Integrations
-
-#### 7.3.1 LocalVllmProcessRewardModel
-
-Adapter around `reward_hub` process-reward-model support.
-
-Purpose:
-
-- score step-wise reasoning trajectories
-- support algorithms such as beam search and particle filtering
-
-Current dependencies:
-
-- local reward runtime via `reward_hub`
-- device selection
-- aggregation method selection
-
-#### 7.3.2 LLMJudgeRewardModel
-
-Adapter around `reward_hub` LLM-judge support.
-
-Purpose:
-
-- score complete candidate responses
-- enable best-of-n without a local process reward model
-
-Current judge concepts:
-
-- `pointwise`
-- `groupwise`
-
-### 7.4 Algorithm Implementations
-
-#### 7.4.1 SelfConsistency
-
-Behavior:
-
-- generate multiple candidate responses
-- project each candidate into a comparison space
-- select the most common projection, with implementation-defined tie-breaking
-
-Supported comparison modes:
-
-- default exact-content projection
-- regex-based projection
-- tool-call voting modes:
-  - `tool_name`
-  - `tool_args`
-  - `tool_hierarchical`
-
-Current use cases:
-
-- tool-calling consistency
-- math answers with structured final-answer extraction
-
-#### 7.4.2 BestOfN
-
-Behavior:
-
-- generate `N` candidates
-- score them with an outcome reward model or LLM judge
-- select the highest-scoring candidate
-
-Current use cases:
-
-- quality-focused selection with a judge/scorer
-- cloud-API scenarios that do not require a local PRM
-
-#### 7.4.3 BeamSearch
-
-Behavior:
-
-- perform step-wise generation with fixed beam width
-- score partial trajectories using a process reward model
-
-Current use cases:
-
-- structured multi-step reasoning
-- problems where partial trajectories are meaningful and scoreable
-
-#### 7.4.4 ParticleGibbs Family
-
-The repository includes a particle-based family in `its_hub/algorithms/particle_gibbs.py`.
-
-Important public classes:
-
-- `ParticleGibbs`
-- `ParticleFiltering`
-- `EntropicParticleFiltering`
-
-Shared conceptual behavior:
-
-- maintain multiple reasoning trajectories
-- resample or retain trajectories according to algorithm-specific selection rules
-- use step-wise scoring for long-horizon reasoning
-
-Current emphasis in docs and examples is on:
-
-- `ParticleFiltering`
-- `EntropicParticleFiltering`
-
-#### 7.4.5 PlanningWrapper
-
-`PlanningWrapper` is a repository utility that adds a planning phase to another ITS algorithm.
-
-Behavior:
-
-- use one generation to propose several approaches
-- allocate remaining budget across approaches
-- run the wrapped algorithm for each approach
-- select the best approach/result using result-level heuristics
-
-Current note:
-
-- this is part of the repository surface
-- it is a wrapper utility rather than one of the foundational ITS primitives
-
-### 7.5 Result Object Semantics
-
-Algorithm result objects generally:
-
-- preserve candidate responses or trajectories
-- expose the selected response through `the_one`
-- MAY include algorithm-specific fields such as:
-  - response counts
-  - scores
-  - selected index
-  - path/particle state
-  - planning metadata
-
-### 7.6 Experimental or Incomplete Surfaces
-
-`its_hub/algorithms/__init__.py` currently exports `MetropolisHastings`, but the implementation is
-not yet complete and raises `NotImplementedError`.
+Structured chat is the primary contract, but some experimental algorithms still rely on
+`ChatMessages.to_prompt()` in current implementations.
 
 Therefore:
 
-- it is part of the repository surface area
-- it is not a required stable algorithm contract in this specification version
+- structured chat is the primary contract
+- exact chat-history fidelity is weaker in some experimental paths than in the stable core
 
-## 8. Budget Semantics
+## 11. Gateway Profiles
 
-`budget` is the repository-wide compute control for one ITS execution.
+### 11.1 Gateway Role in `v1`
 
-Current semantics by algorithm:
+In `origin/v1`, a gateway is an integration profile layered over the library contract.
 
-- `SelfConsistency`
-  - number of parallel generations to compare
-- `BestOfN`
-  - number of candidate responses to score
-- `BeamSearch`
-  - total search effort; commonly interpreted as `beam_width * effective_depth`
-- `ParticleFiltering`
-  - number of particles maintained
-- `EntropicParticleFiltering`
-  - number of particles maintained
-- `PlanningWrapper`
-  - spends one unit on planning, then distributes the remainder across approaches
+The repository-family contract currently includes two concrete gateway profiles:
 
-Important note:
+1. `Current FastAPI IaaS profile`
+   - implemented on the current branch
+   - request-body-driven ITS
 
-- `budget` is shared vocabulary, not a universal identical implementation detail.
-- Each algorithm MUST document how it interprets `budget`.
+2. `Envoy ext-proc profile`
+   - implemented on `origin/envoy_ext_proc`
+   - header-triggered interception in front of an upstream OpenAI-compatible API
 
-## 9. Integration Layer
+### 11.2 Current FastAPI IaaS Profile
 
-### 9.1 reward_hub Integration Contract
+#### 11.2.1 Role
 
-The repository integrates with `reward_hub` rather than re-implementing all reward-model logic.
+The current branch implements an in-process FastAPI service in `its_hub/integration/iaas.py`.
 
-Required repository behavior:
+This profile is a real repository-family gateway implementation, even though it is not the
+normative `origin/v1` core deployment model.
 
-- adapt reward-hub interfaces to the abstract outcome/process reward model contracts
-- normalize prompt/message inputs into the format expected by reward-hub clients
-- preserve algorithm-facing interfaces regardless of reward-hub internals
+#### 11.2.2 Entrypoints and Endpoints
 
-### 9.2 Serving and Gateway Integration
+Entrypoint:
 
-The repository includes a serving layer that turns ITS into an OpenAI-compatible chat-completions
-surface.
+- `its-iaas`
 
-This serving layer is specified in Section 10 as a subsystem of the repository, not as the entire
-repository contract.
+HTTP endpoints:
 
-## 10. Gateway Specification
+- `POST /configure`
+- `GET /v1/models`
+- `POST /v1/chat/completions`
 
-### 10.1 Gateway Role
+#### 11.2.3 Runtime Model
 
-The gateway exposes inference-time scaling behind an OpenAI-compatible chat-completions interface.
+The current IaaS profile uses process-global mutable state:
 
-It does more than proxy one upstream request. It may:
+- `LM_DICT`
+  - configured model registry
+- `SCALING_ALG`
+  - currently active algorithm instance
 
-- make multiple downstream model calls
-- run voting or reward-based selection
-- aggregate usage across multiple calls
-- return either a selected final response or pass the original request through
+This means:
 
-### 10.2 Gateway Profiles
+- configuration is in-memory
+- service state is lost on restart
+- the profile is not horizontally scalable without refactoring
 
-This specification defines two gateway profiles.
+#### 11.2.4 Configuration Contract
 
-#### 10.2.1 Configured Gateway Service Profile
+`POST /configure` selects the active algorithm and model wiring.
 
-A direct HTTP service that:
+Current required/important fields include:
 
-- exposes OpenAI-compatible endpoints itself
-- accepts runtime ITS configuration through a management endpoint
-- stores effective policy in process-local state
-- applies ITS directly inside `/v1/chat/completions`
+- `provider`
+  - current values:
+    - `openai`
+    - `litellm`
+- `endpoint`
+- `api_key`
+  - REQUIRED when `provider == "openai"`
+- `model`
+- `alg`
+  - current supported values:
+    - `self-consistency`
+    - `best-of-n`
+    - `particle-filtering`
+- other current implementation fields include:
+  - `extra_args`
+  - `step_token`
+  - `stop_token`
+  - `rm_device`
+  - `rm_agg_method`
 
-This profile matches the current direct-service implementation style.
+Algorithm-specific current behavior:
 
-#### 10.2.2 Intercepting Gateway Profile
+- `self-consistency`
+  - currently requires `regex_patterns`
+  - supports:
+    - `tool_vote`
+    - `exclude_tool_args`
+- `best-of-n`
+  - requires `rm_name`
+  - supports `rm_name == "llm-judge"` for LLM-judge scoring
+  - when `rm_name == "llm-judge"`, the current implementation also accepts judge-specific fields
+    such as:
+    - `judge_model`
+    - `judge_base_url`
+    - `judge_criterion`
+    - `judge_mode`
+    - `judge_top_n`
+    - `judge_api_key`
+    - `judge_temperature`
+    - `judge_max_tokens`
+    - `enable_judge_logging`
+- `particle-filtering`
+  - requires reward-model configuration
+  - accepts step-generation-related fields such as `step_token` and `stop_token`
+  - currently combines request-supplied fields with some hardcoded defaults in
+    `its_hub/integration/iaas.py`; exact tuning is implementation-defined in this profile
 
-A proxy-integrated or callback-based service that:
+#### 11.2.5 Request Contract
 
-- inspects requests headed to an upstream OpenAI-compatible chat endpoint
-- decides per request whether ITS should be applied
-- either returns a final ITS response immediately or lets the original request continue upstream
+`POST /v1/chat/completions` accepts:
 
-This profile matches the current proxy/ext-proc implementation style.
+- `model`
+- `messages`
+- `budget`
+- `temperature` (OPTIONAL)
+- `max_tokens` (OPTIONAL; currently accepted by the request schema but not yet forwarded into the
+  algorithm call path)
+- `stream` (OPTIONAL, currently unsupported)
+- `tools` (OPTIONAL)
+- `tool_choice` (OPTIONAL)
+- `return_response_only`
 
-### 10.3 Gateway Components
+ITS activation in this profile is request-body-driven:
 
-1. `Transport Adapter`
-   - HTTP handler, proxy hook, ext-proc handler, or equivalent
+- the client sends `budget` in the JSON request body
+- no Envoy-style `X-ITS-*` header protocol is used
 
-2. `Configuration Resolver`
-   - resolves profile-specific inputs into one normalized execution config
+#### 11.2.6 Response Contract
 
-3. `Model / Provider Registry`
-   - OPTIONAL depending on profile
-   - stores long-lived provider registrations
-
-4. `ITS Orchestrator`
-   - executes one normalized ITS request
-
-5. `Algorithm Registry`
-   - resolves algorithm names to implementations
-
-6. `Provider Adapter`
-   - performs downstream OpenAI-compatible or provider-backed calls
-
-7. `Response Shaper`
-   - emits an OpenAI-compatible response envelope
-
-8. `Observability`
-   - logs and OPTIONAL metrics/traces
-
-### 10.4 Gateway ExecutionConfig
-
-The gateway MUST normalize serving inputs into a request-scoped `ExecutionConfig`.
-
-Fields:
-
-- `model` (string)
-- `algorithm` (string)
-- `budget` (integer, `1..1000`)
-- `provider` (object)
-  - `kind`
-  - `endpoint`
-  - `api_key`
-  - `extra_args` (OPTIONAL)
-- `algorithm_config` (object or null)
-- `reward_config` (object or null)
-- `response_mode`
-  - `selected_message_only`
-  - `selected_message_with_metadata`
-
-### 10.5 Base Protocol Contract
-
-The OpenAI-compatible Chat Completions API is the source of truth for the base wire schema.
-
-This repository specification defines only the ITS-related extensions and handling rules.
-
-#### 10.5.1 Required ITS Response Shape
-
-When the gateway returns an ITS-generated response, it MUST be OpenAI-compatible and include:
+The current IaaS profile returns an OpenAI-compatible top-level response shape with:
 
 - `id`
 - `object = "chat.completion"`
 - `created`
 - `model`
 - `choices`
-  - `choices[0].message` is the selected assistant message
-  - `choices[0].finish_reason` is implementation-defined but typically `stop`
 - `usage`
+- `metadata` (OPTIONAL, when algorithm metadata is returned)
 
-Tool-call preservation:
+Current limitations:
 
-- if the selected response is a tool call, the tool-call structure MUST remain present in
-  `choices[0].message`
+- streaming returns `501 Not Implemented`
+- token usage is currently hardcoded to zero
+- response metadata is algorithm-specific rather than standardized across all algorithms
 
-#### 10.5.2 Gateway Extensions
+### 11.3 Envoy ext-proc Profile
 
-Current standardized repository extensions:
+#### 11.3.1 Role
 
-- configured-service request body fields:
-  - `budget`
-  - `return_response_only`
-- configured-service response body field:
-  - `metadata`
-- intercepting-profile request headers:
-  - `X-ITS-Budget`
-  - `X-ITS-Endpoint`
-  - `X-ITS-API-Key` (OPTIONAL)
-- intercepting-profile diagnostic response header:
-  - `x-its-applied: true` (OPTIONAL)
+The `origin/envoy_ext_proc` branch implements an Envoy external-processor profile that intercepts
+OpenAI-compatible requests and short-circuits them when ITS applies.
 
-#### 10.5.3 Streaming
+#### 11.3.2 Components
 
-This specification version standardizes non-streaming ITS behavior only.
+This profile consists of:
 
-- handling of `stream=true` is implementation-defined
-- implementations MUST document whether they reject, ignore, downgrade, or pass through streaming
-  requests
+1. `Envoy HTTP Proxy`
+   - front-door listener and routing layer
 
-### 10.6 Configured Gateway Service Profile
+2. `External Processor Service`
+   - gRPC service implementing Envoy ext-proc callbacks
 
-#### 10.6.1 Required Endpoints
+3. `ITS Orchestrator`
+   - request-scoped config plus long-lived LM client cache
 
-Required endpoints:
+4. `Provider Adapter`
+   - OpenAI-compatible downstream LM client
 
-1. `POST /configure`
-2. `POST /v1/chat/completions`
+5. `Response Shaper`
+   - emits OpenAI-compatible response JSON
 
-Optional but expected endpoint:
+#### 11.3.3 Interception Target
 
-3. `GET /v1/models`
+The intended interception target is OpenAI-compatible chat-completions traffic.
 
-#### 10.6.2 Configuration Payload
+The current Python implementation recognizes:
 
-The configuration surface MUST support these core fields:
+- requests whose `:path` starts with `/v1/chat/completions`
 
-- `provider`
-- `endpoint`
-- `api_key`
-- `model`
-- `alg`
+Requests to other paths pass through untouched.
 
-It MAY also support algorithm-specific fields such as:
+#### 11.3.4 ITS Activation Headers
 
-- self-consistency:
-  - `regex_patterns`
-  - `tool_vote`
-  - `exclude_tool_args`
-- step-wise / PRM algorithms:
-  - `step_token`
-  - `stop_token`
-  - `rm_name`
-  - `rm_device`
-  - `rm_agg_method`
-- LLM judge:
-  - `judge_model`
-  - `judge_base_url`
-  - `judge_criterion`
-  - `judge_mode`
-  - `judge_top_n`
-  - `judge_api_key`
-  - `judge_temperature`
-  - `judge_max_tokens`
-  - `enable_judge_logging`
-- provider-specific:
-  - `extra_args`
-
-#### 10.6.3 Effective Behavior
-
-On successful configuration:
-
-- the gateway registers or updates a model/provider mapping
-- the gateway replaces the active ITS policy for subsequent requests
-- the effective configuration is local to the process and not required to persist across restart
-
-Important current repository constraint:
-
-- the configured-service profile maintains a model registry but only one active ITS algorithm policy
-  at a time
-
-#### 10.6.4 Request Resolution
-
-For `POST /v1/chat/completions`, execution config is resolved from:
-
-1. request body:
-   - `model`
-   - `messages`
-   - `budget`
-   - `tools`
-   - `tool_choice`
-   - `return_response_only`
-2. active gateway policy:
-   - algorithm
-   - provider mapping
-   - reward config
-   - algorithm-specific config
-
-Expected error classes:
-
-- unknown model
-- missing active service configuration
-- invalid `budget`
-- empty `messages`
-
-### 10.7 Intercepting Gateway Profile
-
-#### 10.7.1 Interception Target
-
-The intercepting profile MUST at minimum recognize:
-
-- `POST /v1/chat/completions`
-
-Requests to other paths MAY be passed through untouched.
-
-#### 10.7.2 ITS Activation Headers
-
-In this specification version, ITS activation is driven by:
+ITS activation is currently driven by:
 
 - `X-ITS-Budget`
+  - integer range `1..1000`
 - `X-ITS-Endpoint`
 - `X-ITS-API-Key` (OPTIONAL)
 
-Current note:
+Current branch-specific note:
 
-- per-request algorithm selection is not standardized in the intercepting profile in this version
-- current prototype behavior uses a fixed/default self-consistency policy once ITS is activated
+- per-request algorithm selection is not yet standardized
+- invalid or out-of-range ITS header values fall back to pass-through behavior
+- the ext-proc branch currently uses a fixed self-consistency policy with default content-based
+  voting rather than per-request algorithm/tool-vote configuration
 
-#### 10.7.3 Request Resolution
+#### 11.3.5 Request-Scoped Config
+
+The ext-proc profile constructs a request-scoped config equivalent to:
+
+- `budget`
+- `api_endpoint`
+- `model`
+- `api_key` (OPTIONAL)
+
+The branch names this structure `ITSRequestConfig`.
+
+Current implementation caveat:
+
+- the long-lived LM client cache is keyed by `(api_endpoint, model)`, not by `api_key`
+- therefore per-request API keys are parsed as request inputs, but they are not fully isolated when
+  multiple requests reuse the same endpoint/model pair
+
+#### 11.3.6 Request Resolution
 
 For an intercepted request:
 
-1. parse headers
-2. if required ITS headers are absent or invalid -> `pass_through`
-3. otherwise parse the request body
-4. read:
+1. inspect request path and headers
+2. if path does not start with `/v1/chat/completions` -> `pass_through`
+3. if required ITS headers are absent or invalid -> `pass_through`
+4. buffer and parse the request body
+5. read:
    - `model`
    - `messages`
    - `tools`
    - `tool_choice`
-5. resolve the profile's default/fixed algorithm policy
-6. build `ExecutionConfig`
+6. if `model` is absent -> `pass_through`
+7. run the fixed self-consistency orchestrator
+8. return either:
+   - immediate ITS response
+   - or pass-through behavior on failure
 
-If `model` is absent from the request body, the gateway MAY:
+#### 11.3.7 Pass-Through and Short-Circuit Semantics
 
-- pass through
-- or return an explicit error
-
-The implementation MUST document which behavior it chooses.
-
-#### 10.7.4 Pass-Through and Short-Circuit Semantics
-
-The intercepting profile supports two outcomes:
+The profile supports two outcomes:
 
 1. `pass_through`
    - the original request continues upstream
@@ -968,422 +871,247 @@ The intercepting profile supports two outcomes:
 2. `its_applied`
    - the gateway runs ITS
    - the gateway returns an OpenAI-compatible response directly
-   - the original upstream call is short-circuited
+   - the original upstream request is short-circuited
 
-### 10.8 Gateway Orchestration Contract
+#### 11.3.8 Response Shape
 
-For one ITS-applied request, the gateway orchestrator MUST:
+When ITS is applied, the response MUST be OpenAI-compatible and include:
 
-1. validate the normalized execution config
-2. build or reuse a downstream provider client
-3. build or reuse any required reward/judge client
-4. normalize messages into the algorithm's expected input representation
-5. run the selected algorithm with:
-   - provider client
-   - messages
-   - budget
-   - tools
-   - tool choice
-6. select the final assistant message
-7. aggregate or synthesize usage
-8. shape the final OpenAI-compatible response
+- `id`
+- `object = "chat.completion"`
+- `created`
+- `model`
+- `choices`
+  - `choices[0].message` is the selected assistant message
+  - `choices[0].finish_reason` is typically `stop`
+- `usage`
 
-### 10.9 Usage Accounting
+Additional profile behavior:
 
-Current repository family supports two usage-accounting modes:
+- the response sets `x-its-applied: true`
+- usage is aggregated across the LM calls used by ITS
 
-1. `aggregated_actual`
-   - usage reflects the sum of all downstream calls used by ITS
+#### 11.3.9 Failure Model
 
-2. `placeholder`
-   - usage fields are present but populated with placeholder values such as zero
+The current Envoy profile favors safe fallback:
 
-Implementations MUST document which mode they use.
+- invalid or incomplete ITS activation headers -> pass through
+- non-chat-completions routes -> pass through
+- missing `model` in request body -> pass through
+- ITS processing failure after activation -> pass through
 
-### 10.10 Gateway Failure Model
+### 11.4 Streaming
 
-Failure classes:
+This specification version does not standardize streaming ITS behavior.
 
-1. `Request Validation Failures`
-   - empty `messages`
-   - invalid `budget`
-   - missing `model`
+Current profile notes:
 
-2. `Gateway Configuration Failures`
-   - unknown model registration
-   - missing active policy
-   - unsupported algorithm
+- current FastAPI IaaS profile:
+  - explicit `501 Not Implemented`
+- Envoy ext-proc profile:
+  - request bodies are buffered for interception
+  - response streaming semantics are not standardized here
 
-3. `Provider Failures`
-   - transport failure
-   - non-success upstream status
-   - malformed payload
+## 12. Documentation Surface
 
-4. `Reward Failures`
-   - missing reward runtime
-   - judge call failure
-   - scorer integration failure
+The repository-family documentation surface MAY include the documents below. Not every branch is
+required to contain every document at the same path:
 
-5. `Algorithm Execution Failures`
-   - selection failure
-   - invalid candidate set after filtering
+- `README.md`
+  - top-level orientation and installation matrix
+- `docs/installation.md`
+  - install profiles and dependency expectations
+- `docs/quick-start.md`
+  - common usage flows
+- `docs/algorithms.md`
+  - algorithm-facing guidance
+- `docs/orchestration.md` (`origin/v1`)
+  - orchestrator contract and built-in orchestrator behavior
+- `docs/benchmarking.md`
+  - benchmark workflow
+- `docs/development.md`
+  - contributor guidance and architecture notes
+- `docs/PLANNING_WRAPPER.md`
+  - planning-wrapper behavior
+- `docs/iaas-service.md`
+  - current FastAPI IaaS profile and related gateway usage
+- `its_hub/integration/iaas.md`
+  - migration/architecture document for the Envoy proxy direction on legacy flat-layout Python
+    branches
+- `docs/usage.md`
+  - optional user-facing usage guidance on some branches, including `origin/envoy_ext_proc`
 
-Configured-service profile:
+Documentation is descriptive and user-facing.
 
-- SHOULD return explicit errors for invalid or unconfigured requests
+This specification is normative for the intended repository contract, but branch-specific code
+remains the source of truth for exact runtime behavior.
 
-Intercepting profile:
+## 13. Research, Benchmarks, and Examples
 
-- MUST support pass-through when ITS is not activated
-- MUST document whether activated ITS failures pass through, return explicit errors, or vary by
-  error class
+### 13.1 Benchmark Surface
 
-## 11. Research, Benchmarking, and Example Tooling
+The benchmark surface includes dataset-driven evaluation entrypoints under:
 
-### 11.1 Benchmark Script
-
-`scripts/benchmark.py` is the repository's primary research/benchmark entrypoint.
-
-Current responsibilities:
-
-- load benchmark datasets
-- instantiate a selected algorithm and model adapter
-- run across one or more budgets
-- optionally evaluate results
-- save and display outputs
+- `benchmarking/` on `origin/v1`
+- `scripts/benchmark.py` on legacy flat-layout branches
 
 Current benchmark datasets include:
 
 - MATH-500
 - AIME-2024
 
-Current benchmark-facing algorithm set includes:
+### 13.2 Examples
 
-- self-consistency
-- beam-search
-- particle-filtering
-- entropic-particle-filtering
+The repository family includes runnable examples and notebook-like artifacts, typically under
+`examples/`, `scripts/`, `notebooks/`, or equivalent branch-specific locations, for:
 
-### 11.2 Example Script
+- self-consistency usage
+- math-oriented reasoning flows
+- experimental reasoning/search workflows where installed
 
-`scripts/test_math_example.py` is a runnable example showing:
+## 14. Development, Testing, and Quality
 
-- local OpenAI-compatible/vLLM inference
-- step generation
-- a process reward model
-- particle filtering on math prompts
-
-### 11.3 Research Dependencies
-
-The `research` extra adds repository tooling for:
-
-- dataset loading
-- answer verification
-- visualization and result analysis
-
-## 12. Documentation Surface
-
-### 12.1 Documentation Paths
-
-The repository's documentation surface includes:
-
-- `README.md`
-  - top-level orientation
-- `docs/installation.md`
-  - installation profiles and dependency expectations
-- `docs/quick-start.md`
-  - common usage flows
-- `docs/algorithms.md`
-  - algorithm-level user guidance
-- `docs/benchmarking.md`
-  - research and evaluation workflow
-- `docs/iaas-service.md`
-  - gateway/service usage
-- `docs/development.md`
-  - contributor guidance
-- `docs/PLANNING_WRAPPER.md`
-  - planning-wrapper usage and behavior
-
-### 12.2 Documentation Contract
-
-Documentation is descriptive and user-facing.
-
-This specification is normative for the repository contract when the docs and implementation differ
-at a conceptual level, but implementation details remain the ultimate source of truth for exact
-runtime behavior.
-
-## 13. Development, Testing, and Quality
-
-### 13.1 Development Setup
+### 14.1 Development Setup
 
 The repository supports:
 
 - `uv sync --extra dev`
 - `pip install -e ".[dev]"`
 
-Python version expectations:
+Python expectations:
 
-- Python `>= 3.10`
+- `origin/v1`: Python `>= 3.11`
+- current branch / `origin/envoy_ext_proc`: Python `>= 3.10`
 
-### 13.2 Test Surface
+### 14.2 Test Surface
 
-Tests live under `tests/` and cover core repository behaviors such as:
+Across the repository family, tests and validation assets MAY cover behaviors such as:
 
-- algorithms
-- language-model adapters
+- message and normalization behavior
+- orchestrator behavior and concurrency semantics
+- stable algorithms
 - tool-calling behavior
-- planning wrapper
-- reward-model integration
-- gateway/service behavior
+- judge behavior
+- planning wrapper / experimental behavior where present
+- gateway-specific behavior for the IaaS profile and, where present, Envoy-related flows
 
-### 13.3 Code Quality
+Concrete coverage differs by branch. For example, current Python coverage is centered on the core
+algorithms and the FastAPI IaaS profile, while the Envoy gateway profile currently also relies on
+branch-specific deployment artifacts and script-level validation.
 
-Current repository quality tooling:
+### 14.3 Quality Tooling
+
+Current repository quality tooling includes:
 
 - `pytest`
-- `ruff check`
-- `ruff format`
+- `ruff`
 
-### 13.4 Notebooks and Examples
+## 15. Validation Matrix
 
-Development and research workflows MAY include notebooks and synced notebook artifacts. Their exact
-presence is repository-version-dependent and not part of the core conformance contract.
+A conforming implementation or faithful port SHOULD include tests for the behaviors below.
 
-## 14. Test and Validation Matrix
-
-A conforming repository implementation or faithful port SHOULD include tests for the behaviors below.
-
-### 14.1 Message and Input Model
+### 15.1 Message and Input Model
 
 - string prompts normalize into a single `user` message
 - chat histories preserve role/content/tool-call fields
 - multimodal text extraction behaves consistently
 - tool-call-bearing assistant messages preserve tool-call structures
 
-### 14.2 Provider Adapters
+### 15.2 LM and Orchestrator Contracts
 
-- OpenAI-compatible request shaping is valid
-- batched generation returns one response per candidate
-- tool definitions and tool choice are forwarded correctly
-- transient provider failures are handled according to documented retry policy
+- LM adapters return one response per logical request
+- orchestrators preserve input ordering
+- concurrency limits behave as documented
+- tools, tool choice, and `response_format` are forwarded correctly
 
-### 14.3 Algorithms
+### 15.3 Stable Algorithms
 
-- self-consistency selects from repeated candidates correctly
+- self-consistency selects repeated candidates correctly
 - tool-voting modes behave as documented
 - best-of-n uses outcome scoring correctly
+- result objects expose `the_one`
+
+### 15.4 Experimental Algorithms
+
+If experimental algorithms are implemented or installed:
+
 - beam search uses step generation and beam width correctly
-- particle-filtering family handles particle budget semantics correctly
-- planning wrapper allocates budget across approaches correctly
-- exported incomplete algorithms are either clearly disabled or tested as intentionally unimplemented
+- particle methods handle budget semantics correctly
+- prompt-string fallback behavior is documented
 
-### 14.4 Reward Integrations
+### 15.5 Current FastAPI IaaS Profile
 
-- outcome reward adapters accept prompt/message inputs
-- process reward adapters accept step-wise inputs
-- reward-hub integration preserves expected score shapes
+- `/configure` validates supported algorithm and provider shapes
+- `/v1/models` reflects configured models
+- `/v1/chat/completions` requires configured model state
+- request-body `budget` drives ITS execution
+- tool calls are preserved when produced by the selected algorithm path
+- streaming returns `501 Not Implemented`
+- usage behavior matches the current zero-token implementation or later documented replacement
 
-### 14.5 Gateway Profiles
+### 15.6 Envoy ext-proc Profile
 
-- configured-service profile:
-  - `/configure` applies the active policy
-  - `/v1/chat/completions` resolves request + policy into execution config
-  - tool-call responses are preserved
-  - error cases behave as documented
-- intercepting profile:
-  - requests without ITS activation pass through
-  - requests with ITS activation may be short-circuited
-  - missing-model and ITS-failure fallback behavior matches documentation
+- requests without ITS activation pass through
+- requests with valid ITS activation may be short-circuited
+- missing-model behavior matches documented fallback
+- OpenAI-compatible response shaping is correct
+- `x-its-applied: true` is present on ITS responses
+- aggregated usage behavior matches implementation
 
-### 14.6 Benchmark and Tooling
+## 16. Implementation Checklist
 
-- benchmark dataset loading succeeds for supported datasets
-- benchmark CLI parses budgets and algorithm names correctly
-- example scripts instantiate documented components correctly
-
-## 15. Implementation Checklist
-
-### 15.1 Core Repository Checklist
+### 16.1 Core Repository Checklist
 
 - message normalization layer
 - abstract language-model contract
+- abstract orchestrator contract
 - abstract ITS algorithm contract
 - abstract reward-model contracts
-- step-wise generation helper
-- at least one concrete model adapter
-- at least one concrete ITS algorithm
-- at least one reward-model integration
-- docs and tests for supported surfaces
+- stable algorithms (`SelfConsistency`, `BestOfN`)
+- docs and tests for supported core surfaces
 
-### 15.2 Current Repository-Family Checklist
+### 16.2 Optional Built-in Implementation Checklist
 
 - `OpenAICompatibleLanguageModel`
-- `LiteLLMLanguageModel`
-- `SelfConsistency`
-- `BestOfN`
-- `BeamSearch`
-- particle-filtering family
-- `reward_hub` integration
-- direct-service gateway profile
-- benchmark and example scripts
+- `LMOrchestrator`
+- `LLMJudge`
+- `StepGeneration`
+- experimental algorithms behind the documented optional profiles
 
-### 15.3 Gateway Checklist
+### 16.3 Gateway Checklist
 
-- normalized gateway execution config
+For the current FastAPI IaaS profile:
+
+- `/configure` runtime setup
+- `/v1/models` model enumeration
+- OpenAI-compatible chat-completions response shaping
+- request-body `budget` handling
+- documented non-streaming behavior
+
+For the Envoy ext-proc profile:
+
+- request-scoped ITS config parsing
+- header-driven ITS activation
+- pass-through fallback behavior
 - OpenAI-compatible response shaping
-- configured-service profile support
-- intercepting-profile contract support if that profile is implemented
-- documented streaming behavior
-- documented usage-accounting mode
-- documented ITS failure behavior
+- documented usage accounting mode
+- documented non-streaming behavior
 
-## 16. Reference Algorithms (Language-Agnostic)
+## Appendix A. Non-Normative Notes
 
-### 16.1 Generic ITS Execution
+1. `Repository center of gravity`
+   - `origin/v1` is the design baseline for the core library surface.
 
-```text
-function run_its_request(lm, algorithm, prompt_or_messages, budget, tools, tool_choice):
-  normalized_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
+2. `Why this spec documents multiple branch states`
+   - The repository family currently has a split between the `origin/v1` library refactor and
+     gateway implementations that still live on flat-layout branches.
+   - This specification deliberately keeps the core contract and the gateway profiles separate so
+     future design changes can be made in `SPEC.md` first.
 
-  result = algorithm.ainfer(
-    lm=lm,
-    prompt_or_messages=normalized_messages,
-    budget=budget,
-    return_response_only=false,
-    tools=tools,
-    tool_choice=tool_choice
-  )
+3. `Current gateway inventory`
+   - The current branch still has a concrete FastAPI IaaS service.
+   - `origin/envoy_ext_proc` has a concrete Envoy external-processing gateway profile.
 
-  return result.the_one
-```
-
-### 16.2 Configured-Service Gateway Handling
-
-```text
-function handle_configured_chat_completion(request):
-  validate request.messages is non-empty
-  validate request.budget in 1..1000
-
-  if active_gateway_policy is missing:
-    return error("service_not_configured")
-
-  provider_config = active_gateway_policy.registered_models[request.model]
-  if provider_config is missing:
-    return error("unknown_model")
-
-  execution_config = {
-    model: request.model,
-    algorithm: active_gateway_policy.active_algorithm,
-    budget: request.budget,
-    provider: provider_config,
-    algorithm_config: active_gateway_policy.active_algorithm_config,
-    reward_config: active_gateway_policy.active_reward_config,
-    response_mode: request.return_response_only
-      ? "selected_message_only"
-      : "selected_message_with_metadata"
-  }
-
-  result = orchestrator.run(
-    execution_config,
-    messages=request.messages,
-    tools=request.tools,
-    tool_choice=request.tool_choice
-  )
-
-  return shape_openai_response(result)
-```
-
-### 16.3 Intercepting Gateway Handling
-
-```text
-function handle_intercepted_chat_completion(request_path, headers, body):
-  if request_path is not "/v1/chat/completions":
-    return pass_through()
-
-  budget = parse_int(headers["x-its-budget"])
-  endpoint = headers["x-its-endpoint"]
-  api_key = headers["x-its-api-key"]
-
-  if budget invalid or endpoint missing:
-    return pass_through()
-
-  request = parse_json(body)
-  if request.model missing:
-    return documented_fallback_for_missing_model()
-
-  execution_config = {
-    model: request.model,
-    algorithm: interceptor_default_algorithm,
-    budget: budget,
-    provider: {
-      kind: interceptor_provider_kind,
-      endpoint: endpoint,
-      api_key: api_key
-    },
-    algorithm_config: interceptor_algorithm_config,
-    reward_config: interceptor_reward_config,
-    response_mode: "selected_message_only"
-  }
-
-  result = orchestrator.run(
-    execution_config,
-    messages=request.messages,
-    tools=request.tools,
-    tool_choice=request.tool_choice
-  )
-
-  if result succeeded:
-    return immediate_openai_response(result, headers={"x-its-applied": "true"})
-
-  return documented_fallback_for_its_failure()
-```
-
-### 16.4 Benchmark Execution
-
-```text
-function run_benchmark(dataset, algorithm_name, model, budgets):
-  problems = load_dataset(dataset)
-
-  for budget in budgets:
-    algorithm = init_algorithm(algorithm_name, ...)
-
-    for problem in problems:
-      response = algorithm.infer(model, problem.prompt, budget)
-      record_result(problem, budget, response)
-
-  return aggregate_results()
-```
-
-## Appendix A. Non-Normative Side Notes
-
-These notes are intentionally outside the conformance requirements. They identify areas where the
-current repository implementation family may evolve in a future revision.
-
-1. `Gateway-only vs repository-wide scope`
-   - This `SPEC.md` is intentionally repository-wide.
-   - The gateway specification is included here as one subsystem rather than standing alone.
-
-2. `Configured-service policy granularity`
-   - The current configured-service style keeps one active ITS policy for all requests, even though
-     it also keeps a model registry.
-   - A future revision may define per-model or per-route policies.
-
-3. `Configured-service validation drift`
-   - Current configured-service examples and exact implementation validation rules are not perfectly
-     aligned in every case.
-   - This specification captures the conceptual contract rather than every accidental detail.
-
-4. `Intercepting profile algorithm selection`
-   - The current intercepting profile activates ITS through headers but does not yet standardize full
-     per-request algorithm selection.
-
-5. `Usage accounting`
-   - Current repository-family implementations differ between placeholder usage and aggregated actual
-     usage.
-
-6. `Streaming`
-   - Streaming ITS semantics are not standardized in this version.
-
-7. `Incomplete exported surfaces`
-   - Some exported classes are intentionally incomplete or experimental.
-   - Future revisions may separate stable and experimental exports more explicitly.
+4. `Migration direction`
+   - The long-term design direction is library-first with gateway runtimes treated as integrations,
+     not as the center of the repository contract.

--- a/SPEC.md
+++ b/SPEC.md
@@ -186,6 +186,19 @@ Composition rules:
 - Sections marked OPTIONAL are extension profiles.
 - An implementation MAY support multiple extensions at once.
 
+Conformance claim model:
+
+- `Core Library Conformance`
+  - means the implementation satisfies Profile 1 only
+- `Extension Conformance`
+  - means the implementation satisfies `Core Library Conformance` plus one or more named extension
+    profiles from this section
+- `Full Algorithm Conformance`
+  - means the implementation satisfies:
+    - `Core Library Conformance`
+    - at least one stable algorithm profile from Section 7
+    - every scoring extension required by the claimed stable algorithm profile(s)
+
 ### 3.4 External Dependencies
 
 Common external dependencies include:
@@ -282,7 +295,7 @@ Required behaviors:
 
 - normalize string prompts into structured messages
 - return structured chat messages as the primary representation
-- produce repeated batches of equivalent conversations for parallel generation
+- support derivation of multiple equivalent conversation instances for parallel generation
 - provide a prompt-string fallback representation for compatibility-oriented paths when needed
 
 #### 4.1.5 `ScalingCandidate`
@@ -506,6 +519,11 @@ Required semantics:
 - A gateway profile MAY choose fallback only when the gateway profile explicitly permits fallback.
 
 ## 6. Optional Scoring Extensions
+
+Shared score semantics:
+
+- Scores are numeric values whose only guaranteed semantic is relative ordering within a single
+  execution. No fixed range, normalization, or cross-execution comparability is required.
 
 ### 6.1 `Outcome Reward Extension`
 
@@ -1491,7 +1509,7 @@ Use the same validation profiles as Section 14:
 - documentation of failure behavior and trust boundary
 - deterministic tests for supported core behavior
 
-Additional rule for full algorithm conformance:
+Requirement for `Full Algorithm Conformance`:
 
 - implement at least one stable algorithm profile from Section 7
 


### PR DESCRIPTION
## Summary
- add a repo-wide `SPEC.md` that defines the current `its_hub` architecture, package surfaces, and repository contracts
- include the gateway specification as one subsystem, covering both configured-service and intercepting gateway profiles
- capture algorithm, integration, tooling, validation, and reference-flow expectations in a language-agnostic form

## Test plan
- [x] Reviewed the generated `SPEC.md` for repository scope and gateway coverage
- [ ] Automated tests not run (docs-only change)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Demo” section to the README, including a walkthrough video, a direct browser demo link, and links to demo setup instructions.
  * Introduced a comprehensive `SPEC.md` draft describing the library-first system contract for LLM inference-time scaling, including core abstractions, normalization rules, algorithm profiles, gateway integration options, and observability/failure-handling guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->