### PR TITLE
(fix) trigger publish to test pypi action when a PR is merged to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,11 +53,11 @@ jobs:
 
     # push to Test PyPI on
     # - a new GitHub release is published
-    # - a PR is merged into v1 branch
+    # - a PR is merged into main branch
     publish-test-pypi:
         name: Publish packages to test.pypi.org
         # environment: publish-test-pypi
-        if: ${{ (github.repository_owner == 'Red-Hat-AI-Innovation-Team') && ((github.event.action == 'published') || ((github.event_name == 'push') && (github.ref == 'refs/heads/v1'))) }}
+        if: ${{ (github.repository_owner == 'Red-Hat-AI-Innovation-Team') && ((github.event.action == 'published') || ((github.event_name == 'push') && (github.ref == 'refs/heads/main'))) }}
         permissions:
             contents: read
             # see https://docs.pypi.org/trusted-publishers/


### PR DESCRIPTION
## Summary

The test pypi action still references v1, therefore any pushes to main doesn't trigger this action. This PR updates conditional to reference main instead of v1.  

## Test Plan

<!-- Describe how you tested these changes -->

- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Linting passes (`uv run ruff check its_hub/`)
- [x] Formatting passes (`uv run ruff format --check its_hub/`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Test PyPI publishing workflow to run when changes are pushed to the `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->