### PR TITLE
(fix) Update git workflows to reflect branch naming changes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - "main"
-      - "v1"
       - "release-**"
   pull_request:
     branches:
       - "main"
-      - "v1"
       - "release-**"
     paths:
       - "its_hub/**"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,13 +5,13 @@ name: Build, test, and upload PyPI package
 on:
     push:
         branches:
-            - "v1"
+            - "main"
             - "release-**"
         tags:
             - "v*"
     pull_request:
         branches:
-            - "v1"
+            - "main"
             - "release-**"
     release:
         types:

--- a/.github/workflows/sync-notebooks.yaml
+++ b/.github/workflows/sync-notebooks.yaml
@@ -2,7 +2,7 @@ name: Sync Notebooks
 
 on:
   pull_request:
-    branches: [ v1 ]
+    branches: [ main ]
     paths: [ 'notebooks/**/*.py', 'notebooks/**/*.ipynb' ]
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,12 +6,10 @@ on:
   push:
     branches:
       - "main"
-      - "v1"
       - "release-**"
   pull_request:
     branches:
       - "main"
-      - "v1"
       - "release-**"
     paths:
       - "its_hub/**"


### PR DESCRIPTION
## Description

v1 was recently renamed to main. The GitHub workflows still use v1 as the default branch especially for release workflows. This PR updates workflows to use main for trigger events. 

Closes #239 

### Test Plan

- [x] Unit tests
- [x] E2E tests