### PR TITLE
feat: Add BetaSelfConsistency algorithm

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -8,6 +8,7 @@
   - [Best-of-N](algorithms.md#best-of-n)
   - [Beam Search](algorithms.md#beam-search)
   - [Self-Consistency](algorithms.md#self-consistency)
+  - [Beta Self-Consistency (Experimental)](algorithms.md#beta-self-consistency)
   - [Planning Wrapper](PLANNING_WRAPPER.md)
 - [Orchestration](orchestration.md)
 - [Benchmarking](benchmarking.md)

--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -17,6 +17,7 @@ The `budget` parameter controls computational resources allocated to each algori
 | Beam Search | Total generations ÷ beam width | `BeamSearch(sg, prm, beam_width=4)` |
 | Particle Filtering | Number of particles | `ParticleFiltering(sg, prm)` |
 | Entropic Particle Filtering | Number of particles | `EntropicParticleFiltering(sg, prm)` |
+| Beta Self-Consistency (experimental) | Maximum number of parallel generations | `BetaSelfConsistency()` |
 
 ## Self-Consistency
 
@@ -265,6 +266,22 @@ result = epf.infer(lm, prompt, budget=8)
 
 - To Avoid Early Convergence: 
     - If you notice that a standard filter is producing short, incomplete responses or underperforming, it is likely converging prematurely. ePF directly counteracts this by promoting particle diversity.
+
+
+### Beta Self-Consistency
+
+Beta Self-Consistency is an adaptive variant of Self-Consistency. It starts up to `budget` generations, evaluates the Beta posterior as responses complete, and cancels pending generations once the leading answer reaches `confidence_threshold` (default `0.95`). 
+
+```python
+from its_hub import BetaSelfConsistency
+
+beta_sc = BetaSelfConsistency(confidence_threshold=0.95)
+result = beta_sc.infer(lm, "Solve x^2 + 5x + 6 = 0", budget=64)
+```
+
+The `budget` is the maximum number of generations. Like `SelfConsistency`, this experimental algorithm supports response projection and tool voting.
+
+**Reference:** Pranjal Aggarwal, Aman Madaan, Yiming Yang, and Mausam. 2023. [“Let’s Sample Step by Step: Adaptive-Consistency for Efficient Reasoning and Coding with LLMs.”](https://aclanthology.org/2023.emnlp-main.761/) In *Proceedings of EMNLP 2023*, pages 12375–12396. Association for Computational Linguistics.
 
 
 ## Advanced Configuration

--- a/its_hub/__init__.py
+++ b/its_hub/__init__.py
@@ -17,6 +17,14 @@ from its_hub.core.algorithms.adaptive_self_consistency import AdaptiveSelfConsis
 from its_hub.core.algorithms.bon import BestOfN
 from its_hub.core.algorithms.self_consistency import SelfConsistency
 
+# Optional - requires scipy (install with: pip install its_hub[experimental])
+try:
+    from its_hub.core.algorithms.beta_self_consistency import BetaSelfConsistency
+
+    _has_beta = True
+except ImportError:
+    _has_beta = False
+
 __version__ = version("its_hub")
 
 # Start with core exports
@@ -35,6 +43,9 @@ __all__ = [  # noqa: RUF022
     "SelfConsistency",
     "BestOfN",
 ]
+
+if _has_beta:
+    __all__.append("BetaSelfConsistency")
 
 # Optional LM implementations - only available if [lm] extra is installed
 try:

--- a/its_hub/__init__.py
+++ b/its_hub/__init__.py
@@ -14,16 +14,9 @@ from its_hub.api import (
     AbstractScalingResult,
 )
 from its_hub.core.algorithms.adaptive_self_consistency import AdaptiveSelfConsistency
+from its_hub.core.algorithms.beta_self_consistency import BetaSelfConsistency
 from its_hub.core.algorithms.bon import BestOfN
 from its_hub.core.algorithms.self_consistency import SelfConsistency
-
-# Optional - requires scipy (install with: pip install its_hub[experimental])
-try:
-    from its_hub.core.algorithms.beta_self_consistency import BetaSelfConsistency
-
-    _has_beta = True
-except ImportError:
-    _has_beta = False
 
 __version__ = version("its_hub")
 
@@ -40,12 +33,10 @@ __all__ = [  # noqa: RUF022
     "AbstractScalingResult",
     # Algorithms
     "AdaptiveSelfConsistency",
+    "BetaSelfConsistency",
     "SelfConsistency",
     "BestOfN",
 ]
-
-if _has_beta:
-    __all__.append("BetaSelfConsistency")
 
 # Optional LM implementations - only available if [lm] extra is installed
 try:

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -75,6 +75,7 @@ class BetaSelfConsistency(SelfConsistency):
         Returns:
             Probability in [0, 1] that the majority answer stays dominant.
         """
+        # note that betainc is the CDF of the beta distribution
         return 1.0 - float(betainc(v1 + 1, v2 + 1, 0.5))
 
     async def ainfer(

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections import Counter
 from collections.abc import Callable
@@ -22,9 +23,13 @@ logger = logging.getLogger(__name__)
 class BetaSelfConsistency(SelfConsistency):
     """Self-consistency with Beta-distribution adaptive stopping (Aggarwal et al., 2023).
 
-    Samples one response at a time and computes a Beta posterior probability
-    that the current majority answer will remain the majority. Stops when this
-    probability exceeds confidence_threshold (default 0.95).
+    Fires all budget requests concurrently and checks the Beta posterior
+    probability as each response arrives. Stops and cancels remaining
+    requests once the probability that the majority answer will remain
+    dominant exceeds confidence_threshold (default 0.95).
+
+    This fully utilizes vLLM's continuous batching while still getting
+    the sample-efficiency benefits of adaptive stopping.
 
     The stopping criterion uses the regularized incomplete beta function:
         P(majority stays) = 1 - I_{0.5}(v1 + 1, v2 + 1)
@@ -84,44 +89,67 @@ class BetaSelfConsistency(SelfConsistency):
         chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
         usage = GenerationUsage()
 
-        all_responses: list[dict] = []
+        current_loop = asyncio.get_running_loop()
+        messages_list = chat_messages.to_chat_messages()
 
-        for sample_num in range(1, budget + 1):
-            new_responses = await self.orchestrator.agenerate(
-                lm,
-                chat_messages.to_batch(1),
+        async def _generate_one():
+            return await lm.agenerate_single(
+                messages_list,
                 tools=tools,
                 tool_choice=tool_choice,
+                loop=current_loop,
                 usage_accumulator=usage,
             )
-            all_responses.extend(new_responses)
 
-            if sample_num >= budget:
+        tasks = [asyncio.create_task(_generate_one()) for _ in range(budget)]
+
+        all_responses: list[dict] = []
+        pending = set(tasks)
+        stopped_early = False
+
+        while pending:
+            done, pending = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_COMPLETED
+            )
+
+            for task in done:
+                all_responses.append(task.result())
+
+                if len(all_responses) >= 2 and len(all_responses) < budget:
+                    eligible_indices, projected = self._project_responses(
+                        all_responses
+                    )
+
+                    if len(eligible_indices) >= 2:
+                        counts = Counter(projected)
+                        most_common = counts.most_common(2)
+                        v1 = most_common[0][1]
+                        v2 = most_common[1][1] if len(most_common) > 1 else 0
+
+                        prob = self.beta_stopping_probability(v1, v2)
+
+                        if prob >= self.confidence_threshold:
+                            logger.info(
+                                "Early stop: %d/%d samples, "
+                                "P(majority stays)=%.4f >= %.4f",
+                                len(all_responses),
+                                budget,
+                                prob,
+                                self.confidence_threshold,
+                            )
+                            for t in pending:
+                                t.cancel()
+                            stopped_early = True
+                            break
+
+            if stopped_early:
                 break
 
-            eligible_indices, projected = self._project_responses(all_responses)
-
-            if len(eligible_indices) >= 2:
-                counts = Counter(projected)
-                most_common = counts.most_common(2)
-                v1 = most_common[0][1]
-                v2 = most_common[1][1] if len(most_common) > 1 else 0
-
-                prob = self.beta_stopping_probability(v1, v2)
-
-                if prob >= self.confidence_threshold:
-                    logger.info(
-                        "Early stop at sample %d: P(majority stays)=%.4f >= %.4f",
-                        sample_num,
-                        prob,
-                        self.confidence_threshold,
-                    )
-                    break
-
-        logger.info(
-            "BetaSelfConsistency used %d/%d samples",
-            len(all_responses),
-            budget,
-        )
+        if not stopped_early:
+            logger.info(
+                "BetaSelfConsistency used all %d/%d samples",
+                len(all_responses),
+                budget,
+            )
 
         return self._process_responses(all_responses, return_response_only, usage)

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -113,45 +113,57 @@ class BetaSelfConsistency(SelfConsistency):
 
         all_responses: list[dict] = []
         pending = set(tasks)
+        accounted_tasks: set[asyncio.Task] = set()
         stopped_early = False
 
-        while pending:
-            done, pending = await asyncio.wait(
-                pending, return_when=asyncio.FIRST_COMPLETED
-            )
+        try:
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
 
-            # asyncio.wait may return several tasks at once. Account for every
-            # completed LM call before evaluating whether to stop.
-            all_responses.extend(task.result() for task in done)
+                # asyncio.wait may return several tasks at once. Account for every
+                # completed LM call before evaluating whether to stop.
+                accounted_tasks.update(done)
+                all_responses.extend(task.result() for task in done)
 
-            if len(all_responses) >= 2 and len(all_responses) < budget:
-                eligible_indices, projected = self._project_responses(all_responses)
+                if len(all_responses) >= 2 and len(all_responses) < budget:
+                    eligible_indices, projected = self._project_responses(all_responses)
 
-                if len(eligible_indices) >= 2:
-                    counts = Counter(projected)
-                    most_common = counts.most_common(2)
-                    v1 = most_common[0][1]
-                    v2 = most_common[1][1] if len(most_common) > 1 else 0
+                    if len(eligible_indices) >= 2:
+                        counts = Counter(projected)
+                        most_common = counts.most_common(2)
+                        v1 = most_common[0][1]
+                        v2 = most_common[1][1] if len(most_common) > 1 else 0
 
-                    prob = self.beta_stopping_probability(v1, v2)
+                        prob = self.beta_stopping_probability(v1, v2)
 
-                    if prob >= self.confidence_threshold:
-                        logger.info(
-                            "Early stop: %d/%d samples, P(majority stays)=%.4f >= %.4f",
-                            len(all_responses),
-                            budget,
-                            prob,
-                            self.confidence_threshold,
-                        )
-                        stopped_early = True
+                        if prob >= self.confidence_threshold:
+                            logger.info(
+                                "Early stop: %d/%d samples, "
+                                "P(majority stays)=%.4f >= %.4f",
+                                len(all_responses),
+                                budget,
+                                prob,
+                                self.confidence_threshold,
+                            )
+                            stopped_early = True
 
-            if stopped_early:
-                break
+                if stopped_early:
+                    break
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            outcomes = await asyncio.gather(*tasks, return_exceptions=True)
 
         if stopped_early:
-            for task in pending:
-                task.cancel()
-            await asyncio.gather(*pending, return_exceptions=True)
+            all_responses.extend(
+                outcome
+                for task, outcome in zip(tasks, outcomes)
+                if task not in accounted_tasks
+                and not isinstance(outcome, BaseException)
+            )
         else:
             logger.info(
                 "BetaSelfConsistency used all %d/%d samples",

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -90,17 +90,17 @@ class BetaSelfConsistency(SelfConsistency):
         chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
         usage = GenerationUsage()
 
-        current_loop = asyncio.get_running_loop()
         messages_list = chat_messages.to_chat_messages()
 
         async def _generate_one():
-            return await lm.agenerate_single(
-                messages_list,
+            responses = await self.orchestrator.agenerate(
+                lm,
+                [messages_list],
                 tools=tools,
                 tool_choice=tool_choice,
-                loop=current_loop,
                 usage_accumulator=usage,
             )
+            return responses[0]
 
         tasks = [asyncio.create_task(_generate_one()) for _ in range(budget)]
 
@@ -136,15 +136,17 @@ class BetaSelfConsistency(SelfConsistency):
                                 prob,
                                 self.confidence_threshold,
                             )
-                            for t in pending:
-                                t.cancel()
                             stopped_early = True
                             break
 
             if stopped_early:
                 break
 
-        if not stopped_early:
+        if stopped_early:
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+        else:
             logger.info(
                 "BetaSelfConsistency used all %d/%d samples",
                 len(all_responses),

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -1,0 +1,127 @@
+import logging
+from collections import Counter
+from collections.abc import Callable
+
+from scipy.special import betainc
+
+from its_hub.api import (
+    AbstractLanguageModel,
+    AbstractOrchestrator,
+    ChatMessage,
+    ChatMessages,
+    GenerationUsage,
+)
+from its_hub.core.algorithms.self_consistency import (
+    SelfConsistency,
+    SelfConsistencyResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BetaSelfConsistency(SelfConsistency):
+    """Self-consistency with Beta-distribution adaptive stopping (Aggarwal et al., 2023).
+
+    Samples one response at a time and computes a Beta posterior probability
+    that the current majority answer will remain the majority. Stops when this
+    probability exceeds confidence_threshold (default 0.95).
+
+    The stopping criterion uses the regularized incomplete beta function:
+        P(majority stays) = 1 - I_{0.5}(v1 + 1, v2 + 1)
+    where v1 is the count of the most frequent answer and v2 is the count of
+    the second most frequent answer.
+
+    Reference: "Let's Sample Step by Step: Adaptive-Consistency for Efficient
+    Reasoning and Coding with LLMs" (EMNLP 2023)
+
+    Inherits tool_vote, exclude_args, and projection support from
+    SelfConsistency.
+    """
+
+    def __init__(
+        self,
+        confidence_threshold: float = 0.95,
+        consistency_space_projection_func: Callable | None = None,
+        tool_vote: str | None = None,
+        exclude_args: list[str] | None = None,
+        orchestrator: AbstractOrchestrator | None = None,
+    ):
+        if not 0.5 < confidence_threshold <= 1.0:
+            raise ValueError(
+                f"confidence_threshold must be in (0.5, 1.0], got: {confidence_threshold}"
+            )
+
+        super().__init__(
+            consistency_space_projection_func=consistency_space_projection_func,
+            tool_vote=tool_vote,
+            exclude_args=exclude_args,
+            orchestrator=orchestrator,
+        )
+        self.confidence_threshold = confidence_threshold
+
+    @staticmethod
+    def beta_stopping_probability(v1: int, v2: int) -> float:
+        """Compute P(majority answer remains majority) using Beta posterior.
+
+        Args:
+            v1: Count of the most frequent answer.
+            v2: Count of the second most frequent answer.
+
+        Returns:
+            Probability in [0, 1] that the majority answer stays dominant.
+        """
+        return 1.0 - float(betainc(v1 + 1, v2 + 1, 0.5))
+
+    async def ainfer(
+        self,
+        lm: AbstractLanguageModel,
+        prompt_or_messages: str | list[ChatMessage] | ChatMessages,
+        budget: int,
+        return_response_only: bool = True,
+        tools: list[dict] | None = None,
+        tool_choice: str | dict | None = None,
+    ) -> dict | SelfConsistencyResult:
+        chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
+        usage = GenerationUsage()
+
+        all_responses: list[dict] = []
+
+        for sample_num in range(1, budget + 1):
+            new_responses = await self.orchestrator.agenerate(
+                lm,
+                chat_messages.to_batch(1),
+                tools=tools,
+                tool_choice=tool_choice,
+                usage_accumulator=usage,
+            )
+            all_responses.extend(new_responses)
+
+            if sample_num >= budget:
+                break
+
+            eligible_indices, projected = self._project_responses(all_responses)
+
+            if len(eligible_indices) >= 2:
+                counts = Counter(projected)
+                most_common = counts.most_common(2)
+                v1 = most_common[0][1]
+                v2 = most_common[1][1] if len(most_common) > 1 else 0
+
+                prob = self.beta_stopping_probability(v1, v2)
+
+                if prob >= self.confidence_threshold:
+                    logger.info(
+                        "Early stop at sample %d: P(majority stays)=%.4f >= %.4f",
+                        sample_num,
+                        prob,
+                        self.confidence_threshold,
+                    )
+                    break
+
+        logger.info(
+            "BetaSelfConsistency used %d/%d samples",
+            len(all_responses),
+            budget,
+        )
+
+        return self._process_responses(all_responses, return_response_only, usage)

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -2,8 +2,7 @@ import asyncio
 import logging
 from collections import Counter
 from collections.abc import Callable
-
-from scipy.special import betainc
+from math import comb
 
 from its_hub.api import (
     AbstractLanguageModel,
@@ -31,10 +30,12 @@ class BetaSelfConsistency(SelfConsistency):
     This fully utilizes vLLM's continuous batching while still getting
     the sample-efficiency benefits of adaptive stopping.
 
-    The stopping criterion uses the regularized incomplete beta function:
-        P(majority stays) = 1 - I_{0.5}(v1 + 1, v2 + 1)
-    where v1 is the count of the most frequent answer and v2 is the count of
-    the second most frequent answer.
+    Let v1 and v2 be the vote counts for the two most common answers. Starting
+    from a uniform Beta(1, 1) prior, their posterior is Beta(v1 + 1, v2 + 1).
+    Generation stops when the posterior probability that the leading answer's
+    vote share exceeds 0.5 reaches the configured threshold:
+
+        P(leader's vote share > 0.5) = 1 - I_0.5(v1 + 1, v2 + 1)
 
     Reference: "Let's Sample Step by Step: Adaptive-Consistency for Efficient
     Reasoning and Coding with LLMs" (EMNLP 2023)
@@ -75,8 +76,12 @@ class BetaSelfConsistency(SelfConsistency):
         Returns:
             Probability in [0, 1] that the majority answer stays dominant.
         """
-        # note that betainc is the CDF of the beta distribution
-        return 1.0 - float(betainc(v1 + 1, v2 + 1, 0.5))
+        # At x=0.5 and with integer parameters, the beta CDF is exactly the
+        # lower tail of a fair binomial distribution. This avoids requiring
+        # scipy.special.betainc.
+        num_trials = v1 + v2 + 1
+        beta_cdf = sum(comb(num_trials, k) for k in range(v2 + 1)) / (1 << num_trials)
+        return 1.0 - beta_cdf
 
     async def ainfer(
         self,
@@ -93,6 +98,8 @@ class BetaSelfConsistency(SelfConsistency):
         messages_list = chat_messages.to_chat_messages()
 
         async def _generate_one() -> dict:
+            # A one-item batch lets each response complete independently while
+            # the shared orchestrator still enforces its concurrency limit.
             responses = await self.orchestrator.agenerate(
                 lm,
                 [messages_list],
@@ -113,6 +120,8 @@ class BetaSelfConsistency(SelfConsistency):
                 pending, return_when=asyncio.FIRST_COMPLETED
             )
 
+            # asyncio.wait may return several tasks at once. Account for every
+            # completed LM call before evaluating whether to stop.
             all_responses.extend(task.result() for task in done)
 
             if len(all_responses) >= 2 and len(all_responses) < budget:

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -92,7 +92,7 @@ class BetaSelfConsistency(SelfConsistency):
 
         messages_list = chat_messages.to_chat_messages()
 
-        async def _generate_one():
+        async def _generate_one() -> dict:
             responses = await self.orchestrator.agenerate(
                 lm,
                 [messages_list],
@@ -113,31 +113,28 @@ class BetaSelfConsistency(SelfConsistency):
                 pending, return_when=asyncio.FIRST_COMPLETED
             )
 
-            for task in done:
-                all_responses.append(task.result())
+            all_responses.extend(task.result() for task in done)
 
-                if len(all_responses) >= 2 and len(all_responses) < budget:
-                    eligible_indices, projected = self._project_responses(all_responses)
+            if len(all_responses) >= 2 and len(all_responses) < budget:
+                eligible_indices, projected = self._project_responses(all_responses)
 
-                    if len(eligible_indices) >= 2:
-                        counts = Counter(projected)
-                        most_common = counts.most_common(2)
-                        v1 = most_common[0][1]
-                        v2 = most_common[1][1] if len(most_common) > 1 else 0
+                if len(eligible_indices) >= 2:
+                    counts = Counter(projected)
+                    most_common = counts.most_common(2)
+                    v1 = most_common[0][1]
+                    v2 = most_common[1][1] if len(most_common) > 1 else 0
 
-                        prob = self.beta_stopping_probability(v1, v2)
+                    prob = self.beta_stopping_probability(v1, v2)
 
-                        if prob >= self.confidence_threshold:
-                            logger.info(
-                                "Early stop: %d/%d samples, "
-                                "P(majority stays)=%.4f >= %.4f",
-                                len(all_responses),
-                                budget,
-                                prob,
-                                self.confidence_threshold,
-                            )
-                            stopped_early = True
-                            break
+                    if prob >= self.confidence_threshold:
+                        logger.info(
+                            "Early stop: %d/%d samples, P(majority stays)=%.4f >= %.4f",
+                            len(all_responses),
+                            budget,
+                            prob,
+                            self.confidence_threshold,
+                        )
+                        stopped_early = True
 
             if stopped_early:
                 break

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -117,9 +117,7 @@ class BetaSelfConsistency(SelfConsistency):
                 all_responses.append(task.result())
 
                 if len(all_responses) >= 2 and len(all_responses) < budget:
-                    eligible_indices, projected = self._project_responses(
-                        all_responses
-                    )
+                    eligible_indices, projected = self._project_responses(all_responses)
 
                     if len(eligible_indices) >= 2:
                         counts = Counter(projected)

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -148,9 +148,7 @@ class BetaSelfConsistency(SelfConsistency):
                                 self.confidence_threshold,
                             )
                             stopped_early = True
-
-                if stopped_early:
-                    break
+                            break
         finally:
             for task in tasks:
                 if not task.done():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ dev = [
 # Experimental - not officially supported in MVP
 experimental = [
     "its_hub[lm]",
+    "scipy>=1.11.0",
     "transformers>=4.53.2",
     "reward-hub[prm]>=0.1.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,12 +75,12 @@ dev = [
     "python-dotenv>=1.0.0",
     "jupytext>=1.15.0",
     "jupyter>=1.0.0",
+    "scipy>=1.11.0",
 ]
 
 # Experimental - not officially supported in MVP
 experimental = [
     "its_hub[lm]",
-    "scipy>=1.11.0",
     "transformers>=4.53.2",
     "reward-hub[prm]>=0.1.10",
 ]

--- a/tests/test_beta_self_consistency.py
+++ b/tests/test_beta_self_consistency.py
@@ -32,6 +32,24 @@ class SequentialMockLM:
         return {"role": "assistant", "content": resp}
 
 
+class ConcurrencyTrackingMockLM:
+    """Mock LM that records the number of concurrent generation calls."""
+
+    def __init__(self, delay: float = 0.01):
+        self.delay = delay
+        self.active_calls = 0
+        self.max_active_calls = 0
+
+    async def agenerate_single(self, messages, **kwargs):
+        self.active_calls += 1
+        self.max_active_calls = max(self.max_active_calls, self.active_calls)
+        try:
+            await asyncio.sleep(self.delay)
+            return {"role": "assistant", "content": "42"}
+        finally:
+            self.active_calls -= 1
+
+
 class DelayedMockLM:
     """Mock LM where each response has a controlled delay to test ordering.
     Responses arrive in delay order, so we can predict which arrive first.
@@ -152,6 +170,20 @@ class TestBetaSelfConsistencyEarlyStopping:
         result = await bsc.ainfer(lm, "test", budget=8, return_response_only=False)
 
         assert len(result.responses) == 8
+
+    @pytest.mark.asyncio
+    async def test_respects_orchestrator_max_concurrency(self):
+        lm = ConcurrencyTrackingMockLM()
+        orchestrator = LMOrchestrator(max_concurrency=3)
+        bsc = BetaSelfConsistency(
+            confidence_threshold=1.0,
+            orchestrator=orchestrator,
+        )
+
+        result = await bsc.ainfer(lm, "test", budget=12, return_response_only=False)
+
+        assert len(result.responses) == 12
+        assert lm.max_active_calls == 3
 
     @pytest.mark.asyncio
     async def test_budget_1(self):

--- a/tests/test_beta_self_consistency.py
+++ b/tests/test_beta_self_consistency.py
@@ -4,6 +4,7 @@ import asyncio
 import threading
 
 import pytest
+from scipy.special import betainc
 
 from its_hub.api import ChatMessages
 from its_hub.core.algorithms.beta_self_consistency import BetaSelfConsistency
@@ -110,6 +111,14 @@ class TestBetaSelfConsistencyInit:
 
 class TestBetaStoppingProbability:
     """Test the static beta_stopping_probability method."""
+
+    def test_matches_previous_scipy_implementation(self):
+        for v1 in range(50):
+            for v2 in range(50):
+                expected = 1.0 - float(betainc(v1 + 1, v2 + 1, 0.5))
+                actual = BetaSelfConsistency.beta_stopping_probability(v1, v2)
+
+                assert actual == pytest.approx(expected, abs=1e-12, rel=0), (v1, v2)
 
     def test_unanimous_1(self):
         prob = BetaSelfConsistency.beta_stopping_probability(1, 0)

--- a/tests/test_beta_self_consistency.py
+++ b/tests/test_beta_self_consistency.py
@@ -1,0 +1,359 @@
+"""Tests for BetaSelfConsistency algorithm."""
+
+import threading
+
+import pytest
+
+from its_hub.api import ChatMessages
+from its_hub.core.algorithms.beta_self_consistency import BetaSelfConsistency
+from its_hub.core.algorithms.self_consistency import (
+    SelfConsistencyResult,
+    create_regex_projection_function,
+)
+from its_hub.core.orchestrator import LMOrchestrator
+
+
+class SequentialMockLM:
+    """Mock LM that returns responses in sequential order, thread-safe."""
+
+    def __init__(self, responses: list):
+        self.responses = responses
+        self.call_count = 0
+        self._lock = threading.Lock()
+
+    async def agenerate_single(self, messages, **kwargs):
+        with self._lock:
+            idx = self.call_count % len(self.responses)
+            self.call_count += 1
+        resp = self.responses[idx]
+        if isinstance(resp, dict):
+            return resp
+        return {"role": "assistant", "content": resp}
+
+
+class TestBetaSelfConsistencyInit:
+    """Test constructor validation."""
+
+    def test_default_threshold(self):
+        bsc = BetaSelfConsistency()
+        assert bsc.confidence_threshold == 0.95
+
+    def test_custom_threshold(self):
+        bsc = BetaSelfConsistency(confidence_threshold=0.8)
+        assert bsc.confidence_threshold == 0.8
+
+    def test_threshold_at_boundary(self):
+        bsc = BetaSelfConsistency(confidence_threshold=1.0)
+        assert bsc.confidence_threshold == 1.0
+
+    @pytest.mark.parametrize("bad_threshold", [0.0, 0.5, -0.1, 1.1])
+    def test_invalid_threshold_raises(self, bad_threshold):
+        with pytest.raises(ValueError, match="confidence_threshold must be in"):
+            BetaSelfConsistency(confidence_threshold=bad_threshold)
+
+    def test_default_orchestrator_created(self):
+        bsc = BetaSelfConsistency()
+        assert isinstance(bsc.orchestrator, LMOrchestrator)
+
+    def test_custom_orchestrator_used(self):
+        orch = LMOrchestrator(max_concurrency=4)
+        bsc = BetaSelfConsistency(orchestrator=orch)
+        assert bsc.orchestrator is orch
+
+    def test_inherits_from_self_consistency(self):
+        from its_hub.core.algorithms.self_consistency import SelfConsistency
+
+        bsc = BetaSelfConsistency()
+        assert isinstance(bsc, SelfConsistency)
+
+
+class TestBetaStoppingProbability:
+    """Test the static beta_stopping_probability method."""
+
+    def test_unanimous_1(self):
+        # v1=1, v2=0: P = 1 - I_0.5(2, 1) = 1 - 0.25 = 0.75
+        prob = BetaSelfConsistency.beta_stopping_probability(1, 0)
+        assert abs(prob - 0.75) < 1e-10
+
+    def test_unanimous_2(self):
+        # v1=2, v2=0: P = 1 - I_0.5(3, 1) = 1 - 0.125 = 0.875
+        prob = BetaSelfConsistency.beta_stopping_probability(2, 0)
+        assert abs(prob - 0.875) < 1e-10
+
+    def test_unanimous_4(self):
+        # v1=4, v2=0: P = 1 - I_0.5(5, 1) = 1 - 0.03125 = 0.96875
+        prob = BetaSelfConsistency.beta_stopping_probability(4, 0)
+        assert abs(prob - 0.96875) < 1e-10
+
+    def test_split_50_50(self):
+        # v1=v2: should be close to 0.5 by symmetry
+        prob = BetaSelfConsistency.beta_stopping_probability(5, 5)
+        assert abs(prob - 0.5) < 1e-10
+
+    def test_strong_majority(self):
+        # v1=10, v2=1: should be very high
+        prob = BetaSelfConsistency.beta_stopping_probability(10, 1)
+        assert prob > 0.99
+
+    def test_monotonic_with_v1(self):
+        # More v1 counts → higher probability
+        probs = [
+            BetaSelfConsistency.beta_stopping_probability(v1, 2) for v1 in range(3, 10)
+        ]
+        for i in range(len(probs) - 1):
+            assert probs[i] < probs[i + 1]
+
+    def test_monotonic_with_v2(self):
+        # More v2 counts → lower probability
+        probs = [
+            BetaSelfConsistency.beta_stopping_probability(5, v2) for v2 in range(0, 5)
+        ]
+        for i in range(len(probs) - 1):
+            assert probs[i] > probs[i + 1]
+
+
+class TestBetaSelfConsistencyEarlyStopping:
+    """Test the sample-one-at-a-time + beta stopping behavior."""
+
+    @pytest.mark.asyncio
+    async def test_stops_with_unanimous_agreement(self):
+        """With all identical answers at threshold=0.95, needs 4 samples to stop.
+        v1=4, v2=0 → P=0.96875 ≥ 0.95."""
+        lm = SequentialMockLM(["42"] * 16)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        assert isinstance(result, SelfConsistencyResult)
+        assert len(result.responses) == 4
+        assert result.the_one["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_unanimous_with_lower_threshold(self):
+        """With threshold=0.8, unanimous answers need 2 samples.
+        v1=2, v2=0 → P=0.875 ≥ 0.8."""
+        lm = SequentialMockLM(["42"] * 16)
+        bsc = BetaSelfConsistency(confidence_threshold=0.8)
+
+        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        assert len(result.responses) == 2
+
+    @pytest.mark.asyncio
+    async def test_disagreement_delays_stopping(self):
+        """One disagreement requires more samples to reach confidence."""
+        # Responses: 42, 24, 42, 42, 42, 42, 42, ...
+        lm = SequentialMockLM(["42", "24", "42", "42", "42", "42", "42", "42"])
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # After 2: v1=1,v2=1 → P=0.5
+        # After 3: v1=2,v2=1 → P=0.6875
+        # After 4: v1=3,v2=1 → P=0.8125
+        # After 5: v1=4,v2=1 → P=0.890625
+        # After 6: v1=5,v2=1 → P=0.9375
+        # After 7: v1=6,v2=1 → P=0.964844 → stop
+        assert len(result.responses) == 7
+        assert result.the_one["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_uses_full_budget_when_split(self):
+        """Alternating answers never reach 0.95 confidence."""
+        lm = SequentialMockLM(["a", "b"] * 8)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        assert len(result.responses) == 8
+
+    @pytest.mark.asyncio
+    async def test_budget_1(self):
+        """Budget=1: single sample, no stopping check."""
+        lm = SequentialMockLM(["only_answer"])
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=1, return_response_only=True)
+
+        assert result["content"] == "only_answer"
+        assert lm.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_budget_2_same_answers(self):
+        """Budget=2: 2 identical answers. v1=2,v2=0 → P=0.875 < 0.95.
+        Can't stop early because budget is exhausted."""
+        lm = SequentialMockLM(["yes", "yes"])
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=2, return_response_only=False)
+
+        assert len(result.responses) == 2
+
+    @pytest.mark.asyncio
+    async def test_samples_one_at_a_time(self):
+        """Verify that exactly one sample is generated per iteration."""
+        lm = SequentialMockLM(["42"] * 16)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        # Should stop at 4 samples, each generated individually
+        assert lm.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_threshold_1_0_requires_very_high_confidence(self):
+        """threshold=1.0 is impossible to reach, should exhaust budget."""
+        lm = SequentialMockLM(["42"] * 8)
+        bsc = BetaSelfConsistency(confidence_threshold=1.0)
+
+        result = await bsc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        assert len(result.responses) == 8
+
+
+class TestBetaSelfConsistencyProjection:
+    """Test with custom projection functions."""
+
+    @pytest.mark.asyncio
+    async def test_regex_projection(self):
+        pattern = r"\\boxed\{([^}]+)\}"
+        proj_func = create_regex_projection_function(pattern)
+
+        lm = SequentialMockLM(
+            [
+                "Let me solve this. The answer is \\boxed{42}.",
+                "Using algebra, we get \\boxed{42}.",
+                "By computation \\boxed{42}.",
+                "Therefore \\boxed{42}.",
+            ]
+            + ["\\boxed{99}"] * 12
+        )
+        bsc = BetaSelfConsistency(
+            confidence_threshold=0.95,
+            consistency_space_projection_func=proj_func,
+        )
+
+        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        # All 4 project to ("42",) → stops at 4 (unanimous)
+        assert len(result.responses) == 4
+
+    @pytest.mark.asyncio
+    async def test_default_projection_strips_whitespace(self):
+        lm = SequentialMockLM(
+            ["  answer  ", "answer", "  answer  ", "answer"] + ["other"] * 12
+        )
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        # All project to "answer" → unanimous → stops at 4
+        assert len(result.responses) == 4
+
+
+class TestBetaSelfConsistencyInterface:
+    """Test the algorithm interface and result types."""
+
+    @pytest.mark.asyncio
+    async def test_return_response_only_true(self):
+        lm = SequentialMockLM(["42"] * 8)
+        bsc = BetaSelfConsistency()
+
+        result = await bsc.ainfer(lm, "test", budget=8, return_response_only=True)
+
+        assert isinstance(result, dict)
+        assert result["role"] == "assistant"
+        assert result["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_return_response_only_false(self):
+        lm = SequentialMockLM(["42"] * 8)
+        bsc = BetaSelfConsistency()
+
+        result = await bsc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        assert isinstance(result, SelfConsistencyResult)
+        assert result.the_one["content"] == "42"
+        assert result.usage is not None
+
+    def test_sync_infer(self):
+        lm = SequentialMockLM(["42", "42", "42", "42", "24"] + ["42"] * 3)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = bsc.infer(lm, "test", budget=8, return_response_only=False)
+
+        assert isinstance(result, SelfConsistencyResult)
+        assert result.the_one["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_with_chat_messages(self):
+        lm = SequentialMockLM(["42"] * 8)
+        bsc = BetaSelfConsistency()
+
+        chat_messages = ChatMessages("Solve this problem")
+        result = await bsc.ainfer(
+            lm, chat_messages, budget=8, return_response_only=True
+        )
+
+        assert result["content"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_response_counts_populated(self):
+        lm = SequentialMockLM(["42", "24", "42", "42", "42"] + ["42"] * 11)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        assert result.response_counts["42"] >= 3
+        assert "24" in result.response_counts or len(result.responses) <= 4
+
+
+class TestBetaSelfConsistencyToolCalls:
+    """Test tool-call voting with beta stopping."""
+
+    def _make_tool_response(self, name, args):
+        return {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"function": {"name": name, "arguments": args}}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_tool_vote_name_early_stop(self):
+        resp = self._make_tool_response("get_weather", '{"city": "NYC"}')
+        lm = SequentialMockLM([resp] * 16)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95, tool_vote="tool_name")
+
+        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        # Unanimous tool name → stops at 4
+        assert len(result.responses) == 4
+        assert result.the_one["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_tool_vote_args_with_disagreement(self):
+        r1 = self._make_tool_response("search", '{"q": "cats"}')
+        r2 = self._make_tool_response("search", '{"q": "dogs"}')
+        # cats, dogs, cats, cats, cats, cats, cats → v1=6,v2=1 at sample 7 → P=0.9648 → stop
+        lm = SequentialMockLM([r1, r2, r1, r1, r1, r1, r1] + [r1] * 9)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95, tool_vote="tool_args")
+
+        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        assert len(result.responses) == 7
+
+    @pytest.mark.asyncio
+    async def test_exclude_args_in_tool_voting(self):
+        r1 = self._make_tool_response("search", '{"q": "cats", "request_id": "abc"}')
+        r2 = self._make_tool_response("search", '{"q": "cats", "request_id": "xyz"}')
+        lm = SequentialMockLM([r1, r2, r1, r2] + [r1] * 12)
+        bsc = BetaSelfConsistency(
+            confidence_threshold=0.95,
+            tool_vote="tool_args",
+            exclude_args=["request_id"],
+        )
+
+        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+
+        # After excluding request_id, all have args {"q": "cats"} → unanimous
+        assert len(result.responses) == 4

--- a/tests/test_beta_self_consistency.py
+++ b/tests/test_beta_self_consistency.py
@@ -226,22 +226,32 @@ class TestBetaSelfConsistencyEarlyStopping:
         assert len(result.responses) == 8
 
     @pytest.mark.asyncio
-    async def test_lower_threshold_stops_sooner(self):
+    async def test_lower_threshold_stops_sooner(self, monkeypatch):
         """Lower threshold requires fewer samples for the same agreement."""
-        lm_strict = SequentialMockLM(["42"] * 64)
-        lm_relaxed = SequentialMockLM(["42"] * 64)
+
+        async def wait_for_one(tasks, **kwargs):
+            assert kwargs["return_when"] is asyncio.FIRST_COMPLETED
+            completed = next(iter(tasks))
+            await completed
+            return {completed}, set(tasks) - {completed}
+
+        monkeypatch.setattr(asyncio, "wait", wait_for_one)
+
+        lm_strict = SequentialMockLM(["42"] * 8)
+        lm_relaxed = SequentialMockLM(["42"] * 8)
 
         bsc_strict = BetaSelfConsistency(confidence_threshold=0.95)
         bsc_relaxed = BetaSelfConsistency(confidence_threshold=0.8)
 
         result_strict = await bsc_strict.ainfer(
-            lm_strict, "test", budget=64, return_response_only=False
+            lm_strict, "test", budget=8, return_response_only=False
         )
         result_relaxed = await bsc_relaxed.ainfer(
-            lm_relaxed, "test", budget=64, return_response_only=False
+            lm_relaxed, "test", budget=8, return_response_only=False
         )
 
-        assert len(result_relaxed.responses) <= len(result_strict.responses)
+        assert len(result_strict.responses) == 4
+        assert len(result_relaxed.responses) == 2
 
     @pytest.mark.asyncio
     async def test_delayed_ordering_early_stop(self):

--- a/tests/test_beta_self_consistency.py
+++ b/tests/test_beta_self_consistency.py
@@ -1,5 +1,6 @@
 """Tests for BetaSelfConsistency algorithm."""
 
+import asyncio
 import threading
 
 import pytest
@@ -29,6 +30,28 @@ class SequentialMockLM:
         if isinstance(resp, dict):
             return resp
         return {"role": "assistant", "content": resp}
+
+
+class DelayedMockLM:
+    """Mock LM where each response has a controlled delay to test ordering.
+    Responses arrive in delay order, so we can predict which arrive first.
+    """
+
+    def __init__(self, responses_with_delays: list[tuple]):
+        """Args: list of (response_content, delay_seconds)"""
+        self.responses_with_delays = responses_with_delays
+        self.call_count = 0
+        self._lock = threading.Lock()
+
+    async def agenerate_single(self, messages, **kwargs):
+        with self._lock:
+            idx = self.call_count % len(self.responses_with_delays)
+            self.call_count += 1
+        content, delay = self.responses_with_delays[idx]
+        await asyncio.sleep(delay)
+        if isinstance(content, dict):
+            return content
+        return {"role": "assistant", "content": content}
 
 
 class TestBetaSelfConsistencyInit:
@@ -71,32 +94,26 @@ class TestBetaStoppingProbability:
     """Test the static beta_stopping_probability method."""
 
     def test_unanimous_1(self):
-        # v1=1, v2=0: P = 1 - I_0.5(2, 1) = 1 - 0.25 = 0.75
         prob = BetaSelfConsistency.beta_stopping_probability(1, 0)
         assert abs(prob - 0.75) < 1e-10
 
     def test_unanimous_2(self):
-        # v1=2, v2=0: P = 1 - I_0.5(3, 1) = 1 - 0.125 = 0.875
         prob = BetaSelfConsistency.beta_stopping_probability(2, 0)
         assert abs(prob - 0.875) < 1e-10
 
     def test_unanimous_4(self):
-        # v1=4, v2=0: P = 1 - I_0.5(5, 1) = 1 - 0.03125 = 0.96875
         prob = BetaSelfConsistency.beta_stopping_probability(4, 0)
         assert abs(prob - 0.96875) < 1e-10
 
     def test_split_50_50(self):
-        # v1=v2: should be close to 0.5 by symmetry
         prob = BetaSelfConsistency.beta_stopping_probability(5, 5)
         assert abs(prob - 0.5) < 1e-10
 
     def test_strong_majority(self):
-        # v1=10, v2=1: should be very high
         prob = BetaSelfConsistency.beta_stopping_probability(10, 1)
         assert prob > 0.99
 
     def test_monotonic_with_v1(self):
-        # More v1 counts → higher probability
         probs = [
             BetaSelfConsistency.beta_stopping_probability(v1, 2) for v1 in range(3, 10)
         ]
@@ -104,7 +121,6 @@ class TestBetaStoppingProbability:
             assert probs[i] < probs[i + 1]
 
     def test_monotonic_with_v2(self):
-        # More v2 counts → lower probability
         probs = [
             BetaSelfConsistency.beta_stopping_probability(5, v2) for v2 in range(0, 5)
         ]
@@ -113,54 +129,24 @@ class TestBetaStoppingProbability:
 
 
 class TestBetaSelfConsistencyEarlyStopping:
-    """Test the sample-one-at-a-time + beta stopping behavior."""
+    """Test the fire-all-cancel-early behavior."""
 
     @pytest.mark.asyncio
-    async def test_stops_with_unanimous_agreement(self):
-        """With all identical answers at threshold=0.95, needs 4 samples to stop.
-        v1=4, v2=0 → P=0.96875 ≥ 0.95."""
-        lm = SequentialMockLM(["42"] * 16)
+    async def test_stops_early_with_agreement(self):
+        """With all identical answers, should use fewer than budget samples."""
+        lm = SequentialMockLM(["42"] * 64)
         bsc = BetaSelfConsistency(confidence_threshold=0.95)
 
-        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+        result = await bsc.ainfer(lm, "test", budget=64, return_response_only=False)
 
         assert isinstance(result, SelfConsistencyResult)
-        assert len(result.responses) == 4
-        assert result.the_one["content"] == "42"
-
-    @pytest.mark.asyncio
-    async def test_unanimous_with_lower_threshold(self):
-        """With threshold=0.8, unanimous answers need 2 samples.
-        v1=2, v2=0 → P=0.875 ≥ 0.8."""
-        lm = SequentialMockLM(["42"] * 16)
-        bsc = BetaSelfConsistency(confidence_threshold=0.8)
-
-        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
-
-        assert len(result.responses) == 2
-
-    @pytest.mark.asyncio
-    async def test_disagreement_delays_stopping(self):
-        """One disagreement requires more samples to reach confidence."""
-        # Responses: 42, 24, 42, 42, 42, 42, 42, ...
-        lm = SequentialMockLM(["42", "24", "42", "42", "42", "42", "42", "42"])
-        bsc = BetaSelfConsistency(confidence_threshold=0.95)
-
-        result = await bsc.ainfer(lm, "test", budget=8, return_response_only=False)
-
-        # After 2: v1=1,v2=1 → P=0.5
-        # After 3: v1=2,v2=1 → P=0.6875
-        # After 4: v1=3,v2=1 → P=0.8125
-        # After 5: v1=4,v2=1 → P=0.890625
-        # After 6: v1=5,v2=1 → P=0.9375
-        # After 7: v1=6,v2=1 → P=0.964844 → stop
-        assert len(result.responses) == 7
+        assert len(result.responses) < 64
         assert result.the_one["content"] == "42"
 
     @pytest.mark.asyncio
     async def test_uses_full_budget_when_split(self):
         """Alternating answers never reach 0.95 confidence."""
-        lm = SequentialMockLM(["a", "b"] * 8)
+        lm = SequentialMockLM(["a", "b"] * 32)
         bsc = BetaSelfConsistency(confidence_threshold=0.95)
 
         result = await bsc.ainfer(lm, "test", budget=8, return_response_only=False)
@@ -180,8 +166,7 @@ class TestBetaSelfConsistencyEarlyStopping:
 
     @pytest.mark.asyncio
     async def test_budget_2_same_answers(self):
-        """Budget=2: 2 identical answers. v1=2,v2=0 → P=0.875 < 0.95.
-        Can't stop early because budget is exhausted."""
+        """Budget=2: 2 identical. P=0.875 < 0.95 so no early stop."""
         lm = SequentialMockLM(["yes", "yes"])
         bsc = BetaSelfConsistency(confidence_threshold=0.95)
 
@@ -190,18 +175,7 @@ class TestBetaSelfConsistencyEarlyStopping:
         assert len(result.responses) == 2
 
     @pytest.mark.asyncio
-    async def test_samples_one_at_a_time(self):
-        """Verify that exactly one sample is generated per iteration."""
-        lm = SequentialMockLM(["42"] * 16)
-        bsc = BetaSelfConsistency(confidence_threshold=0.95)
-
-        await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
-
-        # Should stop at 4 samples, each generated individually
-        assert lm.call_count == 4
-
-    @pytest.mark.asyncio
-    async def test_threshold_1_0_requires_very_high_confidence(self):
+    async def test_threshold_1_0_uses_full_budget(self):
         """threshold=1.0 is impossible to reach, should exhaust budget."""
         lm = SequentialMockLM(["42"] * 8)
         bsc = BetaSelfConsistency(confidence_threshold=1.0)
@@ -209,6 +183,38 @@ class TestBetaSelfConsistencyEarlyStopping:
         result = await bsc.ainfer(lm, "test", budget=8, return_response_only=False)
 
         assert len(result.responses) == 8
+
+    @pytest.mark.asyncio
+    async def test_lower_threshold_stops_sooner(self):
+        """Lower threshold requires fewer samples for the same agreement."""
+        lm_strict = SequentialMockLM(["42"] * 64)
+        lm_relaxed = SequentialMockLM(["42"] * 64)
+
+        bsc_strict = BetaSelfConsistency(confidence_threshold=0.95)
+        bsc_relaxed = BetaSelfConsistency(confidence_threshold=0.8)
+
+        result_strict = await bsc_strict.ainfer(
+            lm_strict, "test", budget=64, return_response_only=False
+        )
+        result_relaxed = await bsc_relaxed.ainfer(
+            lm_relaxed, "test", budget=64, return_response_only=False
+        )
+
+        assert len(result_relaxed.responses) <= len(result_strict.responses)
+
+    @pytest.mark.asyncio
+    async def test_delayed_ordering_early_stop(self):
+        """Fast-arriving unanimous responses trigger early stop while slow ones are cancelled."""
+        # 4 fast "42" responses (arrive first), 4 slow responses (should be cancelled)
+        responses = [("42", 0.0)] * 4 + [("99", 0.5)] * 4
+        lm = DelayedMockLM(responses)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=8, return_response_only=False)
+
+        # v1=4, v2=0 → P=0.96875 ≥ 0.95 → stop after 4 fast responses
+        assert len(result.responses) == 4
+        assert all(r["content"] == "42" for r in result.responses)
 
 
 class TestBetaSelfConsistencyProjection:
@@ -220,35 +226,25 @@ class TestBetaSelfConsistencyProjection:
         proj_func = create_regex_projection_function(pattern)
 
         lm = SequentialMockLM(
-            [
-                "Let me solve this. The answer is \\boxed{42}.",
-                "Using algebra, we get \\boxed{42}.",
-                "By computation \\boxed{42}.",
-                "Therefore \\boxed{42}.",
-            ]
-            + ["\\boxed{99}"] * 12
+            ["The answer is \\boxed{42}."] * 16 + ["\\boxed{99}"] * 48
         )
         bsc = BetaSelfConsistency(
             confidence_threshold=0.95,
             consistency_space_projection_func=proj_func,
         )
 
-        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+        result = await bsc.ainfer(lm, "test", budget=64, return_response_only=False)
 
-        # All 4 project to ("42",) → stops at 4 (unanimous)
-        assert len(result.responses) == 4
+        assert len(result.responses) < 64
 
     @pytest.mark.asyncio
     async def test_default_projection_strips_whitespace(self):
-        lm = SequentialMockLM(
-            ["  answer  ", "answer", "  answer  ", "answer"] + ["other"] * 12
-        )
+        lm = SequentialMockLM(["  answer  ", "answer", "  answer  ", "answer"] * 16)
         bsc = BetaSelfConsistency(confidence_threshold=0.95)
 
-        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
+        result = await bsc.ainfer(lm, "test", budget=64, return_response_only=False)
 
-        # All project to "answer" → unanimous → stops at 4
-        assert len(result.responses) == 4
+        assert len(result.responses) < 64
 
 
 class TestBetaSelfConsistencyInterface:
@@ -277,10 +273,10 @@ class TestBetaSelfConsistencyInterface:
         assert result.usage is not None
 
     def test_sync_infer(self):
-        lm = SequentialMockLM(["42", "42", "42", "42", "24"] + ["42"] * 3)
+        lm = SequentialMockLM(["42"] * 16)
         bsc = BetaSelfConsistency(confidence_threshold=0.95)
 
-        result = bsc.infer(lm, "test", budget=8, return_response_only=False)
+        result = bsc.infer(lm, "test", budget=16, return_response_only=False)
 
         assert isinstance(result, SelfConsistencyResult)
         assert result.the_one["content"] == "42"
@@ -296,16 +292,6 @@ class TestBetaSelfConsistencyInterface:
         )
 
         assert result["content"] == "42"
-
-    @pytest.mark.asyncio
-    async def test_response_counts_populated(self):
-        lm = SequentialMockLM(["42", "24", "42", "42", "42"] + ["42"] * 11)
-        bsc = BetaSelfConsistency(confidence_threshold=0.95)
-
-        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
-
-        assert result.response_counts["42"] >= 3
-        assert "24" in result.response_counts or len(result.responses) <= 4
 
 
 class TestBetaSelfConsistencyToolCalls:
@@ -326,27 +312,14 @@ class TestBetaSelfConsistencyToolCalls:
 
         result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
 
-        # Unanimous tool name → stops at 4
-        assert len(result.responses) == 4
+        assert len(result.responses) < 16
         assert result.the_one["tool_calls"][0]["function"]["name"] == "get_weather"
-
-    @pytest.mark.asyncio
-    async def test_tool_vote_args_with_disagreement(self):
-        r1 = self._make_tool_response("search", '{"q": "cats"}')
-        r2 = self._make_tool_response("search", '{"q": "dogs"}')
-        # cats, dogs, cats, cats, cats, cats, cats → v1=6,v2=1 at sample 7 → P=0.9648 → stop
-        lm = SequentialMockLM([r1, r2, r1, r1, r1, r1, r1] + [r1] * 9)
-        bsc = BetaSelfConsistency(confidence_threshold=0.95, tool_vote="tool_args")
-
-        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
-
-        assert len(result.responses) == 7
 
     @pytest.mark.asyncio
     async def test_exclude_args_in_tool_voting(self):
         r1 = self._make_tool_response("search", '{"q": "cats", "request_id": "abc"}')
         r2 = self._make_tool_response("search", '{"q": "cats", "request_id": "xyz"}')
-        lm = SequentialMockLM([r1, r2, r1, r2] + [r1] * 12)
+        lm = SequentialMockLM([r1, r2] * 8)
         bsc = BetaSelfConsistency(
             confidence_threshold=0.95,
             tool_vote="tool_args",
@@ -355,5 +328,5 @@ class TestBetaSelfConsistencyToolCalls:
 
         result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
 
-        # After excluding request_id, all have args {"q": "cats"} → unanimous
-        assert len(result.responses) == 4
+        # After excluding request_id, all have identical args → stops early
+        assert len(result.responses) < 16

--- a/tests/test_beta_self_consistency.py
+++ b/tests/test_beta_self_consistency.py
@@ -226,19 +226,11 @@ class TestBetaSelfConsistencyEarlyStopping:
         assert len(result.responses) == 8
 
     @pytest.mark.asyncio
-    async def test_lower_threshold_stops_sooner(self, monkeypatch):
+    async def test_lower_threshold_stops_sooner(self):
         """Lower threshold requires fewer samples for the same agreement."""
-
-        async def wait_for_one(tasks, **kwargs):
-            assert kwargs["return_when"] is asyncio.FIRST_COMPLETED
-            completed = next(iter(tasks))
-            await completed
-            return {completed}, set(tasks) - {completed}
-
-        monkeypatch.setattr(asyncio, "wait", wait_for_one)
-
-        lm_strict = SequentialMockLM(["42"] * 8)
-        lm_relaxed = SequentialMockLM(["42"] * 8)
+        staggered_responses = [("42", index * 0.01) for index in range(8)]
+        lm_strict = DelayedMockLM(staggered_responses)
+        lm_relaxed = DelayedMockLM(staggered_responses)
 
         bsc_strict = BetaSelfConsistency(confidence_threshold=0.95)
         bsc_relaxed = BetaSelfConsistency(confidence_threshold=0.8)
@@ -291,6 +283,114 @@ class TestBetaSelfConsistencyEarlyStopping:
 
         assert len(result.responses) == budget
         assert result.usage.num_calls == len(result.responses)
+
+    @pytest.mark.asyncio
+    async def test_retains_responses_completed_during_cancellation_race(
+        self, monkeypatch
+    ):
+        """Successful tasks omitted from wait's done set are still retained."""
+
+        class UsageTrackingMockLM(SequentialMockLM):
+            async def agenerate_single(self, messages, **kwargs):
+                response = await super().agenerate_single(messages, **kwargs)
+                kwargs["usage_accumulator"].add(prompt=1, completion=1)
+                return response
+
+        async def wait_with_stale_pending(tasks, return_when):
+            task_list = list(tasks)
+            await asyncio.gather(*task_list)
+            midpoint = len(task_list) // 2
+            return set(task_list[:midpoint]), set(task_list[midpoint:])
+
+        monkeypatch.setattr(asyncio, "wait", wait_with_stale_pending)
+
+        budget = 8
+        lm = UsageTrackingMockLM(["42"] * budget)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=budget, return_response_only=False)
+
+        assert len(result.responses) == budget
+        assert result.usage.num_calls == len(result.responses)
+
+    @pytest.mark.asyncio
+    async def test_generation_failure_cleans_up_all_tasks(self):
+        """A failed generation cancels and awaits every sibling task."""
+
+        class FailingMockLM:
+            def __init__(self, budget):
+                self.budget = budget
+                self.call_count = 0
+                self.active_calls = 0
+                self.cancelled_calls = 0
+                self.all_started = asyncio.Event()
+
+            async def agenerate_single(self, messages, **kwargs):
+                call_index = self.call_count
+                self.call_count += 1
+                self.active_calls += 1
+                if self.call_count == self.budget:
+                    self.all_started.set()
+
+                try:
+                    await self.all_started.wait()
+                    if call_index == 0:
+                        raise ValueError("generation failed")
+                    await asyncio.sleep(10)
+                    return {"role": "assistant", "content": "42"}
+                except asyncio.CancelledError:
+                    self.cancelled_calls += 1
+                    raise
+                finally:
+                    self.active_calls -= 1
+
+        budget = 4
+        lm = FailingMockLM(budget)
+        bsc = BetaSelfConsistency(orchestrator=LMOrchestrator(max_concurrency=-1))
+
+        with pytest.raises(RuntimeError, match="1x ValueError"):
+            await bsc.ainfer(lm, "test", budget=budget)
+
+        assert lm.active_calls == 0
+        assert lm.cancelled_calls == budget - 1
+
+    @pytest.mark.asyncio
+    async def test_caller_cancellation_cleans_up_all_tasks(self):
+        """Cancelling ainfer cancels and awaits every generation task."""
+
+        class SlowMockLM:
+            def __init__(self, budget):
+                self.budget = budget
+                self.active_calls = 0
+                self.cancelled_calls = 0
+                self.all_started = asyncio.Event()
+
+            async def agenerate_single(self, messages, **kwargs):
+                self.active_calls += 1
+                if self.active_calls == self.budget:
+                    self.all_started.set()
+
+                try:
+                    await asyncio.sleep(10)
+                    return {"role": "assistant", "content": "42"}
+                except asyncio.CancelledError:
+                    self.cancelled_calls += 1
+                    raise
+                finally:
+                    self.active_calls -= 1
+
+        budget = 4
+        lm = SlowMockLM(budget)
+        bsc = BetaSelfConsistency(orchestrator=LMOrchestrator(max_concurrency=-1))
+        inference_task = asyncio.create_task(bsc.ainfer(lm, "test", budget=budget))
+        await lm.all_started.wait()
+
+        inference_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await inference_task
+
+        assert lm.active_calls == 0
+        assert lm.cancelled_calls == budget
 
 
 class TestBetaSelfConsistencyProjection:

--- a/tests/test_beta_self_consistency.py
+++ b/tests/test_beta_self_consistency.py
@@ -248,6 +248,31 @@ class TestBetaSelfConsistencyEarlyStopping:
         assert len(result.responses) == 4
         assert all(r["content"] == "42" for r in result.responses)
 
+    @pytest.mark.asyncio
+    async def test_collects_entire_completed_batch_before_stopping(self, monkeypatch):
+        """Responses and usage stay aligned when several tasks finish together."""
+
+        class UsageTrackingMockLM(SequentialMockLM):
+            async def agenerate_single(self, messages, **kwargs):
+                response = await super().agenerate_single(messages, **kwargs)
+                kwargs["usage_accumulator"].add(prompt=1, completion=1)
+                return response
+
+        async def wait_for_entire_batch(tasks, return_when):
+            await asyncio.gather(*tasks)
+            return set(tasks), set()
+
+        monkeypatch.setattr(asyncio, "wait", wait_for_entire_batch)
+
+        budget = 8
+        lm = UsageTrackingMockLM(["42"] * budget)
+        bsc = BetaSelfConsistency(confidence_threshold=0.95)
+
+        result = await bsc.ainfer(lm, "test", budget=budget, return_response_only=False)
+
+        assert len(result.responses) == budget
+        assert result.usage.num_calls == len(result.responses)
+
 
 class TestBetaSelfConsistencyProjection:
     """Test with custom projection functions."""
@@ -257,17 +282,17 @@ class TestBetaSelfConsistencyProjection:
         pattern = r"\\boxed\{([^}]+)\}"
         proj_func = create_regex_projection_function(pattern)
 
-        lm = SequentialMockLM(
-            ["The answer is \\boxed{42}."] * 16 + ["\\boxed{99}"] * 48
+        lm = DelayedMockLM(
+            [("The answer is \\boxed{42}.", 0.0)] * 4 + [("\\boxed{99}", 0.1)] * 12
         )
         bsc = BetaSelfConsistency(
             confidence_threshold=0.95,
             consistency_space_projection_func=proj_func,
         )
 
-        result = await bsc.ainfer(lm, "test", budget=64, return_response_only=False)
+        result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
 
-        assert len(result.responses) < 64
+        assert len(result.responses) < 16
 
     @pytest.mark.asyncio
     async def test_default_projection_strips_whitespace(self):
@@ -339,7 +364,7 @@ class TestBetaSelfConsistencyToolCalls:
     @pytest.mark.asyncio
     async def test_tool_vote_name_early_stop(self):
         resp = self._make_tool_response("get_weather", '{"city": "NYC"}')
-        lm = SequentialMockLM([resp] * 16)
+        lm = DelayedMockLM([(resp, 0.0)] * 4 + [(resp, 0.1)] * 12)
         bsc = BetaSelfConsistency(confidence_threshold=0.95, tool_vote="tool_name")
 
         result = await bsc.ainfer(lm, "test", budget=16, return_response_only=False)
@@ -351,7 +376,7 @@ class TestBetaSelfConsistencyToolCalls:
     async def test_exclude_args_in_tool_voting(self):
         r1 = self._make_tool_response("search", '{"q": "cats", "request_id": "abc"}')
         r2 = self._make_tool_response("search", '{"q": "cats", "request_id": "xyz"}')
-        lm = SequentialMockLM([r1, r2] * 8)
+        lm = DelayedMockLM([(r1, 0.0), (r2, 0.0)] * 2 + [(r1, 0.1), (r2, 0.1)] * 6)
         bsc = BetaSelfConsistency(
             confidence_threshold=0.95,
             tool_vote="tool_args",


### PR DESCRIPTION
## Summary

Add BetaSelfConsistency algorithm (Aggarwal et al., 2023) — an adaptive stopping variant of self-consistency that fires all requests concurrently and cancels remaining ones once a Beta-posterior confidence threshold is met.

## Changes

- **`its_hub/core/algorithms/beta_self_consistency.py`** — New algorithm. Fires all budget requests via `asyncio.create_task`, processes responses as they arrive with `asyncio.wait(FIRST_COMPLETED)`, computes stopping probability using the regularized incomplete beta function (`scipy.special.betainc`), and cancels pending tasks once P >= threshold (default 0.95).
- **`pyproject.toml`** — Add `scipy>=1.11.0` to the `[experimental]` extra.
- **`tests/test_beta_self_consistency.py`** — 20 tests covering init validation, beta stopping probability math, early stopping behavior, delayed-response ordering, projection functions, tool-call voting, and the sync/async interface.

## Test Plan

- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Linting passes (`uv run ruff check its_hub/`)
- [x] Formatting passes (`uv run ruff format --check its_hub/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental `BetaSelfConsistency` inference with adaptive early stopping and parallel, budget-capped generations.
  * Supports response projection and consensus voting, including tool-call voting with optional tool-argument field exclusion.
  * Exposed `BetaSelfConsistency` via the package public API.
* **Bug Fixes**
  * Improved the precision of the confidence/stability calculation used to trigger early stopping.
* **Documentation**
  * Documented Beta Self-Consistency usage, including budget interpretation and an example.
* **Tests**
  * Added deterministic async tests covering early stopping, concurrency limits, cancellation, and projection/tool-voting behavior.
* **Chores**
  * Updated the `experimental` extra to include `scipy>=1.11.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->