### PR TITLE
[feat] Add AdaptiveSelfConsistency algorithm with exponential doubling and early stopping

### DIFF
--- a/its_hub/__init__.py
+++ b/its_hub/__init__.py
@@ -13,6 +13,7 @@ from its_hub.api import (
     AbstractScalingAlgorithm,
     AbstractScalingResult,
 )
+from its_hub.core.algorithms.adaptive_self_consistency import AdaptiveSelfConsistency
 from its_hub.core.algorithms.bon import BestOfN
 from its_hub.core.algorithms.self_consistency import SelfConsistency
 
@@ -30,6 +31,7 @@ __all__ = [  # noqa: RUF022
     "AbstractProcessRewardModel",
     "AbstractScalingResult",
     # Algorithms
+    "AdaptiveSelfConsistency",
     "SelfConsistency",
     "BestOfN",
 ]

--- a/its_hub/core/algorithms/adaptive_self_consistency.py
+++ b/its_hub/core/algorithms/adaptive_self_consistency.py
@@ -5,48 +5,47 @@ from collections.abc import Callable
 from its_hub.api import (
     AbstractLanguageModel,
     AbstractOrchestrator,
-    AbstractScalingAlgorithm,
     ChatMessage,
     ChatMessages,
     GenerationUsage,
 )
 from its_hub.core.algorithms.self_consistency import (
+    SelfConsistency,
     SelfConsistencyResult,
-    _default_projection_func,
-    _select_hierarchical_most_common_or_random,
-    _select_most_common_or_random,
 )
-from its_hub.core.orchestrator import LMOrchestrator
-from its_hub.core.utils import extract_content_from_lm_response
 
 logger = logging.getLogger(__name__)
 
 
-class AdaptiveSelfConsistency(AbstractScalingAlgorithm):
+class AdaptiveSelfConsistency(SelfConsistency):
     """Self-consistency with exponential doubling and early stopping.
 
     Starts with 2 samples, checks if a supermajority (default 75%) agree,
     and doubles the sample count each round until the budget is reached.
     Previous samples are kept across rounds — no resampling.
+
+    Inherits tool_vote, exclude_args, and projection support from
+    SelfConsistency.
     """
 
     def __init__(
         self,
         threshold: float = 0.75,
         consistency_space_projection_func: Callable | None = None,
+        tool_vote: str | None = None,
+        exclude_args: list[str] | None = None,
         orchestrator: AbstractOrchestrator | None = None,
     ):
         if not 0.5 < threshold <= 1.0:
             raise ValueError(f"threshold must be in (0.5, 1.0], got: {threshold}")
 
