### PR TITLE
fix: concurrency in pytest

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -215,8 +215,13 @@ class TestParameterForwarding:
         lm = MockLM()
         temps = [0.5, 0.8, 1.0]
         await orch.agenerate(lm, _make_batch(3), temperature=temps)
-        for call, expected_temp in zip(lm.calls, temps):
-            assert call["temperature"] == expected_temp
+        # Match by content (run_in_executor does not guarantee execution or completion order)
+        temp_by_msg = {
+            call["messages"][0].content: call["temperature"]
+            for call in lm.calls
+        }
+        for i, expected_temp in enumerate(temps):
+            assert temp_by_msg[f"msg-{i}"] == expected_temp
 
     @pytest.mark.asyncio
     async def test_include_stop_str_forwarded(self):

--- a/tests/test_raw_choices.py
+++ b/tests/test_raw_choices.py
@@ -44,21 +44,13 @@ class RawChoiceMockLM:
 class RawChoiceMockORM:
     """Mock outcome reward model that returns predetermined scores."""
 
-    def __init__(self, scores: list[float]):
-        self.scores = scores
+    def __init__(self, score_map: dict[str, float]):
+        self.score_map = score_map
         self.call_count = 0
 
-    def score(self, messages, **kwargs):
-        if isinstance(messages[0], list):
-            out = self.scores[self.call_count : self.call_count + len(messages)]
-            self.call_count += len(messages)
-            return out
-        s = self.scores[self.call_count % len(self.scores)]
-        self.call_count += 1
-        return s
-
-    async def ascore(self, messages, orchestrator=None, **kwargs):
-        return self.score(messages)
+    async def ascore(self, conversations, orchestrator=None, **kwargs):
+        self.call_count = len(conversations)
+        return [self.score_map[conv[-1].content] for conv in conversations]
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +153,7 @@ async def test_self_consistency_raw_choices_return_response_only():
 async def test_best_of_n_with_raw_choices():
     """BestOfN should work when responses contain _raw_choice."""
     lm = RawChoiceMockLM(["resp A", "resp B", "resp C"])
-    orm = RawChoiceMockORM([0.3, 0.9, 0.1])
+    orm = RawChoiceMockORM({"resp A": 0.3, "resp B": 0.9, "resp C": 0.1})
     bon = BestOfN(orm=orm)
 
     result = await bon.ainfer(lm, "test", budget=3, return_response_only=False)
@@ -176,14 +168,15 @@ async def test_best_of_n_dedup_with_raw_choices():
     """BestOfN deduplication must not break on _raw_choice metadata.
 
     Two "same" responses get deduped, so only 2 unique candidates are scored.
-    The ORM returns [0.5, 0.8] — "different" wins with score 0.8."""
-    lm = RawChoiceMockLM(["same", "same", "different"])
-    orm = RawChoiceMockORM([0.5, 0.8])
+    "answer B" scores higher (0.8 vs 0.5) and wins."""
+    lm = RawChoiceMockLM(["answer A", "answer A", "answer B"])
+    orm = RawChoiceMockORM({"answer A": 0.5, "answer B": 0.8})
     bon = BestOfN(orm=orm)
 
     result = await bon.ainfer(lm, "test", budget=3, return_response_only=False)
 
-    assert result.the_one["content"] == "different"
+    assert orm.call_count == 2
+    assert result.the_one["content"] == "answer B"
     json.dumps(result.the_one)
 
 


### PR DESCRIPTION
## Summary

Fixed two tests that assumed that `run_in_executor` would guarantee execution order (it seems that Python 3.14 is the first version where that guarantee doesn't hold).

- `test_per_message_temperature`: match calls by message content instead of position
- `test_best_of_n_with_raw_choices`: score by response content instead of position

## Checklist

- [x] Tests pass (`uv run pytest tests/test_orchestrator.py tests/test_raw_choices.py -v`)
- [x] Linting passes (`uv run ruff check its_hub/`)
- [x] Formatting passes (`uv run ruff format --check its_hub/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Tests**
  - Improved reliability of per-message temperature checks by aligning each response with its corresponding input content.
  - Updated best-of-N coverage to use content-based scoring and adjusted winner expectations.
  - Added verification of scoring call counts during evaluation.
- **CI / Automation**
  - Expanded the unit test workflow to run on Python 3.11–3.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->