### PR TITLE
simplify: reduce GIL overhead, deduplicate test helpers, clean up wrapper

### DIFF
--- a/its_hub/core/orchestrator.py
+++ b/its_hub/core/orchestrator.py
@@ -170,13 +170,11 @@ class LMOrchestrator(AbstractOrchestrator):
 
 
 
-
-
 class RustLMOrchestrator(AbstractOrchestrator):
     """ABC-inheriting wrapper around the PyO3 _RustLMOrchestrator.
 
     PyO3 classes cannot inherit from Python ABCs, so this thin wrapper
-    inherits AbstractOrchestrator and is a thin wrapper of the Rust implementation.
+    delegates to the Rust implementation.
     """
 
     def __init__(self, max_concurrency: int = 32):

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -79,16 +79,9 @@ impl RustLMOrchestrator {
         let n = messages_lst.len();
 
         if n == 0 {
-            let empty = pyo3_async_runtimes::tokio::future_into_py::<_, PyObject>(
-                py,
-                async move {
-                    Python::with_gil(|py| {
-                        let list = PyList::empty(py);
-                        Ok(list.unbind().into())
-                    })
-                },
-            )?;
-            return wrap_future_as_coroutine(py, &empty);
+            let ns = PyDict::new(py);
+            py.run(c"async def _e():\n    return []\n_c = _e()", Some(&ns), Some(&ns))?;
+            return Ok(ns.get_item("_c")?.expect("empty coroutine"));
         }
 
         let resolved_mct =
@@ -119,18 +112,23 @@ impl RustLMOrchestrator {
         let sem = self.semaphore.clone();
 
         let future = pyo3_async_runtimes::tokio::future_into_py::<_, PyObject>(py, async move {
-            let futures: Vec<_> = (0..n)
-                .map(|i| {
-                    let sem = sem.clone();
-                    let (lm, msgs, base_kwargs, temp) = Python::with_gil(|py| {
+            let prepared: Vec<_> = Python::with_gil(|py| {
+                (0..n)
+                    .map(|i| {
                         (
                             lm.clone_ref(py),
                             messages[i].clone_ref(py),
                             base_kwargs.clone_ref(py),
                             temperatures[i].clone_ref(py),
                         )
-                    });
+                    })
+                    .collect()
+            });
 
+            let futures: Vec<_> = prepared
+                .into_iter()
+                .map(|(lm, msgs, base_kwargs, temp)| {
+                    let sem = sem.clone();
                     async move {
                         let _permit = match &sem {
                             Some(s) => Some(s.acquire().await.expect("semaphore never closed")),
@@ -160,30 +158,25 @@ impl RustLMOrchestrator {
                     let list = PyList::new(py, results.iter().map(|r| r.bind(py)))?;
                     Ok(list.unbind().into())
                 }),
-                Err(e) => {
-                    let msg = Python::with_gil(|py| {
-                        let type_name = e
-                            .value(py)
-                            .get_type()
-                            .name()
-                            .map(|n| n.to_string())
-                            .unwrap_or_else(|_| "Unknown".to_string());
-                        format!(
-                            "LMOrchestrator: 1 error(s), {} cancelled out of {} generation(s) (1x {})",
-                            n - 1,
-                            n,
-                            type_name
-                        )
-                    });
+                Err(e) => Python::with_gil(|py| {
+                    let type_name = e
+                        .value(py)
+                        .get_type()
+                        .name()
+                        .map(|n| n.to_string())
+                        .unwrap_or_else(|_| "Unknown".to_string());
+                    let msg = format!(
+                        "LMOrchestrator: 1 error(s), {} cancelled out of {} generation(s) (1x {})",
+                        n - 1,
+                        n,
+                        type_name
+                    );
                     let runtime_err = PyErr::new::<PyRuntimeError, _>(msg);
-                    Python::with_gil(|py| {
-                        runtime_err
-                            .value(py)
-                            .setattr("__cause__", e.value(py))?;
-                        Ok::<_, PyErr>(())
-                    })?;
+                    runtime_err
+                        .value(py)
+                        .setattr("__cause__", e.value(py))?;
                     Err(runtime_err)
-                }
+                })
             }
         })?;
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -98,9 +98,14 @@ def _make_batch(n: int) -> list[list[ChatMessage]]:
     ]
 
 
+def _unwrap(orchestrator):
+    """Get the inner implementation (unwrap RustLMOrchestrator to its delegate)."""
+    return getattr(orchestrator, "_inner", orchestrator)
+
+
 def _sem_value(orchestrator) -> int:
     """Read the semaphore counter (works for Python, raw Rust, and wrapped Rust)."""
-    inner = orchestrator._inner if hasattr(orchestrator, "_inner") else orchestrator
+    inner = _unwrap(orchestrator)
     if hasattr(inner, "_semaphore_value"):
         val = inner._semaphore_value()
         assert val is not None
@@ -111,7 +116,7 @@ def _sem_value(orchestrator) -> int:
 
 def _has_semaphore(orchestrator) -> bool:
     """Check whether the orchestrator has a semaphore."""
-    inner = orchestrator._inner if hasattr(orchestrator, "_inner") else orchestrator
+    inner = _unwrap(orchestrator)
     if hasattr(inner, "_has_semaphore"):
         return inner._has_semaphore()
     return inner._semaphore is not None


### PR DESCRIPTION
## Summary
- Merge two separate `Python::with_gil` calls in Rust error path into one (eliminates redundant GIL acquire/release)
- Hoist per-future GIL acquisitions outside the iterator loop (N acquires → 1 for batch cloning)
- Simplify empty-batch path to return `[]` directly via inline coroutine instead of spawning a tokio future + wrapping it
- Extract `_unwrap()` test helper to deduplicate the `_inner` unwrapping pattern shared by `_sem_value` and `_has_semaphore`
- Fix 4→2 blank lines between classes and redundant "thin wrapper" phrasing in `RustLMOrchestrator` docstring

## Test plan
- [x] `cargo check` — Rust compiles cleanly
- [x] All 124 orchestrator tests pass (Python, rust-raw, rust-abc parametrizations)