-        self.threshold = threshold
-        self.consistency_space_projection_func = (
-            consistency_space_projection_func or _default_projection_func
+        super().__init__(
+            consistency_space_projection_func=consistency_space_projection_func,
+            tool_vote=tool_vote,
+            exclude_args=exclude_args,
+            orchestrator=orchestrator,
         )
-
-        if orchestrator is None:
-            orchestrator = LMOrchestrator()
-        self.orchestrator = orchestrator
+        self.threshold = threshold
 
     async def ainfer(
         self,
@@ -81,26 +80,23 @@ class AdaptiveSelfConsistency(AbstractScalingAlgorithm):
             if len(all_responses) >= budget:
                 break
 
-            projected = [
-                self.consistency_space_projection_func(
-                    extract_content_from_lm_response(r)
-                )
-                for r in all_responses
-            ]
-            counts = Counter(projected)
-            top_count = counts.most_common(1)[0][1]
-            agreement = top_count / len(all_responses)
+            eligible_indices, projected = self._project_responses(all_responses)
 
-            if agreement >= self.threshold:
-                logger.info(
-                    "Early stop at round %d: %d/%d samples agree (%.0f%% >= %.0f%%)",
-                    round_num,
-                    top_count,
-                    len(all_responses),
-                    agreement * 100,
-                    self.threshold * 100,
-                )
-                break
+            if eligible_indices:
+                counts = Counter(projected)
+                top_count = counts.most_common(1)[0][1]
+                agreement = top_count / len(eligible_indices)
+
+                if agreement >= self.threshold:
+                    logger.info(
+                        "Early stop at round %d: %d/%d samples agree (%.0f%% >= %.0f%%)",
+                        round_num,
+                        top_count,
+                        len(eligible_indices),
+                        agreement * 100,
+                        self.threshold * 100,
+                    )
+                    break
 
             # Double: next batch size equals current total
             next_batch_size = len(all_responses)
@@ -113,29 +109,3 @@ class AdaptiveSelfConsistency(AbstractScalingAlgorithm):
         )
 
         return self._process_responses(all_responses, return_response_only, usage)
-
-    def _process_responses(
-        self,
-        responses: list[dict],
-        return_response_only: bool = True,
-        usage: GenerationUsage | None = None,
-    ) -> dict | SelfConsistencyResult:
-        projected = [
-            self.consistency_space_projection_func(extract_content_from_lm_response(r))
-            for r in responses
-        ]
-
-        if projected and isinstance(projected[0], tuple):
-            counts, selected_index = _select_hierarchical_most_common_or_random(
-                projected
-            )
-        else:
-            counts, selected_index = _select_most_common_or_random(projected)
-
-        result = SelfConsistencyResult(
-            responses=responses,
-            response_counts=counts,
-            selected_index=selected_index,
-            usage=usage,
-        )
-        return result.the_one if return_response_only else result

--- a/its_hub/core/algorithms/adaptive_self_consistency.py
+++ b/its_hub/core/algorithms/adaptive_self_consistency.py
@@ -1,0 +1,141 @@
+import logging
+from collections import Counter
+from collections.abc import Callable
+
+from its_hub.api import (
+    AbstractLanguageModel,
+    AbstractOrchestrator,
+    AbstractScalingAlgorithm,
+    ChatMessage,
+    ChatMessages,
+    GenerationUsage,
+)
+from its_hub.core.algorithms.self_consistency import (
+    SelfConsistencyResult,
+    _default_projection_func,
+    _select_hierarchical_most_common_or_random,
+    _select_most_common_or_random,
+)
+from its_hub.core.orchestrator import LMOrchestrator
+from its_hub.core.utils import extract_content_from_lm_response
+
+logger = logging.getLogger(__name__)
+
+
+class AdaptiveSelfConsistency(AbstractScalingAlgorithm):
+    """Self-consistency with exponential doubling and early stopping.
+
+    Starts with 2 samples, checks if a supermajority (default 75%) agree,
+    and doubles the sample count each round until the budget is reached.
+    Previous samples are kept across rounds — no resampling.
+    """
+
+    def __init__(
+        self,
+        threshold: float = 0.75,
+        consistency_space_projection_func: Callable | None = None,
+        orchestrator: AbstractOrchestrator | None = None,
+    ):
+        if not 0.5 < threshold <= 1.0:
+            raise ValueError(f"threshold must be in (0.5, 1.0], got: {threshold}")
+
+        self.threshold = threshold
+        self.consistency_space_projection_func = (
+            consistency_space_projection_func or _default_projection_func
+        )
+
+        if orchestrator is None:
+            orchestrator = LMOrchestrator()
+        self.orchestrator = orchestrator
+
+    async def ainfer(
+        self,
+        lm: AbstractLanguageModel,
+        prompt_or_messages: str | list[ChatMessage] | ChatMessages,
+        budget: int,
+        return_response_only: bool = True,
+        tools: list[dict] | None = None,
+        tool_choice: str | dict | None = None,
+    ) -> dict | SelfConsistencyResult:
+        chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
+        usage = GenerationUsage()
+
+        all_responses: list[dict] = []
+        next_batch_size = min(2, budget)
+        round_num = 0
+
+        while len(all_responses) < budget:
+            batch_size = min(next_batch_size, budget - len(all_responses))
+            round_num += 1
+
+            new_responses = await self.orchestrator.agenerate(
+                lm,
+                chat_messages.to_batch(batch_size),
+                tools=tools,
+                tool_choice=tool_choice,
+                usage_accumulator=usage,
+            )
+            all_responses.extend(new_responses)
+
+            # Check stopping criterion (skip if we've exhausted the budget)
+            if len(all_responses) >= budget:
+                break
+
+            projected = [
+                self.consistency_space_projection_func(
+                    extract_content_from_lm_response(r)
+                )
+                for r in all_responses
+            ]
+            counts = Counter(projected)
+            top_count = counts.most_common(1)[0][1]
+            agreement = top_count / len(all_responses)
+
+            if agreement >= self.threshold:
+                logger.info(
+                    "Early stop at round %d: %d/%d samples agree (%.0f%% >= %.0f%%)",
+                    round_num,
+                    top_count,
+                    len(all_responses),
+                    agreement * 100,
+                    self.threshold * 100,
+                )
+                break
+
+            # Double: next batch size equals current total
+            next_batch_size = len(all_responses)
+
+        logger.info(
+            "AdaptiveSelfConsistency used %d/%d samples in %d round(s)",
+            len(all_responses),
+            budget,
+            round_num,
+        )
+
+        return self._process_responses(all_responses, return_response_only, usage)
+
+    def _process_responses(
+        self,
+        responses: list[dict],
+        return_response_only: bool = True,
+        usage: GenerationUsage | None = None,
+    ) -> dict | SelfConsistencyResult:
+        projected = [
+            self.consistency_space_projection_func(extract_content_from_lm_response(r))
+            for r in responses
+        ]
+
+        if projected and isinstance(projected[0], tuple):
+            counts, selected_index = _select_hierarchical_most_common_or_random(
+                projected
+            )
+        else:
+            counts, selected_index = _select_most_common_or_random(projected)
+
+        result = SelfConsistencyResult(
+            responses=responses,
+            response_counts=counts,
+            selected_index=selected_index,
+            usage=usage,
+        )
+        return result.the_one if return_response_only else result

--- a/its_hub/core/algorithms/self_consistency.py
+++ b/its_hub/core/algorithms/self_consistency.py
@@ -211,6 +211,39 @@ class SelfConsistency(AbstractScalingAlgorithm):
         # process responses and return result
         return self._process_responses(responses, return_response_only, usage)
 
+    def _project_responses(self, responses: list[dict]) -> tuple[list[int], list]:
+        """Project responses to comparable values for voting.
+
+        Handles tool-call vs content routing based on tool_vote setting.
+
+        Returns:
+            (eligible_indices, projected_values) where eligible_indices maps
+            back to positions in the original responses list.
+        """
+        tool_call_count = sum(1 for r in responses if r.get("tool_calls"))
+        required_majority = math.ceil(len(responses) / 2)
+        has_majority_tool_calls = tool_call_count >= required_majority
+
+        if has_majority_tool_calls and self.tool_vote:
+            eligible_indices = [
+                i for i, r in enumerate(responses) if r.get("tool_calls")
+            ]
+            projected = [
+                self._extract_tool_call_features(responses[i]) for i in eligible_indices
+            ]
+        else:
+            eligible_indices = [
+                i for i, r in enumerate(responses) if not r.get("tool_calls")
+            ]
+            projected = [
+                self.consistency_space_projection_func(
+                    extract_content_from_lm_response(responses[i])
+                )
+                for i in eligible_indices
+            ]
+
+        return eligible_indices, projected
+
     def _process_responses(
         self,
         responses: list[dict],
@@ -218,12 +251,8 @@ class SelfConsistency(AbstractScalingAlgorithm):
         usage: GenerationUsage | None = None,
     ) -> dict | SelfConsistencyResult:
         """Process responses and return result."""
-        # Check if majority of responses have tool calls to decide voting method
-        tool_call_count = sum(1 for r in responses if r.get("tool_calls"))
-        required_majority = math.ceil(len(responses) / 2)
-        has_majority_tool_calls = tool_call_count >= required_majority
-
         # Warn if tool calls detected but tool_vote not set
+        tool_call_count = sum(1 for r in responses if r.get("tool_calls"))
         if tool_call_count > 0 and not self.tool_vote:
             logging.warning(
                 f"Detected {tool_call_count}/{len(responses)} responses with tool calls, "
@@ -231,25 +260,7 @@ class SelfConsistency(AbstractScalingAlgorithm):
                 "(e.g., 'tool_name', 'tool_args', 'tool_hierarchical') for tool call voting."
             )
 
-        # Determine eligible responses and create projections
-        if has_majority_tool_calls and self.tool_vote:
-            eligible_indices = [
-                i for i, r in enumerate(responses) if r.get("tool_calls")
-            ]
-            responses_projected = [
-                self._extract_tool_call_features(responses[i]) for i in eligible_indices
-            ]
-        else:
-            # Content voting - filter out tool call responses
-            eligible_indices = [
-                i for i, r in enumerate(responses) if not r.get("tool_calls")
-            ]
-            responses_projected = [
-                self.consistency_space_projection_func(
-                    extract_content_from_lm_response(responses[i])
-                )
-                for i in eligible_indices
-            ]
+        eligible_indices, responses_projected = self._project_responses(responses)
 
         # Error if no eligible responses after filtering
         if not eligible_indices:

--- a/tests/test_adaptive_self_consistency.py
+++ b/tests/test_adaptive_self_consistency.py
@@ -1,0 +1,263 @@
+"""Tests for AdaptiveSelfConsistency algorithm."""
+
+import threading
+
+import pytest
+
+from its_hub.api import ChatMessages
+from its_hub.core.algorithms.adaptive_self_consistency import AdaptiveSelfConsistency
+from its_hub.core.algorithms.self_consistency import (
+    SelfConsistencyResult,
+    create_regex_projection_function,
+)
+from its_hub.core.orchestrator import LMOrchestrator
+
+
+class SequentialMockLM:
+    """Mock LM that returns responses in sequential order, thread-safe."""
+
+    def __init__(self, responses: list[str]):
+        self.responses = responses
+        self.call_count = 0
+        self._lock = threading.Lock()
+
+    async def agenerate_single(self, messages, **kwargs):
+        with self._lock:
+            idx = self.call_count % len(self.responses)
+            self.call_count += 1
+        return {"role": "assistant", "content": self.responses[idx]}
+
+
+class TestAdaptiveSelfConsistencyInit:
+    """Test constructor validation."""
+
+    def test_default_threshold(self):
+        asc = AdaptiveSelfConsistency()
+        assert asc.threshold == 0.75
+
+    def test_custom_threshold(self):
+        asc = AdaptiveSelfConsistency(threshold=0.9)
+        assert asc.threshold == 0.9
+
+    def test_threshold_at_boundary(self):
+        asc = AdaptiveSelfConsistency(threshold=1.0)
+        assert asc.threshold == 1.0
+
+    @pytest.mark.parametrize("bad_threshold", [0.0, 0.5, -0.1, 1.1])
+    def test_invalid_threshold_raises(self, bad_threshold):
+        with pytest.raises(ValueError, match="threshold must be in"):
+            AdaptiveSelfConsistency(threshold=bad_threshold)
+
+    def test_default_orchestrator_created(self):
+        asc = AdaptiveSelfConsistency()
+        assert isinstance(asc.orchestrator, LMOrchestrator)
+
+    def test_custom_orchestrator_used(self):
+        orch = LMOrchestrator(max_concurrency=4)
+        asc = AdaptiveSelfConsistency(orchestrator=orch)
+        assert asc.orchestrator is orch
+
+
+class TestAdaptiveSelfConsistencyEarlyStopping:
+    """Test the doubling + early stopping behavior."""
+
+    @pytest.mark.asyncio
+    async def test_stops_after_round_1_when_all_agree(self):
+        """2/2 = 100% >= 75% → stop after first round."""
+        lm = SequentialMockLM(["42"] * 8)
+        asc = AdaptiveSelfConsistency(threshold=0.75)
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        assert isinstance(result, SelfConsistencyResult)
+        assert len(result.responses) == 2
+        assert result.the_one["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_stops_after_round_2(self):
+        """Round 1: 1/2=50%. Round 2: 3/4=75% → stop."""
+        lm = SequentialMockLM(["42", "24", "42", "42", "x", "x", "x", "x"])
+        asc = AdaptiveSelfConsistency(threshold=0.75)
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        assert len(result.responses) == 4
+        assert result.the_one["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_uses_full_budget_when_no_agreement(self):
+        """Never reaches 75% → exhausts budget."""
+        lm = SequentialMockLM(["a", "b", "c", "d", "a", "b", "c", "d"])
+        asc = AdaptiveSelfConsistency(threshold=0.75)
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        assert len(result.responses) == 8
+
+    @pytest.mark.asyncio
+    async def test_doubling_sequence(self):
+        """Verify the 2→4→8 doubling pattern when threshold never met."""
+        lm = SequentialMockLM(["a", "b", "c", "d", "e", "f", "g", "h"])
+        asc = AdaptiveSelfConsistency(threshold=1.0)
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # With threshold=1.0 and all different answers, should use full budget
+        assert len(result.responses) == 8
+        # Verify call count matches budget
+        assert lm.call_count == 8
+
+    @pytest.mark.asyncio
+    async def test_partial_last_batch(self):
+        """Budget=5: rounds are 2→2→1 (last batch is partial)."""
+        lm = SequentialMockLM(["a", "b", "c", "d", "e"])
+        asc = AdaptiveSelfConsistency(threshold=1.0)
+
+        result = await asc.ainfer(lm, "test", budget=5, return_response_only=False)
+
+        assert len(result.responses) == 5
+        assert lm.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_budget_1(self):
+        """Budget=1: single sample, no voting needed."""
+        lm = SequentialMockLM(["only_answer"])
+        asc = AdaptiveSelfConsistency(threshold=0.75)
+
+        result = await asc.ainfer(lm, "test", budget=1, return_response_only=True)
+
+        assert result["content"] == "only_answer"
+        assert lm.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_budget_2_agreement(self):
+        """Budget=2: 2/2=100% ≥ 75% → stop (both agree)."""
+        lm = SequentialMockLM(["yes", "yes"])
+        asc = AdaptiveSelfConsistency(threshold=0.75)
+
+        result = await asc.ainfer(lm, "test", budget=2, return_response_only=False)
+
+        # With budget=2, first batch fills budget → no early stopping check needed
+        assert len(result.responses) == 2
+        assert result.the_one["content"] == "yes"
+
+    @pytest.mark.asyncio
+    async def test_strict_threshold_needs_unanimity(self):
+        """threshold=1.0 requires all answers identical to stop early."""
+        lm = SequentialMockLM(["42", "42", "42", "24"] + ["42"] * 4)
+        asc = AdaptiveSelfConsistency(threshold=1.0)
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # Round 1: ["42","42"] → 100% → STOP (both agree)
+        assert len(result.responses) == 2
+
+    @pytest.mark.asyncio
+    async def test_relaxed_threshold(self):
+        """threshold=0.6: easier to trigger early stop."""
+        lm = SequentialMockLM(["42", "24", "42", "42", "42", "42", "42", "42"])
+        asc = AdaptiveSelfConsistency(threshold=0.6)
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # Round 1: ["42","24"] → 50% < 60% → continue
+        # Round 2: ["42","24","42","42"] → 75% ≥ 60% → stop
+        assert len(result.responses) == 4
+
+
+class TestAdaptiveSelfConsistencyProjection:
+    """Test with custom projection functions."""
+
+    @pytest.mark.asyncio
+    async def test_regex_projection(self):
+        """Early stopping works with regex-based answer extraction."""
+        pattern = r"\\boxed\{([^}]+)\}"
+        proj_func = create_regex_projection_function(pattern)
+
+        lm = SequentialMockLM(
+            [
+                "Let me solve this. The answer is \\boxed{42}.",
+                "Using algebra, we get \\boxed{42}.",
+                "By computation \\boxed{24}.",
+                "Therefore \\boxed{42}.",
+            ]
+            + ["\\boxed{99}"] * 12
+        )
+        asc = AdaptiveSelfConsistency(
+            threshold=0.75,
+            consistency_space_projection_func=proj_func,
+        )
+
+        result = await asc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        # Round 1: 2 samples → projections ("42",), ("42",) → 100% → STOP
+        assert len(result.responses) == 2
+
+    @pytest.mark.asyncio
+    async def test_default_projection_strips_whitespace(self):
+        lm = SequentialMockLM(["  answer  ", "answer", "  answer  "] + ["other"] * 5)
+        asc = AdaptiveSelfConsistency(threshold=0.75)
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # Round 1: projections are "answer", "answer" → 100% → STOP
+        assert len(result.responses) == 2
+
+
+class TestAdaptiveSelfConsistencyInterface:
+    """Test the algorithm interface and result types."""
+
+    @pytest.mark.asyncio
+    async def test_return_response_only_true(self):
+        lm = SequentialMockLM(["42", "42"])
+        asc = AdaptiveSelfConsistency()
+
+        result = await asc.ainfer(lm, "test", budget=2, return_response_only=True)
+
+        assert isinstance(result, dict)
+        assert result["role"] == "assistant"
+        assert result["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_return_response_only_false(self):
+        lm = SequentialMockLM(["42", "42"])
+        asc = AdaptiveSelfConsistency()
+
+        result = await asc.ainfer(lm, "test", budget=2, return_response_only=False)
+
+        assert isinstance(result, SelfConsistencyResult)
+        assert result.the_one["content"] == "42"
+        assert result.usage is not None
+
+    def test_sync_infer(self):
+        """Test the sync wrapper works."""
+        lm = SequentialMockLM(["42", "42", "42", "24"])
+        asc = AdaptiveSelfConsistency(threshold=0.75)
+
+        result = asc.infer(lm, "test", budget=4, return_response_only=False)
+
+        assert isinstance(result, SelfConsistencyResult)
+        assert result.the_one["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_with_chat_messages(self):
+        lm = SequentialMockLM(["42", "42"])
+        asc = AdaptiveSelfConsistency()
+
+        chat_messages = ChatMessages("Solve this problem")
+        result = await asc.ainfer(
+            lm, chat_messages, budget=2, return_response_only=True
+        )
+
+        assert result["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_response_counts_populated(self):
+        lm = SequentialMockLM(["42", "24", "42", "42"])
+        asc = AdaptiveSelfConsistency(threshold=0.75)
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # Should have stopped at 4 samples with 3x "42" and 1x "24"
+        assert result.response_counts["42"] == 3
+        assert result.response_counts["24"] == 1

--- a/tests/test_adaptive_self_consistency.py
+++ b/tests/test_adaptive_self_consistency.py
@@ -16,7 +16,7 @@ from its_hub.core.orchestrator import LMOrchestrator
 class SequentialMockLM:
     """Mock LM that returns responses in sequential order, thread-safe."""
 
-    def __init__(self, responses: list[str]):
+    def __init__(self, responses: list):
         self.responses = responses
         self.call_count = 0
         self._lock = threading.Lock()
@@ -25,7 +25,10 @@ class SequentialMockLM:
         with self._lock:
             idx = self.call_count % len(self.responses)
             self.call_count += 1
-        return {"role": "assistant", "content": self.responses[idx]}
+        resp = self.responses[idx]
+        if isinstance(resp, dict):
+            return resp
+        return {"role": "assistant", "content": resp}
 
 
 class TestAdaptiveSelfConsistencyInit:
@@ -261,3 +264,79 @@ class TestAdaptiveSelfConsistencyInterface:
         # Should have stopped at 4 samples with 3x "42" and 1x "24"
         assert result.response_counts["42"] == 3
         assert result.response_counts["24"] == 1
+
+    def test_inherits_from_self_consistency(self):
+        from its_hub.core.algorithms.self_consistency import SelfConsistency
+
+        asc = AdaptiveSelfConsistency()
+        assert isinstance(asc, SelfConsistency)
+
+
+class TestAdaptiveSelfConsistencyToolCalls:
+    """Test tool-call voting with early stopping."""
+
+    def _make_tool_response(self, name, args):
+        return {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"function": {"name": name, "arguments": args}}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_tool_vote_name_early_stop(self):
+        """Early stop when tool name agrees across samples."""
+        resp = self._make_tool_response("get_weather", '{"city": "NYC"}')
+        resp_diff = self._make_tool_response("get_time", '{"tz": "UTC"}')
+        lm = SequentialMockLM([resp, resp, resp_diff] + [resp] * 5)
+        asc = AdaptiveSelfConsistency(threshold=0.75, tool_vote="tool_name")
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # Round 1: 2 samples, both "get_weather" → 100% → STOP
+        assert len(result.responses) == 2
+        assert result.the_one["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_tool_vote_args_no_early_stop(self):
+        """Different args prevent early stopping."""
+        r1 = self._make_tool_response("search", '{"q": "cats"}')
+        r2 = self._make_tool_response("search", '{"q": "dogs"}')
+        r3 = self._make_tool_response("search", '{"q": "cats"}')
+        r4 = self._make_tool_response("search", '{"q": "cats"}')
+        lm = SequentialMockLM([r1, r2, r3, r4])
+        asc = AdaptiveSelfConsistency(threshold=0.75, tool_vote="tool_args")
+
+        result = await asc.ainfer(lm, "test", budget=4, return_response_only=False)
+
+        # Round 1: ["cats", "dogs"] → 50% < 75% → continue
+        # Round 2: 3x "cats", 1x "dogs" → 75% → STOP
+        assert len(result.responses) == 4
+
+    @pytest.mark.asyncio
+    async def test_tool_vote_hierarchical_early_stop(self):
+        """Hierarchical tool vote: name + args must agree."""
+        resp = self._make_tool_response("calc", '{"expr": "2+2"}')
+        lm = SequentialMockLM([resp] * 8)
+        asc = AdaptiveSelfConsistency(threshold=0.75, tool_vote="tool_hierarchical")
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # All identical → stops at round 1
+        assert len(result.responses) == 2
+
+    @pytest.mark.asyncio
+    async def test_exclude_args_in_tool_voting(self):
+        """exclude_args filters non-semantic args before comparison."""
+        r1 = self._make_tool_response("search", '{"q": "cats", "request_id": "abc"}')
+        r2 = self._make_tool_response("search", '{"q": "cats", "request_id": "xyz"}')
+        lm = SequentialMockLM([r1, r2] + [r1] * 6)
+        asc = AdaptiveSelfConsistency(
+            threshold=0.75,
+            tool_vote="tool_args",
+            exclude_args=["request_id"],
+        )
+
+        result = await asc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # After excluding request_id, both have args {"q": "cats"} → 100% → STOP
+        assert len(result.responses) == 2


### PR DESCRIPTION
### Summary

  - Introduce `AdaptiveSelfConsistency`, a budget-efficient variant of self-consistency that starts with 2 samples and doubles each round, stopping early when a configurable supermajority threshold (default 75%) is reached
  - Extract `_project_responses()` from `SelfConsistency._process_responses()` so the new algorithm can reuse all projection/voting logic via inheritance
  - Add comprehensive test suite covering early stopping, doubling sequence, tool-call voting, projection functions, and edge cases

  ### Motivation

  Standard self-consistency generates all `N` samples upfront, even when the model agrees on the answer within the first few. For high-budget runs this wastes compute. Adaptive self-consistency addresses this by generating incrementally — 2 → 4 → 8 → ... — and stopping as soon as a supermajority emerges among the collected samples. Previous samples are kept
  across rounds (no resampling), so no work is wasted.

  ### Design

  `AdaptiveSelfConsistency` inherits from `SelfConsistency` and overrides only `ainfer()`. This gives it full access to:
  - Content-based and tool-call voting (`tool_vote`, `exclude_args`)
  - Custom projection functions (`consistency_space_projection_func`)
  - The shared `_process_responses()` / `_project_responses()` pipeline

  A new `_project_responses()` method was refactored out of `_process_responses()` in `SelfConsistency` to allow the adaptive algorithm to check agreement mid-run without duplicating the tool-aware projection logic.

  **Doubling schedule:** batch sizes follow 2 → 4 → 8 → ..., capped at the remaining budget. The last batch may be partial.

  **Threshold:** configurable in `(0.5, 1.0]`. A value of `0.75` means 75% of eligible (projected) samples must agree for early stopping.

  ### Changed files

  | File | Change |
  |------|--------|
  | `its_hub/core/algorithms/adaptive_self_consistency.py` | New algorithm implementation |
  | `its_hub/core/algorithms/self_consistency.py` | Extract `_project_responses()` from `_process_responses()` |
  | `its_hub/__init__.py` | Export `AdaptiveSelfConsistency` |
  | `tests/test_adaptive_self_consistency.py` | 20 tests covering init, early stopping, projection, interface, and tool-call voting |

  ### Test plan

  - [ ] `uv run pytest tests/test_adaptive_self_consistency.py -v` — all 20 new tests pass
  - [ ] `uv run pytest tests/test_algorithms.py -v` — existing self-consistency tests still pass (refactor is backward-compatible)
  - [ ] `uv run ruff check its_hub/` — no lint issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Adaptive Self-Consistency algorithm, which progressively increases sampling and can stop early when responses reach the configured agreement threshold.
  - Exposed the algorithm through the public package API.
  - Added support for content-based and tool-call-based consistency voting, including configurable argument exclusions.

- **Bug Fixes**
  - Improved response processing and warnings when tool calls are present without tool-call voting enabled.

- **Tests**
  - Added comprehensive coverage for adaptive sampling, thresholds, projections, inference modes, chat messages, and tool-call voting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->