### PR TITLE
(feat) Envoy ext_proc gateway integration using iaas

### DIFF
--- a/.github/actions/compile-protos/action.yml
+++ b/.github/actions/compile-protos/action.yml
@@ -11,6 +11,6 @@ runs:
           exit 0
         fi
         git submodule update --init --recursive || true
-        mkdir -p its_hub/integration/ext_proc/proto
-        printf 'import sys\nfrom pathlib import Path\n\n_proto_dir = Path(__file__).parent\nif str(_proto_dir) not in sys.path:\n    sys.path.insert(0, str(_proto_dir))\n' > its_hub/integration/ext_proc/proto/__init__.py
+        mkdir -p its_hub/integration/proto
+        printf 'import sys\nfrom pathlib import Path\n\n_proto_dir = Path(__file__).parent\nif str(_proto_dir) not in sys.path:\n    sys.path.insert(0, str(_proto_dir))\n' > its_hub/integration/proto/__init__.py
         make proto-compile

--- a/.github/workflows/sentrux.yaml
+++ b/.github/workflows/sentrux.yaml
@@ -61,7 +61,7 @@ jobs:
     - name: Stage proto files for Sentrux (base)
       if: github.event_name == 'pull_request'
       continue-on-error: true
-      run: git add -f its_hub/integration/ext_proc/proto/
+      run: git add -f its_hub/integration/proto/
 
     - name: Run Sentrux on base
       if: github.event_name == 'pull_request'
@@ -86,7 +86,7 @@ jobs:
 
     - name: Stage proto files for Sentrux (head)
       continue-on-error: true
-      run: git add -f its_hub/integration/ext_proc/proto/
+      run: git add -f its_hub/integration/proto/
 
     - name: Run Sentrux on head
       id: head

--- a/.gitignore
+++ b/.gitignore
@@ -190,8 +190,6 @@ results/
 
 .its-hub/
 
-# Envoy ext_proc
-its_hub/integration/ext_proc/proto/
+# Generated Envoy proto files
+its_hub/integration/proto/
 third_party/.submodules-initialized
-envoy.log
-envoy-grpc.log

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,7 @@ results/
 # Generated Envoy proto files
 its_hub/integration/proto/
 third_party/.submodules-initialized
+envoy.log
+envoy-grpc.log
+iaas-ext-proc.log
+iaas.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ python scripts/benchmark.py --help
 ### IaaS Service (Inference-as-a-Service)
 ```bash
 # Start IaaS service
-uv run its-iaas --host 0.0.0.0 --port 8108
+uv run its-iaas --host 127.0.0.1 --port 8109
 
 # Or using justfile (if available)
 just iaas-start

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ help:
 	@echo "  make upgrade-protos - Restore proto submodules to pinned commits from .gitmodules"
 
 # Directories
-PROTO_OUT_DIR := its_hub/integration/ext_proc/proto
+PROTO_OUT_DIR := its_hub/integration/proto
 THIRD_PARTY := third_party
 
 # Proto source directories
@@ -172,7 +172,7 @@ envoy-stack-stop:
 
 # Start IaaS service on localhost:8109
 iaas-start:
-	uv run its-iaas --host 0.0.0.0 --port 8109
+	uv run its-iaas --host 127.0.0.1 --port 8109
 
 # Check IaaS service health
 iaas-health:
@@ -189,7 +189,7 @@ envoy-iaas-stack:
 	@echo "Press Ctrl+C to stop all services"
 	@trap 'kill 0' INT; \
 	(uv run its-iaas-ext-proc --port 50051 2>&1 | tee ext-proc.log) & \
-	(uv run its-iaas --host 0.0.0.0 --port 8109 2>&1 | tee iaas.log) & \
+	(uv run its-iaas --host 127.0.0.1 --port 8109 2>&1 | tee iaas.log) & \
 	(envoy -c its_hub/integration/iaas/envoy_config.yaml 2>&1 | tee envoy.log) & \
 	wait
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # Handles proto compilation for Envoy external processor
 
 .PHONY: help setup setup-envoy upgrade-protos proto-compile proto-clean submodule-init \
-        iaas-start iaas-health envoy-stack envoy-stack-stop envoy-start envoy-grpc envoy-test envoy-health test
+        iaas-start iaas-health envoy-stack envoy-stack-stop envoy-start envoy-grpc envoy-test envoy-health \
+        envoy-iaas-stack envoy-iaas-stack-stop test
 
 # Default target
 help:
@@ -26,6 +27,8 @@ help:
 	@echo "  make envoy-grpc       - Start Envoy external processor gRPC service"
 	@echo "  make envoy-test       - Test Envoy external processor with sample requests"
 	@echo "  make envoy-health     - Check Envoy cluster health and statistics"
+	@echo "  make envoy-iaas-stack      - Start Envoy + ext_proc + IaaS together"
+	@echo "  make envoy-iaas-stack-stop - Stop all three services"
 	@echo ""
 	@echo "Testing Commands:"
 	@echo "  make test           - Run all pytest tests"
@@ -167,13 +170,36 @@ envoy-stack-stop:
 	@pkill -f "envoy-grpc" || echo "gRPC service not running"
 	@echo "✓ Envoy stack stopped"
 
-# Start IaaS service on localhost:8108
+# Start IaaS service on localhost:8109
 iaas-start:
-	uv run its-iaas --host 0.0.0.0 --port 8108
+	uv run its-iaas --host 0.0.0.0 --port 8109
 
 # Check IaaS service health
 iaas-health:
-	curl -v -s http://localhost:8108/v1/models | jq .
+	curl -v -s http://localhost:8109/v1/models | jq .
+
+# Start Envoy + ext_proc + IaaS together
+envoy-iaas-stack:
+	@echo "Starting IaaS stack (Envoy + ext_proc + IaaS)..."
+	@echo "Logs will be written to:"
+	@echo "  - envoy.log (Envoy proxy on port 8108)"
+	@echo "  - ext-proc.log (gRPC ext_proc on port 50051)"
+	@echo "  - iaas.log (IaaS FastAPI on port 8109)"
+	@echo ""
+	@echo "Press Ctrl+C to stop all services"
+	@trap 'kill 0' INT; \
+	(uv run its-iaas-ext-proc --port 50051 2>&1 | tee ext-proc.log) & \
+	(uv run its-iaas --host 0.0.0.0 --port 8109 2>&1 | tee iaas.log) & \
+	(envoy -c its_hub/integration/iaas/envoy_config.yaml 2>&1 | tee envoy.log) & \
+	wait
+
+# Stop IaaS stack
+envoy-iaas-stack-stop:
+	@echo "Stopping IaaS stack..."
+	@pkill -f "envoy -c" || echo "Envoy proxy not running"
+	@pkill -f "its-iaas-ext-proc" || echo "gRPC service not running"
+	@pkill -f "its-iaas" || echo "IaaS services not running"
+	@echo "✓ IaaS stack stopped"
 
 # Start Envoy proxy with ext_proc configuration
 envoy-start:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help:
 	@echo "  make proto-clean    - Remove generated proto files"
 	@echo ""
 	@echo "Service Commands:"
-	@echo "  make iaas-start       - Start IaaS service on localhost:8108"
+	@echo "  make iaas-start       - Start IaaS service on localhost:8109"
 	@echo "  make iaas-health      - Check IaaS service health"
 	@echo "  make envoy-stack      - Start Envoy proxy + gRPC service together"
 	@echo "  make envoy-stack-stop - Stop Envoy stack"
@@ -183,12 +183,12 @@ envoy-iaas-stack:
 	@echo "Starting IaaS stack (Envoy + ext_proc + IaaS)..."
 	@echo "Logs will be written to:"
 	@echo "  - envoy.log (Envoy proxy on port 8108)"
-	@echo "  - ext-proc.log (gRPC ext_proc on port 50051)"
+	@echo "  - iaas-ext-proc.log (gRPC ext_proc on port 50051)"
 	@echo "  - iaas.log (IaaS FastAPI on port 8109)"
 	@echo ""
 	@echo "Press Ctrl+C to stop all services"
 	@trap 'kill 0' INT; \
-	(uv run its-iaas-ext-proc --port 50051 2>&1 | tee ext-proc.log) & \
+	(uv run its-iaas-ext-proc --port 50051 2>&1 | tee iaas-ext-proc.log) & \
 	(uv run its-iaas --host 127.0.0.1 --port 8109 2>&1 | tee iaas.log) & \
 	(envoy -c its_hub/integration/iaas/envoy_config.yaml 2>&1 | tee envoy.log) & \
 	wait

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To use ITS as an external processor with Envoy:
 make setup-envoy
 ```
 
-For more information, refer to [docs/ext-proc-gateway.md](docs/ext-proc-gateway.md).
+For more information, refer to [docs/ext-proc-gateway.md](docs/ext-proc-gateway.md) and [docs/iaas-service.md](docs/iaas-service.md).
 
 ## Quick Start
 

--- a/docs/iaas-service.md
+++ b/docs/iaas-service.md
@@ -18,6 +18,49 @@ The IaaS service provides an OpenAI-compatible API with inference-time scaling a
 └──────────────┘    └─────────────────┘    └──────────────────┘
 ```
 
+## Activation Model
+
+ITS activation is conveyed **in-band** via the request body and optional HTTP headers.
+The `budget` field in the request body triggers ITS; without it, the service default is
+used.
+
+### Per-Request Configuration
+
+| Source | Field / Header | Description | Priority |
+|---|---|---|---|
+| HTTP header | `X-ITS-Budget` | Override compute budget | 1 (highest) |
+| HTTP header | `X-ITS-Endpoint` | Override LLM endpoint | 1 |
+| HTTP header | `X-ITS-API-Key` | Override API key | 1 |
+| Request body | `budget` | Compute budget | 2 |
+| `/configure` | `budget`, `endpoint`, `api_key` | Service defaults | 3 (lowest) |
+
+Priority chain: **header > body > service default**. Headers are intended for Envoy
+ext_proc routing but are also accepted on the standalone IaaS endpoint.
+
+### Algorithm Selection
+
+The algorithm is configured globally via `POST /configure` with the `alg` field.
+Per-request algorithm selection is not supported. Currently only `self-consistency` is
+available through the gateway.
+
+## API Key Handling
+
+API keys can enter the system through three paths:
+
+1. **`/configure` body** — stored in memory as the service default; used when no
+   per-request key is provided
+2. **`X-ITS-API-Key` header** — per-request override, highest priority
+3. **Request body** — not supported; keys must come via `/configure` or headers
+
+**Security properties:**
+
+- Keys are **never logged** — the gateway logs endpoint and model but not credentials
+- Keys are **hashed** (SHA-256, truncated to 16 hex chars) in LM cache keys to prevent
+  credential cross-contamination between requests using different API keys
+- Keys are **not persisted** to disk — they exist only in memory for the lifetime of the
+  service process
+- On shutdown, all cached LM clients (and their associated keys) are cleared
+
 ## Prerequisites
 
 - **Software**: Python 3.11+, its_hub library
@@ -285,6 +328,56 @@ CUDA_VISIBLE_DEVICES=1 uv run its-iaas \
   --host 127.0.0.1 --port 8109 > iaas.log 2>&1 &
 ```
 
+## Failure Policy
+
+| Failure | HTTP Status | Response |
+|---|---|---|
+| Service not configured (no `/configure` call) | 200 (SSE) / 400 | `"Service not configured"` error in stream or HTTP 400 |
+| Invalid budget (non-integer, out of range) | 400 | `"Bad Request"` with detail |
+| Unsupported algorithm | 400 | `"Algorithm 'X' not supported"` |
+| Invalid regex pattern in `/configure` | 400 | Regex compilation error detail |
+| Downstream LLM unreachable / timeout | 500 | `"Generation failed. Check server logs for details."` |
+| Algorithm execution error | 500 | `"Generation failed. Check server logs for details."` |
+| `/configure` internal error | 500 | `"Configuration failed. Check server logs for details."` |
+
+Error responses in the streaming path (`stream: true`) are delivered as SSE `data:` frames
+with an `error` field, followed by `data: [DONE]`. The HTTP status is always 200 for
+streaming responses (per SSE convention).
+
+Non-streaming errors return standard HTTP error responses with a `detail` field.
+Internal error details are **never exposed** to clients — they are logged server-side at
+ERROR level.
+
+## Streaming
+
+The IaaS service accepts `"stream": true` in the request body. However, ITS algorithms
+require all candidate responses before selecting the best one, so **true token-level
+streaming is not possible**.
+
+Instead, the service **buffers the full ITS result** and then emits it as SSE chunks:
+
+1. The algorithm generates all candidates and selects the winner
+2. The selected response is emitted as one or more `data:` frames in OpenAI SSE format
+3. A final `data: [DONE]` frame signals completion
+
+For content responses, a single content chunk is emitted. For tool call responses, each
+tool call is emitted as a separate chunk followed by a `finish_reason: "tool_calls"` frame.
+
+Clients using the OpenAI SDK with `stream=True` will work correctly — the response just
+arrives as a burst rather than incrementally.
+
+## Restart and Scaling
+
+- **State**: The service holds an in-memory LM client cache (LRU, default 64 entries),
+  a gateway instance, and the service config set via `/configure`. No state is persisted
+  to disk.
+- **Restart**: Restarting clears all cached LM clients and the service config.
+  `/configure` must be called again after restart.
+- **Horizontal scaling**: Multiple IaaS instances can run independently. Each maintains
+  its own LM client cache, config, and gateway. There is no shared state between
+  instances. A load balancer must route `/configure` to all instances or each instance
+  must be configured independently.
+
 ## API Endpoints
 
 ### Configuration
@@ -416,6 +509,20 @@ curl -X POST http://localhost:8108/v1/chat/completions \
   }'
 ```
 
+### Header Stripping
+
+When deployed behind Envoy, `X-ITS-*` headers are stripped in two layers to ensure
+upstream LLM services never see ITS metadata:
+
+1. **Envoy route-level**: The pass-through route includes `request_headers_to_remove`
+   for `X-ITS-Budget`, `X-ITS-Endpoint`, and `X-ITS-API-Key`, stripping them before
+   forwarding to the LLM upstream.
+2. **ext_proc code-level**: The external processor strips any stray `X-ITS-*` headers
+   from requests it processes, as a defense-in-depth measure.
+
+On the IaaS route, headers are preserved — the IaaS service reads them for per-request
+configuration overrides.
+
 ### Generating the Envoy Config
 
 The bundled Envoy config can be printed and customized:
@@ -429,3 +536,5 @@ its-iaas --print-config > envoy_config.yaml
 ```
 
 See the config comments for customization options (ports, timeouts, failure modes).
+
+For standalone ext_proc deployment (without IaaS), see [ext_proc Gateway Guide](ext-proc-gateway.md).

--- a/docs/iaas-service.md
+++ b/docs/iaas-service.md
@@ -4,7 +4,7 @@ This guide provides comprehensive instructions for setting up and running the it
 
 ## Overview
 
-The IaaS service provides an OpenAI-compatible API with inference-time scaling algorithms. **Optimized for tool-calling applications** including agents, function calling, and multi-step reasoning. Currently supports **Best-of-N** and **Self-Consistency** algorithms.
+The IaaS service provides an OpenAI-compatible API with inference-time scaling algorithms. **Optimized for tool-calling applications** including agents, function calling, and multi-step reasoning. Currently supports **Self-Consistency**, with **Best-of-N** coming soon.
 
 ### Architecture
 
@@ -26,59 +26,36 @@ The IaaS service provides an OpenAI-compatible API with inference-time scaling a
 
 ## Quick Start
 
-### Start IaaS Service
+### Start IaaS Service (standalone)
 
 ```bash
-uv run its-iaas --host 0.0.0.0 --port 8108
+uv run its-iaas --port 8109
 ```
 
 **Parameters:**
-- `--host 0.0.0.0`: Listen on all interfaces
-- `--port 8108`: Default port for IaaS service
+- `--host`: Host to bind to (default: `127.0.0.1`, localhost only)
+- `--port 8109`: Default port for IaaS service
 - `--dev`: Optional development mode with auto-reload
+- `--print-config`: Print the bundled Envoy config to stdout and exit
 
-### 3. Configure IaaS Service
+### Configure IaaS Service
 
 The IaaS service supports different algorithm configurations based on your use case.
-
-## Algorithm Configurations
 
 ### Self-Consistency with Tool Voting
 
 Best for: Tool-calling models where you want to vote on tool usage patterns.
 
-**With OpenAI:**
 ```bash
-curl -X POST http://localhost:8108/configure \
+curl -X POST http://localhost:8109/configure \
   -H "Content-Type: application/json" \
   -d '{
-    "provider": "litellm",
-    "endpoint": "auto",
+    "endpoint": "https://api.openai.com/v1",
     "api_key": "your-openai-api-key",
     "model": "gpt-4o-mini",
     "alg": "self-consistency",
     "tool_vote": "tool_hierarchical",
     "exclude_args": ["timestamp", "request_id", "id", "type"]
-  }'
-```
-
-**With AWS Bedrock:**
-```bash
-curl -X POST http://localhost:8108/configure \
-  -H "Content-Type: application/json" \
-  -d '{
-    "provider": "litellm",
-    "endpoint": "auto",
-    "api_key": null,
-    "model": "bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-    "alg": "self-consistency",
-    "tool_vote": "tool_hierarchical",
-    "exclude_args": ["timestamp", "request_id", "id"],
-    "extra_args": {
-      "aws_access_key_id": "your-access-key",
-      "aws_secret_access_key": "your-secret-key",
-      "aws_region_name": "us-east-1"
-    }
   }'
 ```
 
@@ -88,73 +65,18 @@ curl -X POST http://localhost:8108/configure \
 
 ---
 
-### Best-of-N with LLM Judge
+### Best-of-N with LLM Judge (coming soon)
 
-Best for: Cloud APIs where you want LLM-based scoring without local reward models.
-
-**With OpenAI:**
-```bash
-curl -X POST http://localhost:8108/configure \
-  -H "Content-Type: application/json" \
-  -d '{
-    "provider": "litellm",
-    "endpoint": "auto",
-    "api_key": "your-openai-api-key",
-    "model": "gpt-4o-mini",
-    "alg": "best-of-n",
-    "rm_name": "llm-judge",
-    "judge_model": "gpt-4o-mini",
-    "judge_base_url": "auto",
-    "judge_mode": "groupwise",
-    "judge_criterion": "multi_step_tool_judge",
-    "judge_api_key": "your-openai-api-key",
-    "judge_temperature": 0.7,
-    "judge_max_tokens": 2048
-  }'
-```
-
-**With AWS Bedrock:**
-```bash
-curl -X POST http://localhost:8108/configure \
-  -H "Content-Type: application/json" \
-  -d '{
-    "provider": "litellm",
-    "endpoint": "auto",
-    "api_key": null,
-    "model": "bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-    "alg": "best-of-n",
-    "rm_name": "llm-judge",
-    "judge_model": "bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0",
-    "judge_base_url": "auto",
-    "judge_mode": "groupwise",
-    "judge_criterion": "multi_step_tool_judge",
-    "judge_api_key": null,
-    "judge_temperature": 0.7,
-    "judge_max_tokens": 2048,
-    "extra_args": {
-      "aws_access_key_id": "your-access-key",
-      "aws_secret_access_key": "your-secret-key",
-      "aws_region_name": "us-east-1"
-    }
-  }'
-```
-
-**Parameters:**
-- `rm_name`: Set to `"llm-judge"` to use LLM-based scoring
-- `judge_model`: LiteLLM model name for the judge
-- `judge_mode`: `"pointwise"` or `"groupwise"` (groupwise recommended)
-- `judge_criterion`: Criterion for judging (e.g., `"overall_quality"`, `"multi_step_tool_judge"`)
-- `judge_temperature`: Temperature for judge generation (0.0-1.0)
+Best for: When you want LLM-based scoring without local reward models. Not yet available through the IaaS gateway — currently only supported via the library API directly.
 
 ---
 
 ### Common Parameters
 
 All configurations support:
-- `provider`: `"litellm"` for multi-cloud support
-- `endpoint`: API endpoint URL or `"auto"` for LiteLLM auto-detection
-- `api_key`: API key for the provider (use `null` for Bedrock with credentials in `extra_args`)
-- `model`: Model identifier (format depends on provider)
+- `endpoint`: OpenAI-compatible API endpoint URL
+- `api_key`: API key for the provider
+- `model`: Model identifier
 - `alg`: Algorithm name - `"self-consistency"` or `"best-of-n"`
 
 ## Usage Examples
@@ -164,7 +86,7 @@ All configurations support:
 Tool calling is the primary use case for IaaS with Self-Consistency and Best-of-N algorithms.
 
 ```bash
-curl -X POST http://localhost:8108/v1/chat/completions \
+curl -X POST http://localhost:8109/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "gpt-4o-mini",
@@ -208,7 +130,7 @@ curl -X POST http://localhost:8108/v1/chat/completions \
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="http://localhost:8108/v1",
+    base_url="http://localhost:8109/v1",
     api_key="dummy-key"  # Not validated for local use
 )
 
@@ -253,7 +175,7 @@ print(f"Arguments: {tool_calls[0].function.arguments}")
 ### Basic Text Request
 
 ```bash
-curl -X POST http://localhost:8108/v1/chat/completions \
+curl -X POST http://localhost:8109/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "gpt-4o-mini",
@@ -278,7 +200,7 @@ The `budget` parameter controls the computational effort:
 
 ```bash
 # Forward IaaS service only
-ssh -L 8108:localhost:8108 user@server-ip
+ssh -L 8109:localhost:8109 user@server-ip
 
 # Forward vLLM service only  
 ssh -L 8100:localhost:8100 user@server-ip
@@ -288,14 +210,14 @@ ssh -L 8100:localhost:8100 user@server-ip
 
 ```bash
 # Forward both services
-ssh -L 8100:localhost:8100 -L 8108:localhost:8108 user@server-ip
+ssh -L 8100:localhost:8100 -L 8109:localhost:8109 user@server-ip
 ```
 
 ### Background SSH Tunnel
 
 ```bash
 # Run tunnel in background
-ssh -f -N -L 8100:localhost:8100 -L 8108:localhost:8108 user@server-ip
+ssh -f -N -L 8100:localhost:8100 -L 8109:localhost:8109 user@server-ip
 ```
 
 ### Access from Local Machine
@@ -313,7 +235,7 @@ curl -X POST http://localhost:8100/v1/chat/completions \
   }'
 
 # Test IaaS with scaling
-curl -X POST http://localhost:8108/v1/chat/completions \
+curl -X POST http://localhost:8109/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "Qwen/Qwen2.5-Math-1.5B-Instruct",
@@ -329,7 +251,7 @@ curl -X POST http://localhost:8108/v1/chat/completions \
 ```bash
 # Check if services are running
 ss -tlnp | grep 8100  # vLLM
-ss -tlnp | grep 8108  # IaaS
+ss -tlnp | grep 8109  # IaaS
 
 # Check GPU usage
 nvidia-smi
@@ -339,7 +261,7 @@ nvidia-smi
 
 ```bash
 # Find process IDs
-ss -tlnp | grep 8108
+ss -tlnp | grep 8109
 
 # Kill specific process
 kill -9 <PID>
@@ -356,11 +278,11 @@ pkill -f "its-iaas"
 ```bash
 # Run vLLM in background
 CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen2.5-Math-1.5B-Instruct \
-  --dtype float16 --host 0.0.0.0 --port 8100 > vllm.log 2>&1 &
+  --dtype float16 --host 127.0.0.1 --port 8100 > vllm.log 2>&1 &
 
 # Run IaaS in background
 CUDA_VISIBLE_DEVICES=1 uv run its-iaas \
-  --host 0.0.0.0 --port 8108 > iaas.log 2>&1 &
+  --host 127.0.0.1 --port 8109 > iaas.log 2>&1 &
 ```
 
 ## API Endpoints
@@ -383,7 +305,7 @@ CUDA_VISIBLE_DEVICES=1 uv run its-iaas \
 **1. Port Already in Use**
 ```bash
 # Check what's using the port
-ss -tlnp | grep 8108
+ss -tlnp | grep 8109
 # Kill the process
 kill -9 <PID>
 ```
@@ -405,9 +327,9 @@ huggingface-cli download Qwen/Qwen2.5-Math-PRM-7B
 **4. Connection Refused**
 ```bash
 # Check if service is running
-curl -X GET http://localhost:8108/docs
+curl -X GET http://localhost:8109/docs
 # Check firewall settings
-# Verify host binding (0.0.0.0 vs 127.0.0.1)
+# Verify host binding
 ```
 
 **5. Slow Responses**
@@ -447,41 +369,63 @@ python -c "import traceback; traceback.print_exc()"
 
 ## Security Considerations
 
-- Services bind to `0.0.0.0` for external access
+- Services bind to `127.0.0.1` (localhost only) by default — use `--host 0.0.0.0` only when network access is intentional
+- `POST /configure` is an unauthenticated admin endpoint — when binding to `0.0.0.0`, protect it with network-level access control (firewall, Envoy, reverse proxy)
 - Use SSH tunneling for secure remote access
 - Consider adding authentication for production use
 - Monitor resource usage to prevent abuse
 
-## Integration Examples
+## Envoy Integration
 
-### Watson Orchestrate
-The service is compatible with Watson Orchestrate's OpenAI-compatible API:
+The IaaS service can be deployed behind Envoy with an ext_proc filter that routes requests with `X-ITS-*` headers to the IaaS backend.
 
-```python
-# Watson Orchestrate integration
-import openai
+### Architecture
 
-client = openai.OpenAI(
-    base_url="http://localhost:8108/v1",
-    api_key="dummy-key"
-)
-
-response = client.chat.completions.create(
-    model="Qwen/Qwen2.5-Math-1.5B-Instruct",
-    messages=[{"role": "user", "content": "Solve this math problem"}],
-    extra_body={"budget": 4}  # IaaS-specific parameter
-)
+```
+Client → Envoy (port 8108)
+   ├── /v1/chat/completions + X-ITS-* headers  →  ext_proc → IaaS (port 8109)  [transparent ITS]
+   └── /* (no ITS headers)  →  LLM upstream (port 8100)                        [passthrough]
 ```
 
-### Custom Applications
-The service follows OpenAI's API format with the addition of the `budget` parameter for controlling inference-time scaling.
+The ext_proc acts as a lightweight router — it checks for `X-ITS-Budget` and redirects matching requests to the IaaS backend. The IaaS service handles algorithm execution.
 
-## Next Steps
+### Starting the Full Stack
 
-1. **Production Deployment**: Consider using Docker containers and orchestration
-2. **Monitoring**: Add metrics collection and alerting
-3. **Authentication**: Implement API key management
-4. **Load Balancing**: Scale horizontally with multiple instances
-5. **Model Management**: Implement model versioning and hot-swapping
+```bash
+# Start all three services together
+make envoy-iaas-stack
 
-For more information, see the [its_hub documentation](https://github.com/your-org/its_hub) and [API reference](http://localhost:8108/docs).
+# Or start individually:
+its-iaas-ext-proc --port 50051 &  # ext_proc gRPC router
+its-iaas --host 127.0.0.1 --port 8109 &  # IaaS service
+its-iaas --print-config | envoy -c /dev/stdin &  # Envoy proxy
+```
+
+### Using ITS Through Envoy
+
+Requests with `X-ITS-*` headers are intercepted by ext_proc and routed to IaaS:
+
+```bash
+curl -X POST http://localhost:8108/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "X-ITS-Budget: 4" \
+  -H "X-ITS-Endpoint: http://localhost:8100/v1" \
+  -d '{
+    "model": "your-model-name",
+    "messages": [{"role": "user", "content": "What is 2+2?"}]
+  }'
+```
+
+### Generating the Envoy Config
+
+The bundled Envoy config can be printed and customized:
+
+```bash
+# Print config to stdout
+its-iaas --print-config
+
+# Save to file for customization
+its-iaas --print-config > envoy_config.yaml
+```
+
+See the config comments for customization options (ports, timeouts, failure modes).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,8 @@
 | **Core** | `pip install its_hub` | Algorithms and interfaces only (2 dependencies) |
 | **LM** | `pip install its_hub[lm]` | OpenAI-compatible LM, LLMJudge, StepGeneration |
 | **IaaS** | `pip install its_hub[iaas]` | FastAPI Inference-as-a-Service server |
+| **ext_proc** | `pip install its_hub[ext_proc]` | Envoy external processor gateway (gRPC + protobuf) |
+| **envoy-iaas** | `pip install its_hub[envoy-iaas]` | Full Envoy + IaaS stack (iaas + ext_proc combined) |
 | **Experimental** | `pip install its_hub[experimental]` | Particle Filtering, Beam Search, reward-hub integration |
 | **Research** | `pip install its_hub[research]` | Benchmarks, evaluation tools |
 | **Dev** | `pip install -e ".[dev]"` | Contributing, testing |
@@ -123,6 +125,92 @@ uv run pytest tests/ --cov=its_hub
 # Code quality
 uv run ruff check its_hub/ --fix
 uv run ruff format its_hub/
+```
+
+---
+
+## Gateway Installation
+
+The gateway extras provide two deployment modes for inference-time scaling. Both require
+the `lm` extra as a base dependency.
+
+### Standalone IaaS (FastAPI)
+
+```bash
+pip install its_hub[iaas]
+```
+
+Provides the `its-iaas` CLI command to run a standalone OpenAI-compatible API server with
+ITS. No Envoy or gRPC dependencies.
+
+```python
+# Verify
+from its_hub.integration.iaas.app import app
+print("IaaS OK")
+```
+
+See [IaaS Service Guide](iaas-service.md) for configuration and usage.
+
+### Envoy ext_proc Gateway
+
+```bash
+pip install its_hub[ext_proc]
+```
+
+Provides the `envoy-grpc` CLI command for the Envoy external processor. Requires compiled
+proto files and an Envoy proxy.
+
+**Additional prerequisites**: git, make, [Envoy proxy](https://www.envoyproxy.io/docs/envoy/latest/start/install)
+
+```bash
+# Initialize submodules and compile proto files
+make setup-envoy
+
+# Verify
+python -c "from its_hub.integration.ext_proc.processor import ExternalProcessor; print('ext_proc OK')"
+```
+
+See [ext_proc Gateway Guide](ext-proc-gateway.md) for configuration and usage.
+
+### Envoy + IaaS Combined
+
+```bash
+pip install its_hub[envoy-iaas]
+```
+
+Installs both `iaas` and `ext_proc` extras for the combined deployment where Envoy routes
+`X-ITS-*` header requests to the IaaS backend via an ext_proc filter. Provides three CLI
+commands: `its-iaas`, `its-iaas-ext-proc`, and `envoy-grpc`.
+
+```bash
+make setup-envoy  # Still needed for proto files
+
+# Start the full stack
+make envoy-iaas-stack
+```
+
+See the [Envoy Integration](iaas-service.md#envoy-integration) section in the IaaS guide.
+
+### Proto Generation
+
+Both `ext_proc` and `envoy-iaas` require compiled Envoy proto files. The `make setup-envoy`
+target handles this automatically:
+
+1. Initializes git submodules (`envoy-data-plane-api`, `xds`, `protoc-gen-validate`)
+2. Compiles `.proto` files to Python using `grpc_tools.protoc`
+3. Outputs to `its_hub/integration/proto/`
+
+To recompile after proto changes:
+
+```bash
+make proto-clean    # Remove generated files
+make proto-compile  # Recompile
+```
+
+To restore submodules to pinned commits (after a `git pull` updates `.gitmodules`):
+
+```bash
+make upgrade-protos
 ```
 
 ---

--- a/its_hub/core/algorithms/self_consistency.py
+++ b/its_hub/core/algorithms/self_consistency.py
@@ -342,6 +342,15 @@ class SelfConsistency(AbstractScalingAlgorithm):
             raise ValueError(f"Unknown tool_vote type: {self.tool_vote}")
 
 
+def validate_regex_patterns(patterns: list[str]) -> None:
+    """Validate regex patterns before passing to create_regex_projection_function."""
+    for p in patterns:
+        try:
+            re.compile(p)
+        except re.error as e:
+            raise ValueError(f"Invalid regex pattern {p!r}: {e}") from e
+
+
 def create_regex_projection_function(
     patterns: str | list[str],
 ) -> Callable[[str], tuple]:

--- a/its_hub/core/gateway.py
+++ b/its_hub/core/gateway.py
@@ -101,7 +101,7 @@ class ITSGateway(AbstractGateway):
                 validate_regex_patterns(regex_patterns)
                 projection_func = create_regex_projection_function(regex_patterns)
             algorithm = SelfConsistency(
-                projection_func,
+                consistency_space_projection_func=projection_func,
                 tool_vote=tool_vote,
                 exclude_args=exclude_tool_args,
                 orchestrator=self._orchestrator,

--- a/its_hub/core/gateway.py
+++ b/its_hub/core/gateway.py
@@ -104,6 +104,7 @@ class ITSGateway(AbstractGateway):
                 projection_func,
                 tool_vote=tool_vote,
                 exclude_args=exclude_tool_args,
+                orchestrator=self._orchestrator,
             )
 
         self._algorithm = algorithm

--- a/its_hub/core/gateway.py
+++ b/its_hub/core/gateway.py
@@ -19,11 +19,17 @@ from its_hub.api import (
     GenerationUsage,
     ITSRequestConfig,
 )
-from its_hub.core.algorithms.self_consistency import SelfConsistency
+from its_hub.core.algorithms.self_consistency import (
+    SelfConsistency,
+    create_regex_projection_function,
+    validate_regex_patterns,
+)
 from its_hub.core.lms.openai_lm import OpenAICompatibleLanguageModel
 from its_hub.core.orchestrator import LMOrchestrator
 
 logger = logging.getLogger(__name__)
+
+SUPPORTED_ALGORITHMS = frozenset({"self-consistency"})
 
 
 class ITSGateway(AbstractGateway):
@@ -72,6 +78,37 @@ class ITSGateway(AbstractGateway):
             tuple[str, str, str], OpenAICompatibleLanguageModel
         ] = OrderedDict()
         logger.info("ITSGateway initialized with algorithm=%s", self._algorithm_name)
+
+    def configure(
+        self,
+        alg: str,
+        regex_patterns: list[str] | None = None,
+        tool_vote: str | None = None,
+        exclude_tool_args: list[str] | None = None,
+    ) -> None:
+        """Configure the gateway's scaling algorithm at runtime.
+
+        Raises ValueError for unsupported algorithms or invalid options.
+        """
+        if alg not in SUPPORTED_ALGORITHMS:
+            raise ValueError(
+                f"Algorithm {alg!r} not supported. Choose from: {SUPPORTED_ALGORITHMS}"
+            )
+
+        if alg == "self-consistency":
+            projection_func = None
+            if regex_patterns:
+                validate_regex_patterns(regex_patterns)
+                projection_func = create_regex_projection_function(regex_patterns)
+            algorithm = SelfConsistency(
+                projection_func,
+                tool_vote=tool_vote,
+                exclude_args=exclude_tool_args,
+            )
+
+        self._algorithm = algorithm
+        self._algorithm_name = type(algorithm).__name__
+        logger.info("ITSGateway reconfigured with algorithm=%s", self._algorithm_name)
 
     @staticmethod
     def _hash_api_key(api_key: str | None) -> str:
@@ -142,6 +179,8 @@ class ITSGateway(AbstractGateway):
         request_id = kwargs.get("request_id")
         log_prefix = f"[{request_id}] " if request_id else ""
 
+        if not config.api_endpoint:
+            raise ValueError("api_endpoint must be specified in ITSRequestConfig")
         if not config.model:
             raise ValueError(
                 "Model must be specified in ITSRequestConfig before running"

--- a/its_hub/integration/ext_proc/processor.py
+++ b/its_hub/integration/ext_proc/processor.py
@@ -12,7 +12,7 @@ import time
 import uuid
 
 import grpc
-import its_hub.integration.ext_proc.proto  # noqa: F401
+import its_hub.integration.proto  # noqa: F401
 from envoy.config.core.v3 import base_pb2
 from envoy.service.ext_proc.v3 import external_processor_pb2 as ext_proc_pb2
 from envoy.service.ext_proc.v3 import external_processor_pb2_grpc as ext_proc_grpc

--- a/its_hub/integration/iaas/app.py
+++ b/its_hub/integration/iaas/app.py
@@ -265,7 +265,8 @@ async def _stream_chat_completions(
                 return_response_only=True,
             )
         except Exception as e:
-            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+            logger.error("Streaming chat completion failed: %s", e, exc_info=True)
+            yield f"data: {json.dumps({'error': 'Generation failed. Check server logs for details.'})}\n\n"
             yield "data: [DONE]\n\n"
             return
 

--- a/its_hub/integration/iaas/app.py
+++ b/its_hub/integration/iaas/app.py
@@ -1,0 +1,351 @@
+"""Inference-as-a-Service (IaaS) FastAPI application.
+
+Provides an OpenAI-compatible API server for inference-time scaling algorithms.
+Delegates to ITSGateway for LM lifecycle management and algorithm dispatch,
+following the same adapter pattern as the Envoy ext_proc integration.
+"""
+
+import json
+import logging
+import time
+import uuid
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+from fastapi import FastAPI, Header, HTTPException, status
+from fastapi.responses import StreamingResponse
+
+from its_hub.api.types import ITSRequestConfig
+from its_hub.core.algorithms.self_consistency import SelfConsistency
+from its_hub.core.gateway import ITSGateway
+from its_hub.integration.iaas.models import (
+    ChatCompletionChoice,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+    ConfigRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _ServiceConfig:
+    """Mutable service-level defaults set via /configure."""
+
+    endpoint: str = ""
+    model: str = ""
+    api_key: str | None = None
+    budget: int = 4
+    temperature: float | None = None
+
+
+class _ServiceState:
+    """Encapsulates all mutable service state (replaces module-level globals)."""
+
+    def __init__(self):
+        self.gateway: ITSGateway = ITSGateway(algorithm=SelfConsistency())
+        self.config = _ServiceConfig()
+
+    def reset(self):
+        self.gateway = ITSGateway(algorithm=SelfConsistency())
+        self.config = _ServiceConfig()
+
+
+_state = _ServiceState()
+
+
+@asynccontextmanager
+async def _lifespan(application: FastAPI):
+    yield
+    await _state.gateway.ashutdown()
+
+
+app = FastAPI(
+    title="its_hub Inference-as-a-Service",
+    description="OpenAI-compatible API for inference-time scaling algorithms",
+    version="0.1.0-alpha",
+    lifespan=_lifespan,
+)
+
+
+def _build_its_config(
+    request: ChatCompletionRequest,
+    its_budget: int | None = None,
+    its_endpoint: str | None = None,
+    its_api_key: str | None = None,
+) -> ITSRequestConfig:
+    """Build ITSRequestConfig merging headers, body, and service defaults.
+
+    Priority: header > body > service default.
+    """
+    if its_budget is not None:
+        budget = its_budget
+    elif request.budget is not None:
+        budget = request.budget
+    else:
+        budget = _state.config.budget
+
+    api_endpoint = its_endpoint or _state.config.endpoint
+    api_key = its_api_key if its_api_key is not None else _state.config.api_key
+
+    return ITSRequestConfig(
+        budget=budget,
+        api_endpoint=api_endpoint,
+        model=request.model,
+        api_key=api_key,
+    )
+
+
+@app.post("/configure", status_code=status.HTTP_200_OK)
+async def config_service(request: ConfigRequest) -> dict[str, str]:
+    """Configure the IaaS service with language model and scaling algorithm."""
+    try:
+        _state.gateway.configure(
+            alg=request.alg,
+            regex_patterns=request.regex_patterns,
+            tool_vote=request.tool_vote,
+            exclude_tool_args=request.exclude_tool_args,
+        )
+        _state.config.endpoint = request.endpoint
+        _state.config.model = request.model
+        _state.config.api_key = request.api_key
+        if request.budget is not None:
+            _state.config.budget = request.budget
+        if request.temperature is not None:
+            _state.config.temperature = request.temperature
+
+        logger.info(
+            "Configured IaaS: model=%s, alg=%s, budget=%s",
+            request.model,
+            request.alg,
+            _state.config.budget,
+        )
+        return {
+            "status": "success",
+            "message": f"Initialized {request.model} with {request.alg} algorithm",
+        }
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except Exception as e:
+        logger.error("Configuration failed: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Configuration failed. Check server logs for details.",
+        ) from e
+
+
+@app.get("/v1/models")
+async def list_models() -> dict[str, list[dict[str, str]]]:
+    """List available models (OpenAI-compatible endpoint)."""
+    if _state.config.model:
+        return {
+            "data": [
+                {
+                    "id": _state.config.model,
+                    "object": "model",
+                    "owned_by": "its_hub",
+                }
+            ]
+        }
+    return {"data": []}
+
+
+@app.post("/v1/chat/completions", response_model=ChatCompletionResponse)
+async def chat_completions(
+    request: ChatCompletionRequest,
+    x_its_budget: int | None = Header(None),
+    x_its_endpoint: str | None = Header(None),
+    x_its_api_key: str | None = Header(None),
+) -> ChatCompletionResponse | StreamingResponse:
+    """Generate chat completion with inference-time scaling."""
+    if request.stream:
+        return await _stream_chat_completions(
+            request, x_its_budget, x_its_endpoint, x_its_api_key
+        )
+
+    try:
+        its_config = _build_its_config(
+            request, x_its_budget, x_its_endpoint, x_its_api_key
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+
+    try:
+        messages_dicts = [msg.to_dict() for msg in request.messages]
+
+        result = await _state.gateway.arun_chat_completion(
+            config=its_config,
+            messages=messages_dicts,
+            tools=request.tools,
+            tool_choice=request.tool_choice,
+            return_response_only=request.return_response_only,
+        )
+
+        if request.return_response_only:
+            response_message = result["message"]
+        else:
+            response_message = result["the_one"]
+
+        usage = result.get("usage", {})
+
+        metadata = None
+        if not request.return_response_only:
+            metadata = {
+                "algorithm": "self-consistency",
+                "all_responses": result.get("responses"),
+                "response_counts": result.get("response_counts"),
+                "selected_index": result.get("selected_index"),
+            }
+
+        return ChatCompletionResponse(
+            id=f"chatcmpl-its-{uuid.uuid4()}",
+            created=int(time.time()),
+            model=request.model,
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=response_message,
+                    finish_reason="stop",
+                )
+            ],
+            usage=ChatCompletionUsage(
+                prompt_tokens=usage.get("prompt_tokens", 0),
+                completion_tokens=usage.get("completion_tokens", 0),
+                total_tokens=usage.get("total_tokens", 0),
+            ),
+            metadata=metadata,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except Exception as e:
+        logger.error("Chat completion failed: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Generation failed. Check server logs for details.",
+        ) from e
+
+
+async def _stream_chat_completions(
+    request: ChatCompletionRequest,
+    its_budget: int | None = None,
+    its_endpoint: str | None = None,
+    its_api_key: str | None = None,
+) -> StreamingResponse:
+    """Handle streaming requests by buffering ITS result then sending as SSE chunks."""
+
+    async def _generate():
+        response_id = f"chatcmpl-its-{uuid.uuid4()}"
+        created = int(time.time())
+
+        its_config = _build_its_config(request, its_budget, its_endpoint, its_api_key)
+
+        if not its_config.api_endpoint:
+            yield f"data: {json.dumps({'error': 'Service not configured'})}\n\n"
+            yield "data: [DONE]\n\n"
+            return
+
+        messages_dicts = [msg.to_dict() for msg in request.messages]
+
+        try:
+            result = await _state.gateway.arun_chat_completion(
+                config=its_config,
+                messages=messages_dicts,
+                tools=request.tools,
+                tool_choice=request.tool_choice,
+                return_response_only=True,
+            )
+        except Exception as e:
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+            yield "data: [DONE]\n\n"
+            return
+
+        response_message = result["message"]
+        content = response_message.get("content")
+        tool_calls = response_message.get("tool_calls")
+
+        if tool_calls:
+            for i, tc in enumerate(tool_calls):
+                chunk = {
+                    "id": response_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": request.model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": i,
+                                        "id": tc.get(
+                                            "id", f"call_{uuid.uuid4().hex[:24]}"
+                                        ),
+                                        "type": "function",
+                                        "function": {
+                                            "name": tc.get("function", {}).get(
+                                                "name", ""
+                                            ),
+                                            "arguments": tc.get("function", {}).get(
+                                                "arguments", "{}"
+                                            ),
+                                        },
+                                    }
+                                ],
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+            done_chunk = {
+                "id": response_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": request.model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            }
+            yield f"data: {json.dumps(done_chunk)}\n\n"
+
+        elif content:
+            content_chunk = {
+                "id": response_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": request.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": content},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            yield f"data: {json.dumps(content_chunk)}\n\n"
+
+            done_chunk = {
+                "id": response_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": request.model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            }
+            yield f"data: {json.dumps(done_chunk)}\n\n"
+
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )

--- a/its_hub/integration/iaas/app_server.py
+++ b/its_hub/integration/iaas/app_server.py
@@ -1,0 +1,111 @@
+"""HTTP server for the IaaS FastAPI application."""
+
+import argparse
+import logging
+import sys
+from importlib import resources
+
+try:
+    import uvicorn
+except ImportError:
+    uvicorn = None  # type: ignore[assignment]
+
+from its_hub.integration.iaas.app import app
+
+logger = logging.getLogger(__name__)
+
+
+def _configure_logging(level_name: str) -> None:
+    numeric_level = getattr(logging, level_name.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f"Invalid log level: {level_name}")
+
+    logging.getLogger().setLevel(numeric_level)
+    for logger_name in (
+        "its_hub.integration.iaas.app",
+        "its_hub.integration.iaas.app_server",
+        "its_hub.core.gateway",
+        "its_hub.core.algorithms.self_consistency",
+    ):
+        logging.getLogger(logger_name).setLevel(numeric_level)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="ITS Inference-as-a-Service")
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind the server to (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8109,
+        help="Port to bind the server (default: 8109)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (e.g., DEBUG, INFO, WARNING)",
+    )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Run in development mode with auto-reload",
+    )
+    parser.add_argument(
+        "--print-config",
+        action="store_true",
+        help="Print the sample Envoy config to stdout and exit",
+    )
+    return parser.parse_args()
+
+
+def _print_config() -> None:
+    """Print the bundled sample Envoy config to stdout."""
+    config = resources.files("its_hub.integration.iaas").joinpath("envoy_config.yaml")
+    sys.stdout.write(config.read_text())
+
+
+def serve(host: str = "127.0.0.1", port: int = 8109, dev: bool = False):
+    """Start the uvicorn server."""
+    uvicorn_config = {
+        "host": host,
+        "port": port,
+        "log_level": "info" if not dev else "debug",
+    }
+
+    if dev:
+        logger.info("Running in development mode with auto-reload")
+        uvicorn.run("its_hub.integration.iaas.app:app", reload=True, **uvicorn_config)
+    else:
+        uvicorn.run(app, **uvicorn_config)
+
+
+def main():
+    """Entry point for the IaaS HTTP service."""
+    args = _parse_args()
+
+    if args.print_config:
+        _print_config()
+        return
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    _configure_logging(args.log_level)
+
+    if uvicorn is None:
+        print(
+            "Error: iaas dependencies not installed.\n"
+            "Install with: pip install 'its_hub[iaas]'"
+        )
+        raise SystemExit(1)
+
+    logger.info("Starting IaaS on %s:%d", args.host, args.port)
+    serve(host=args.host, port=args.port, dev=args.dev)
+
+
+if __name__ == "__main__":
+    main()

--- a/its_hub/integration/iaas/app_server.py
+++ b/its_hub/integration/iaas/app_server.py
@@ -10,8 +10,6 @@ try:
 except ImportError:
     uvicorn = None  # type: ignore[assignment]
 
-from its_hub.integration.iaas.app import app
-
 logger = logging.getLogger(__name__)
 
 
@@ -69,6 +67,8 @@ def _print_config() -> None:
 
 def serve(host: str = "127.0.0.1", port: int = 8109, dev: bool = False):
     """Start the uvicorn server."""
+    from its_hub.integration.iaas.app import app
+
     uvicorn_config = {
         "host": host,
         "port": port,

--- a/its_hub/integration/iaas/envoy_config.yaml
+++ b/its_hub/integration/iaas/envoy_config.yaml
@@ -7,16 +7,13 @@
 # X-ITS-Route header, and calls clear_route_cache. No body buffering,
 # no algorithm execution. The IaaS service does the actual ITS work.
 #
-# Two ways to reach IaaS:
-# 1. Transparent — send X-ITS-Budget header with normal OpenAI requests;
-#    the ext_proc router redirects to IaaS automatically.
-# 2. Explicit — target the /its/ prefix to reach IaaS directly
-#    (has its own /configure and /v1/chat/completions endpoints).
+# How requests reach IaaS:
+#   Send X-ITS-Budget header with normal OpenAI requests;
+#   the ext_proc router redirects to IaaS automatically.
 #
 # Architecture:
 #   Client -> Envoy (port 8108)
 #     ├── X-ITS-Budget present -> ext_proc sets X-ITS-Route -> IaaS (port 8109)
-#     ├── /its/*  ->  IaaS FastAPI (port 8109)     [explicit, prefix stripped]
 #     └── /* (no ITS headers)  ->  LLM Backend (port 8100)
 #
 # Usage:
@@ -24,7 +21,7 @@
 #   its-iaas --print-config > envoy_config.yaml
 #
 #   # Start all services
-#   its-iaas --router --port 50051 &  # Lightweight ext_proc router
+#   its-iaas-ext-proc --port 50051 &  # Lightweight ext_proc router
 #   its-iaas --port 8109 &            # IaaS FastAPI service
 #   envoy -c envoy_config.yaml        # Envoy proxy
 #
@@ -131,6 +128,7 @@ static_resources:
                 - x-its-budget
                 - x-its-endpoint
                 - x-its-api-key
+                - x-its-route
                 route:
                   cluster: llm_upstream
                   timeout: 300s  # **CUSTOMIZE**: Timeout for upstream LLM requests
@@ -140,7 +138,7 @@ static_resources:
   # ----------------------------------------------------------------------------
   clusters:
   # Lightweight ext_proc Router (routing decisions only, no algorithm execution)
-  # Started via: its-iaas --router --port 50051
+  # Started via: its-iaas-ext-proc --port 50051
   - name: ext_proc_cluster
     connect_timeout: 5s
     type: LOGICAL_DNS
@@ -168,7 +166,7 @@ static_resources:
 
   # IaaS FastAPI Service (ITS algorithm execution, /configure and OpenAI-compatible API)
   # Started via: its-iaas --port 8109
-  # Receives requests from both direct /its/ access and ext_proc-routed traffic
+  # Receives ext_proc-routed traffic when X-ITS-Budget is present
   - name: iaas_upstream
     connect_timeout: 5s
     type: LOGICAL_DNS

--- a/its_hub/integration/iaas/envoy_config.yaml
+++ b/its_hub/integration/iaas/envoy_config.yaml
@@ -1,0 +1,220 @@
+# Envoy Configuration for ITS Gateway
+#
+# This configuration sets up Envoy with a lightweight ext_proc router that
+# directs ITS requests to the IaaS backend service (Option 2 architecture).
+#
+# The ext_proc is a pure router — it checks for X-ITS-Budget, sets an
+# X-ITS-Route header, and calls clear_route_cache. No body buffering,
+# no algorithm execution. The IaaS service does the actual ITS work.
+#
+# Two ways to reach IaaS:
+# 1. Transparent — send X-ITS-Budget header with normal OpenAI requests;
+#    the ext_proc router redirects to IaaS automatically.
+# 2. Explicit — target the /its/ prefix to reach IaaS directly
+#    (has its own /configure and /v1/chat/completions endpoints).
+#
+# Architecture:
+#   Client -> Envoy (port 8108)
+#     ├── X-ITS-Budget present -> ext_proc sets X-ITS-Route -> IaaS (port 8109)
+#     ├── /its/*  ->  IaaS FastAPI (port 8109)     [explicit, prefix stripped]
+#     └── /* (no ITS headers)  ->  LLM Backend (port 8100)
+#
+# Usage:
+#   # Get this config
+#   its-iaas --print-config > envoy_config.yaml
+#
+#   # Start all services
+#   its-iaas --router --port 50051 &  # Lightweight ext_proc router
+#   its-iaas --port 8109 &            # IaaS FastAPI service
+#   envoy -c envoy_config.yaml        # Envoy proxy
+#
+# Customization Guide:
+# ====================
+# 1. Change Envoy listening port: Update port_value under listeners[0].address (default: 8108)
+# 2. Change ext_proc gRPC port: Update port_value in ext_proc_cluster endpoints (default: 50051)
+# 3. Change IaaS HTTP port: Update port_value in iaas_upstream endpoints (default: 8109)
+# 4. Change upstream LLM endpoint: Update address/port in llm_upstream cluster (default: localhost:8100)
+# 5. Change failure behavior: Set failure_mode_allow to false to reject requests when ext_proc is down
+
+# ==============================================================================
+# Admin Interface - Monitoring and Debugging
+# ==============================================================================
+# Access at http://localhost:9901 for stats, health checks, and configuration
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address:
+      protocol: TCP
+      address: 127.0.0.1
+      port_value: 9901
+
+# ==============================================================================
+# Static Resources Configuration
+# ==============================================================================
+static_resources:
+  # ------------------------------------------------------------------------------
+  # LISTENER - Client-facing HTTP proxy
+  # ------------------------------------------------------------------------------
+  listeners:
+  - name: listener_0
+    address:
+      socket_address:
+        protocol: TCP
+        address: 127.0.0.1  # Localhost only (use 0.0.0.0 to listen on all interfaces)
+        port_value: 8108     # **CUSTOMIZE**: Client request port (your API gateway endpoint)
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          http_filters:
+          # ----------------------------------------------------------------------
+          # External Processor Filter - ITS Algorithm Execution (transparent mode)
+          # ----------------------------------------------------------------------
+          # This filter sends request headers to the lightweight router ext_proc
+          # which checks for X-ITS-Budget. If present, it sets X-ITS-Route and
+          # calls clear_route_cache so Envoy re-routes to the IaaS service.
+          # No body buffering — the router completes in microseconds.
+          - name: envoy.filters.http.ext_proc
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+              grpc_service:
+                envoy_grpc:
+                  cluster_name: ext_proc_cluster
+                timeout: 5s    # Router is lightweight — fast timeout is fine
+              # **IMPORTANT**: Fail-safe mode - allows requests through if ext_proc is down
+              # Set to false to reject requests when ext_proc unavailable
+              failure_mode_allow: true
+              message_timeout: 5s
+              # Header-only mode — the router never inspects the body
+              processing_mode:
+                request_header_mode: SEND      # Send headers to ext_proc (needed to check X-ITS-Budget)
+          # ----------------------------------------------------------------------
+          # Router Filter - Routes to Upstream Services
+          # ----------------------------------------------------------------------
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          # Route Configuration
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              # ----------------------------------------------------------------
+              # Route 1: ext_proc routed ITS -> IaaS service
+              # ----------------------------------------------------------------
+              # When the router ext_proc detects X-ITS-Budget, it sets
+              # X-ITS-Route: its-service and calls clear_route_cache. Envoy
+              # re-evaluates routes and matches this header-based route.
+              # ITS headers are preserved — IaaS reads them for per-request config.
+              - match:
+                  prefix: "/"
+                  headers:
+                  - name: X-ITS-Route
+                    exact_match: "its-service"
+                route:
+                  cluster: iaas_upstream
+                  timeout: 300s  # **CUSTOMIZE**: Timeout for ITS processing
+              # ----------------------------------------------------------------
+              # Route 2: All other traffic -> LLM upstream (pass-through)
+              # ----------------------------------------------------------------
+              - match:
+                  prefix: "/"
+                request_headers_to_remove:
+                - x-its-budget
+                - x-its-endpoint
+                - x-its-api-key
+                route:
+                  cluster: llm_upstream
+                  timeout: 300s  # **CUSTOMIZE**: Timeout for upstream LLM requests
+
+  # ----------------------------------------------------------------------------
+  # CLUSTERS - Backend Services
+  # ----------------------------------------------------------------------------
+  clusters:
+  # Lightweight ext_proc Router (routing decisions only, no algorithm execution)
+  # Started via: its-iaas --router --port 50051
+  - name: ext_proc_cluster
+    connect_timeout: 5s
+    type: LOGICAL_DNS
+    # **REQUIRED**: HTTP/2 for gRPC communication
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+    load_assignment:
+      cluster_name: ext_proc_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 50051  # **CUSTOMIZE**: ext_proc gRPC port
+    health_checks:
+    - timeout: 1s
+      interval: 10s
+      unhealthy_threshold: 2
+      healthy_threshold: 2
+      grpc_health_check: {}
+
+  # IaaS FastAPI Service (ITS algorithm execution, /configure and OpenAI-compatible API)
+  # Started via: its-iaas --port 8109
+  # Receives requests from both direct /its/ access and ext_proc-routed traffic
+  - name: iaas_upstream
+    connect_timeout: 5s
+    type: LOGICAL_DNS
+    dns_lookup_family: V4_ONLY
+    load_assignment:
+      cluster_name: iaas_upstream
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8109  # **CUSTOMIZE**: IaaS service port
+    health_checks:
+    - timeout: 1s
+      interval: 10s
+      unhealthy_threshold: 2
+      healthy_threshold: 2
+      http_health_check:
+        path: "/docs"
+        expected_statuses:
+        - start: 200
+          end: 299
+
+  # Upstream LLM Service (fallback when ITS headers not present)
+  # **CUSTOMIZE THIS**: Point to your actual LLM endpoint (vLLM, OpenAI-compatible, etc.)
+  - name: llm_upstream
+    connect_timeout: 5s
+    type: LOGICAL_DNS
+    dns_lookup_family: V4_ONLY
+    load_assignment:
+      cluster_name: llm_upstream
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 8100  # **CUSTOMIZE**: Your LLM service port
+    health_checks:
+    - timeout: 1s
+      interval: 30s
+      unhealthy_threshold: 3
+      healthy_threshold: 2
+      http_health_check:
+        path: "/health"
+        expected_statuses:
+        - start: 200
+          end: 299

--- a/its_hub/integration/iaas/ext_processor.py
+++ b/its_hub/integration/iaas/ext_processor.py
@@ -12,7 +12,7 @@ import logging
 import uuid
 
 import grpc
-import its_hub.integration.ext_proc.proto  # noqa: F401
+import its_hub.integration.proto  # noqa: F401
 from envoy.config.core.v3 import base_pb2
 from envoy.service.ext_proc.v3 import external_processor_pb2 as ext_proc_pb2
 from envoy.service.ext_proc.v3 import external_processor_pb2_grpc as ext_proc_grpc

--- a/its_hub/integration/iaas/ext_processor.py
+++ b/its_hub/integration/iaas/ext_processor.py
@@ -1,0 +1,132 @@
+"""Lightweight ext_proc for IaaS.
+
+A minimal gRPC External Processor that acts purely as a routing decision maker.
+When X-ITS-Budget is present, it sets an X-ITS-Route header and calls
+clear_route_cache so Envoy re-routes the request to the IaaS service.
+
+No body buffering, no algorithm execution — completes in microseconds.
+"""
+
+# ruff: noqa: I001
+import logging
+import uuid
+
+import grpc
+import its_hub.integration.ext_proc.proto  # noqa: F401
+from envoy.config.core.v3 import base_pb2
+from envoy.service.ext_proc.v3 import external_processor_pb2 as ext_proc_pb2
+from envoy.service.ext_proc.v3 import external_processor_pb2_grpc as ext_proc_grpc
+
+_ITS_ROUTE_HEADER = "X-ITS-Route"
+_ITS_ROUTE_VALUE = "its-service"
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalProcessorService(ext_proc_grpc.ExternalProcessorServicer):
+    """Lightweight ext_proc that routes ITS requests to the IaaS service.
+
+    Checks for X-ITS-Budget in request headers. If present, injects an
+    X-ITS-Route header and sets clear_route_cache so Envoy re-evaluates
+    the route table and forwards the request to the IaaS upstream cluster.
+
+    ITS headers are preserved on the IaaS path so the service can read
+    per-request config. Stray ITS headers on the pass-through path are
+    stripped so they never leak to the upstream LLM.
+    """
+
+    async def Process(  # noqa: N802 — gRPC servicer interface requires this name
+        self,
+        request_iterator,
+        context: grpc.ServicerContext,
+    ):
+        peer = context.peer()
+        request_id = f"{peer}-{uuid.uuid4().hex[:8]}"
+
+        try:
+            async for request in request_iterator:
+                if request.HasField("request_headers"):
+                    has_budget = False
+                    its_keys = []
+
+                    for header in request.request_headers.headers.headers:
+                        key = header.key.lower()
+                        if key.startswith("x-its-"):
+                            its_keys.append(key)
+                            if key == "x-its-budget":
+                                has_budget = True
+
+                    if has_budget:
+                        logger.info(
+                            "[%s] ITS budget detected, routing to IaaS",
+                            request_id,
+                        )
+                        yield _ROUTE_TO_IAAS
+                    else:
+                        yield self._pass_through(its_keys)
+
+                elif request.HasField("response_headers"):
+                    yield ext_proc_pb2.ProcessingResponse(
+                        response_headers=ext_proc_pb2.HeadersResponse(
+                            response=ext_proc_pb2.CommonResponse(
+                                status=ext_proc_pb2.CommonResponse.CONTINUE
+                            )
+                        )
+                    )
+
+                elif request.HasField("response_body"):
+                    yield ext_proc_pb2.ProcessingResponse(
+                        response_body=ext_proc_pb2.BodyResponse(
+                            response=ext_proc_pb2.CommonResponse(
+                                status=ext_proc_pb2.CommonResponse.CONTINUE
+                            )
+                        )
+                    )
+
+        except Exception as e:
+            logger.error("[%s] Stream error: %s", request_id, e, exc_info=True)
+            await context.abort(grpc.StatusCode.INTERNAL, str(e))
+
+    @staticmethod
+    def _pass_through(its_keys: list[str]) -> ext_proc_pb2.ProcessingResponse:
+        """Pass through without routing. Strips any stray X-ITS-* headers."""
+        if not its_keys:
+            return _PASS_THROUGH
+        return ext_proc_pb2.ProcessingResponse(
+            request_headers=ext_proc_pb2.HeadersResponse(
+                response=ext_proc_pb2.CommonResponse(
+                    status=ext_proc_pb2.CommonResponse.CONTINUE,
+                    header_mutation=ext_proc_pb2.HeaderMutation(
+                        remove_headers=its_keys,
+                    ),
+                )
+            )
+        )
+
+
+_ROUTE_TO_IAAS = ext_proc_pb2.ProcessingResponse(
+    request_headers=ext_proc_pb2.HeadersResponse(
+        response=ext_proc_pb2.CommonResponse(
+            status=ext_proc_pb2.CommonResponse.CONTINUE,
+            header_mutation=ext_proc_pb2.HeaderMutation(
+                set_headers=[
+                    base_pb2.HeaderValueOption(
+                        header=base_pb2.HeaderValue(
+                            key=_ITS_ROUTE_HEADER,
+                            raw_value=_ITS_ROUTE_VALUE.encode(),
+                        )
+                    ),
+                ],
+            ),
+            clear_route_cache=True,
+        )
+    )
+)
+
+_PASS_THROUGH = ext_proc_pb2.ProcessingResponse(
+    request_headers=ext_proc_pb2.HeadersResponse(
+        response=ext_proc_pb2.CommonResponse(
+            status=ext_proc_pb2.CommonResponse.CONTINUE
+        )
+    )
+)

--- a/its_hub/integration/iaas/ext_processor.py
+++ b/its_hub/integration/iaas/ext_processor.py
@@ -114,7 +114,8 @@ _ROUTE_TO_IAAS = ext_proc_pb2.ProcessingResponse(
                         header=base_pb2.HeaderValue(
                             key=_ITS_ROUTE_HEADER,
                             raw_value=_ITS_ROUTE_VALUE.encode(),
-                        )
+                        ),
+                        append_action=base_pb2.HeaderValueOption.OVERWRITE_IF_EXISTS_OR_ADD,
                     ),
                 ],
             ),

--- a/its_hub/integration/iaas/grpc_server.py
+++ b/its_hub/integration/iaas/grpc_server.py
@@ -12,11 +12,6 @@ except ImportError:
     health = None  # type: ignore[assignment]
     health_pb2_grpc = None  # type: ignore[assignment]
 
-from its_hub.integration.iaas.ext_processor import (
-    ExternalProcessorService,
-    ext_proc_grpc,
-)
-
 logger = logging.getLogger(__name__)
 
 
@@ -51,6 +46,11 @@ def _parse_args() -> argparse.Namespace:
 
 async def serve(port: int = 50051):
     """Start the gRPC ext_proc server."""
+    from its_hub.integration.iaas.ext_processor import (
+        ExternalProcessorService,
+        ext_proc_grpc,
+    )
+
     server = grpc.aio.server()
     ext_proc_grpc.add_ExternalProcessorServicer_to_server(
         ExternalProcessorService(), server

--- a/its_hub/integration/iaas/grpc_server.py
+++ b/its_hub/integration/iaas/grpc_server.py
@@ -1,0 +1,96 @@
+"""gRPC server for the IaaS ext_proc."""
+
+import argparse
+import asyncio
+import logging
+
+try:
+    import grpc
+    from grpc_health.v1 import health, health_pb2_grpc
+except ImportError:
+    grpc = None  # type: ignore[assignment]
+    health = None  # type: ignore[assignment]
+    health_pb2_grpc = None  # type: ignore[assignment]
+
+from its_hub.integration.iaas.ext_processor import (
+    ExternalProcessorService,
+    ext_proc_grpc,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _configure_logging(level_name: str) -> None:
+    numeric_level = getattr(logging, level_name.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f"Invalid log level: {level_name}")
+
+    logging.getLogger().setLevel(numeric_level)
+    for logger_name in (
+        "its_hub.integration.iaas.ext_processor",
+        "its_hub.integration.iaas.grpc_server",
+    ):
+        logging.getLogger(logger_name).setLevel(numeric_level)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="ITS IaaS ext_proc")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=50051,
+        help="Port to bind the gRPC server (default: 50051)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (e.g., DEBUG, INFO, WARNING)",
+    )
+    return parser.parse_args()
+
+
+async def serve(port: int = 50051):
+    """Start the gRPC ext_proc server."""
+    server = grpc.aio.server()
+    ext_proc_grpc.add_ExternalProcessorServicer_to_server(
+        ExternalProcessorService(), server
+    )
+
+    health_servicer = health.aio.HealthServicer()
+    health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
+
+    server.add_insecure_port(f"[::]:{port}")
+
+    logger.info("Starting IaaS ext_proc on port %d", port)
+    await server.start()
+    logger.info("IaaS ext_proc ready — routing X-ITS-Budget requests to IaaS")
+
+    try:
+        await server.wait_for_termination()
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        logger.info("ext_proc shutting down")
+        await server.stop(grace=5)
+
+
+def main():
+    """Entry point for the IaaS ext_proc gRPC service."""
+    args = _parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    _configure_logging(args.log_level)
+
+    if grpc is None:
+        print(
+            "Error: ext_proc dependencies not installed.\n"
+            "Install with: pip install 'its_hub[ext_proc]'"
+        )
+        raise SystemExit(1)
+
+    asyncio.run(serve(port=args.port))
+
+
+if __name__ == "__main__":
+    main()

--- a/its_hub/integration/iaas/models.py
+++ b/its_hub/integration/iaas/models.py
@@ -1,0 +1,116 @@
+"""Pydantic request/response models for the IaaS API."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from its_hub.api.types import ChatMessage
+from its_hub.core.gateway import SUPPORTED_ALGORITHMS
+
+
+class ConfigRequest(BaseModel):
+    """Configuration request for setting up the IaaS service."""
+
+    provider: str = Field("openai", description="LM provider: 'openai'")
+    endpoint: str = Field(..., description="Language model endpoint URL")
+    api_key: str | None = Field(None, description="API key for the language model")
+    model: str = Field(..., description="Model name identifier")
+    alg: str = Field(..., description="Scaling algorithm to use")
+    extra_args: dict[str, Any] | None = Field(
+        None, description="Additional provider-specific arguments"
+    )
+    regex_patterns: list[str] | None = Field(
+        None, description="Regex patterns for self-consistency projection function"
+    )
+    budget: int | None = Field(
+        None,
+        ge=1,
+        le=1000,
+        description="Default budget for requests that don't specify one",
+    )
+    temperature: float | None = Field(
+        None,
+        ge=0.0,
+        le=2.0,
+        description="Default sampling temperature",
+    )
+    tool_vote: str | None = Field(
+        None,
+        description="Tool voting strategy: 'tool_name', 'tool_args', 'tool_hierarchical'",
+    )
+    exclude_tool_args: list[str] | None = Field(
+        None,
+        description="Tool argument names to exclude from voting",
+    )
+
+    @field_validator("alg")
+    @classmethod
+    def validate_algorithm(cls, v):
+        if v not in SUPPORTED_ALGORITHMS:
+            raise ValueError(
+                f"Algorithm '{v}' not supported. Choose from: {SUPPORTED_ALGORITHMS}"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def validate_config_requirements(self):
+        if self.alg == "self-consistency" and not self.regex_patterns:
+            raise ValueError(
+                "regex_patterns are required when using self-consistency algorithm"
+            )
+        if self.provider == "openai" and not self.api_key:
+            raise ValueError("api_key is required when using openai provider")
+        return self
+
+
+class ChatCompletionRequest(BaseModel):
+    """Chat completion request with inference-time scaling support."""
+
+    model: str = Field(..., description="Model identifier")
+    messages: list[ChatMessage] = Field(..., description="Conversation messages")
+    budget: int | None = Field(
+        None, ge=1, le=1000, description="Computational budget for scaling"
+    )
+    temperature: float | None = Field(
+        None, ge=0.0, le=2.0, description="Sampling temperature"
+    )
+    max_tokens: int | None = Field(None, ge=1, description="Maximum tokens to generate")
+    stream: bool | None = Field(False, description="Stream response")
+    tools: list[dict[str, Any]] | None = Field(
+        None, description="Available tools for the model to call"
+    )
+    tool_choice: str | dict[str, Any] | None = Field(
+        None, description="Tool choice strategy"
+    )
+    return_response_only: bool = Field(
+        True, description="Return only final response or include algorithm metadata"
+    )
+
+    @field_validator("messages")
+    @classmethod
+    def validate_messages(cls, v):
+        if not v:
+            raise ValueError("At least one message is required")
+        return v
+
+
+class ChatCompletionChoice(BaseModel):
+    index: int
+    message: dict
+    finish_reason: str
+
+
+class ChatCompletionUsage(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    total_tokens: int
+
+
+class ChatCompletionResponse(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: list[ChatCompletionChoice]
+    usage: ChatCompletionUsage
+    metadata: dict[str, Any] | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
 ]
 
 [project.scripts]
-# its-iaas removed for MVP - will be added back in [iaas] extra if needed
+its-iaas = "its_hub.integration.iaas.app_server:main"
+its-iaas-ext-proc = "its_hub.integration.iaas.grpc_server:main"
 envoy-grpc = "its_hub.integration.ext_proc.server:main"
 
 [tool.setuptools_scm]
@@ -89,6 +90,11 @@ research = [
     "datasets>=2.0.0",     # For loading benchmark datasets (MATH500, AIME)
     "matplotlib>=3.5.0",   # For visualization scripts
 ]
+
+[tool.setuptools.package-data]
+"its_hub.integration.ext_proc.proto" = ["**/*.py"]
+"its_hub.integration.ext_proc" = ["envoy_config.yaml"]
+"its_hub.integration.iaas" = ["envoy_config.yaml"]
 
 [tool.setuptools]
 package-dir = {"" = "."}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ ext_proc = [
 ]
 
 dev = [
-    "its_hub[lm,iaas,ext_proc]"
+    "its_hub[lm,iaas,ext_proc]",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ iaas = [
     "click>=8.1.0",
 ]
 
+envoy-iaas = [
+    "its_hub[iaas,ext_proc]",
+]
+
 ext_proc = [
     "its_hub[lm]",
     "grpcio>=1.60.0",
@@ -68,7 +72,7 @@ ext_proc = [
 ]
 
 dev = [
-    "its_hub[lm,iaas,ext_proc]",
+    "its_hub[lm,iaas,ext_proc]"
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ research = [
 ]
 
 [tool.setuptools.package-data]
-"its_hub.integration.ext_proc.proto" = ["**/*.py"]
+"its_hub.integration.proto" = ["**/*.py"]
 "its_hub.integration.ext_proc" = ["envoy_config.yaml"]
 "its_hub.integration.iaas" = ["envoy_config.yaml"]
 
@@ -110,4 +110,9 @@ include = [
     "its_hub.core.*",
     "its_hub.integration",
     "its_hub.integration.*",
+]
+
+[tool.coverage.run]
+omit = [
+    "its_hub/integration/proto/*",
 ]

--- a/tests/test_ext_proc_processor.py
+++ b/tests/test_ext_proc_processor.py
@@ -8,7 +8,7 @@ import pytest
 
 try:
     import grpc
-    import its_hub.integration.ext_proc.proto  # noqa: F401
+    import its_hub.integration.proto  # noqa: F401
     from envoy.config.core.v3 import base_pb2
     from envoy.service.ext_proc.v3 import external_processor_pb2 as ext_proc_pb2
     from envoy.type.v3 import http_status_pb2

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -236,6 +236,19 @@ class TestConfigure:
         with pytest.raises(ValueError, match="Invalid regex pattern"):
             gw.configure(alg="self-consistency", regex_patterns=["[invalid("])
 
+    def test_configure_preserves_orchestrator(self):
+        orch = MagicMock()
+        gw = ITSGateway(algorithm=MagicMock(), orchestrator=orch)
+        with patch("its_hub.core.gateway.SelfConsistency") as sc_cls:
+            sc_cls.return_value = MagicMock()
+            type(sc_cls.return_value).__name__ = "SelfConsistency"
+            gw.configure(
+                alg="self-consistency",
+                regex_patterns=[r"\\boxed{([^}]+)}"],
+            )
+            sc_cls.assert_called_once()
+            assert sc_cls.call_args.kwargs["orchestrator"] is orch
+
     def test_configure_invalid_tool_vote(self):
         gw = ITSGateway(algorithm=MagicMock())
         with pytest.raises(ValueError, match="tool_vote must be one of"):

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from its_hub.api.types import GenerationUsage, ITSRequestConfig
-from its_hub.core.gateway import ITSGateway
+from its_hub.core.gateway import SUPPORTED_ALGORITHMS, ITSGateway
 
 
 def _make_result(usage=None):
@@ -205,3 +205,59 @@ class TestHashApiKey:
 
     def test_hash_length(self):
         assert len(ITSGateway._hash_api_key("sk-test")) == 16
+
+
+class TestConfigure:
+    def test_configure_self_consistency(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        gw.configure(
+            alg="self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+        )
+        assert gw._algorithm_name == "SelfConsistency"
+
+    def test_configure_with_tool_vote(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        gw.configure(
+            alg="self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+            tool_vote="tool_name",
+            exclude_tool_args=["timestamp"],
+        )
+        assert gw._algorithm_name == "SelfConsistency"
+
+    def test_configure_unsupported_algorithm(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        with pytest.raises(ValueError, match="not supported"):
+            gw.configure(alg="beam-search")
+
+    def test_configure_invalid_regex(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        with pytest.raises(ValueError, match="Invalid regex pattern"):
+            gw.configure(alg="self-consistency", regex_patterns=["[invalid("])
+
+    def test_configure_invalid_tool_vote(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        with pytest.raises(ValueError, match="tool_vote must be one of"):
+            gw.configure(
+                alg="self-consistency",
+                regex_patterns=[r"\\boxed{([^}]+)}"],
+                tool_vote="invalid",
+            )
+
+
+class TestSupportedAlgorithms:
+    def test_self_consistency_supported(self):
+        assert "self-consistency" in SUPPORTED_ALGORITHMS
+
+    def test_is_frozenset(self):
+        assert isinstance(SUPPORTED_ALGORITHMS, frozenset)
+
+
+class TestEndpointValidation:
+    @pytest.mark.asyncio
+    async def test_missing_endpoint_raises(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        config = _make_config(api_endpoint="")
+        with pytest.raises(ValueError, match="api_endpoint"):
+            await gw.arun_chat_completion(config, MESSAGES)

--- a/tests/test_iaas.py
+++ b/tests/test_iaas.py
@@ -529,6 +529,29 @@ class TestBudgetValidation:
         assert response.status_code == 400
         assert "budget" in response.json()["detail"].lower()
 
+    def test_over_max_budget_header_rejected(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(return_value=_mock_gateway_result())
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        response = iaas_client.post(
+            "/v1/chat/completions",
+            json=request_data,
+            headers={"X-ITS-Budget": "1001"},
+        )
+        assert response.status_code == 400
+        assert "budget" in response.json()["detail"].lower()
+
     def test_configure_rejects_invalid_budget(self, iaas_client, vllm_endpoint):
         config = {
             "endpoint": vllm_endpoint,
@@ -600,7 +623,7 @@ class TestExtProcessor:
         from envoy.config.core.v3 import base_pb2
         from envoy.service.ext_proc.v3 import external_processor_pb2 as ext_proc_pb2
 
-        from its_hub.integration.ext_proc.proto import envoy  # noqa: F401
+        from its_hub.integration.proto import envoy  # noqa: F401
 
         def _build(headers: dict[str, str]):
             header_list = [

--- a/tests/test_iaas.py
+++ b/tests/test_iaas.py
@@ -1,5 +1,6 @@
 """Tests for the Inference-as-a-Service (IaaS) integration."""
 
+import logging
 from collections import Counter
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -727,3 +728,104 @@ class TestExtProcessor:
         removed = list(headers_resp.header_mutation.remove_headers)
         assert "x-its-endpoint" in removed
         assert "x-its-api-key" in removed
+
+
+class TestAppServer:
+    """Tests for app_server.py entry point."""
+
+    def test_configure_logging(self):
+        from its_hub.integration.iaas.app_server import _configure_logging
+
+        _configure_logging("DEBUG")
+        assert (
+            logging.getLogger("its_hub.integration.iaas.app").level == logging.DEBUG
+        )
+
+    def test_configure_logging_invalid_level(self):
+        from its_hub.integration.iaas.app_server import _configure_logging
+
+        with pytest.raises(ValueError, match="Invalid log level"):
+            _configure_logging("BOGUS")
+
+    def test_parse_args_defaults(self):
+        from its_hub.integration.iaas.app_server import _parse_args
+
+        with patch("sys.argv", ["its-iaas"]):
+            args = _parse_args()
+        assert args.host == "127.0.0.1"
+        assert args.port == 8109
+        assert args.log_level == "INFO"
+        assert args.dev is False
+        assert args.print_config is False
+
+    def test_print_config(self, capsys):
+        from its_hub.integration.iaas.app_server import _print_config
+
+        _print_config()
+        output = capsys.readouterr().out
+        assert "envoy" in output.lower()
+
+    def test_serve_calls_uvicorn(self):
+        from its_hub.integration.iaas.app_server import serve
+
+        with patch("its_hub.integration.iaas.app_server.uvicorn") as mock_uvicorn:
+            serve(host="127.0.0.1", port=9999)
+            mock_uvicorn.run.assert_called_once()
+            call_kwargs = mock_uvicorn.run.call_args
+            assert call_kwargs.kwargs["host"] == "127.0.0.1"
+            assert call_kwargs.kwargs["port"] == 9999
+
+    def test_main_print_config(self, capsys):
+        from its_hub.integration.iaas.app_server import main
+
+        with patch("sys.argv", ["its-iaas", "--print-config"]):
+            main()
+        output = capsys.readouterr().out
+        assert "envoy" in output.lower()
+
+    def test_main_missing_uvicorn(self):
+        from its_hub.integration.iaas import app_server
+
+        with (
+            patch("sys.argv", ["its-iaas"]),
+            patch.object(app_server, "uvicorn", None),
+            pytest.raises(SystemExit),
+        ):
+            app_server.main()
+
+
+class TestGrpcServer:
+    """Tests for grpc_server.py entry point."""
+
+    def test_configure_logging(self):
+        from its_hub.integration.iaas.grpc_server import _configure_logging
+
+        _configure_logging("WARNING")
+        assert (
+            logging.getLogger("its_hub.integration.iaas.ext_processor").level
+            == logging.WARNING
+        )
+
+    def test_configure_logging_invalid_level(self):
+        from its_hub.integration.iaas.grpc_server import _configure_logging
+
+        with pytest.raises(ValueError, match="Invalid log level"):
+            _configure_logging("BOGUS")
+
+    def test_parse_args_defaults(self):
+        from its_hub.integration.iaas.grpc_server import _parse_args
+
+        with patch("sys.argv", ["its-iaas-ext-proc"]):
+            args = _parse_args()
+        assert args.port == 50051
+        assert args.log_level == "INFO"
+
+    def test_main_missing_grpc(self):
+        from its_hub.integration.iaas import grpc_server
+
+        with (
+            patch("sys.argv", ["its-iaas-ext-proc"]),
+            patch.object(grpc_server, "grpc", None),
+            pytest.raises(SystemExit),
+        ):
+            grpc_server.main()

--- a/tests/test_iaas.py
+++ b/tests/test_iaas.py
@@ -293,6 +293,107 @@ class TestChatCompletions:
         assert response.status_code == 422
 
 
+class TestStreamingChatCompletions:
+    """Tests for the SSE streaming path (_stream_chat_completions)."""
+
+    def _parse_sse(self, response):
+        """Parse SSE lines from a streaming response into data payloads."""
+        import json
+
+        chunks = []
+        for line in response.text.splitlines():
+            if line.startswith("data: "):
+                payload = line[len("data: "):]
+                if payload == "[DONE]":
+                    chunks.append("[DONE]")
+                else:
+                    chunks.append(json.loads(payload))
+        return chunks
+
+    def _configure_and_mock(self, iaas_client, endpoint, mock_return=None, side_effect=None):
+        _state.config.endpoint = endpoint
+        _state.config.model = TEST_CONSTANTS["DEFAULT_MODEL_NAME"]
+        _state.config.api_key = TEST_CONSTANTS["DEFAULT_API_KEY"]
+        mock_gw = MagicMock()
+        if side_effect:
+            mock_gw.arun_chat_completion = AsyncMock(side_effect=side_effect)
+        else:
+            mock_gw.arun_chat_completion = AsyncMock(return_value=mock_return)
+        _state.gateway = mock_gw
+        return mock_gw
+
+    def test_stream_content_response(self, iaas_client, vllm_endpoint):
+        self._configure_and_mock(
+            iaas_client, vllm_endpoint, mock_return=_mock_gateway_result("Hello world")
+        )
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        request_data["stream"] = True
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        chunks = self._parse_sse(response)
+        assert len(chunks) == 3
+        assert chunks[0]["choices"][0]["delta"]["content"] == "Hello world"
+        assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+        assert chunks[2] == "[DONE]"
+
+    def test_stream_tool_call_response(self, iaas_client, vllm_endpoint):
+        tool_call_result = {
+            "message": {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_abc123",
+                        "function": {"name": "calculator", "arguments": '{"x": 1}'},
+                    }
+                ],
+            },
+            "usage": {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15, "num_calls": 1},
+        }
+        self._configure_and_mock(iaas_client, vllm_endpoint, mock_return=tool_call_result)
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        request_data["stream"] = True
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        chunks = self._parse_sse(response)
+        assert len(chunks) == 3
+        tc_delta = chunks[0]["choices"][0]["delta"]["tool_calls"][0]
+        assert tc_delta["function"]["name"] == "calculator"
+        assert chunks[1]["choices"][0]["finish_reason"] == "tool_calls"
+        assert chunks[2] == "[DONE]"
+
+    def test_stream_not_configured(self, iaas_client):
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        request_data["stream"] = True
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        chunks = self._parse_sse(response)
+        assert chunks[0]["error"] == "Service not configured"
+        assert chunks[1] == "[DONE]"
+
+    def test_stream_gateway_error_sanitized(self, iaas_client, vllm_endpoint):
+        self._configure_and_mock(
+            iaas_client,
+            vllm_endpoint,
+            side_effect=RuntimeError("Connection to http://internal:8100 refused"),
+        )
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        request_data["stream"] = True
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        chunks = self._parse_sse(response)
+        assert "internal:8100" not in chunks[0]["error"]
+        assert "Check server logs" in chunks[0]["error"]
+        assert chunks[1] == "[DONE]"
+
+
 class TestPydanticModels:
     def test_valid_config_request(self):
         config = ConfigRequest(

--- a/tests/test_iaas.py
+++ b/tests/test_iaas.py
@@ -1,0 +1,706 @@
+"""Tests for the Inference-as-a-Service (IaaS) integration."""
+
+from collections import Counter
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from its_hub.api.types import ChatMessage
+from its_hub.integration.iaas.app import _state, app
+from its_hub.integration.iaas.models import (
+    ChatCompletionRequest,
+    ConfigRequest,
+)
+from tests.conftest import TEST_CONSTANTS
+from tests.mocks.test_data import TestDataFactory
+
+
+@pytest.fixture
+def iaas_client():
+    """Create a test client for the IaaS API, resetting state between tests."""
+    _state.reset()
+    yield TestClient(app)
+    _state.reset()
+
+
+@pytest.fixture(scope="session")
+def vllm_endpoint(vllm_server):
+    """Alias the vllm_server fixture for clarity in IaaS tests."""
+    return vllm_server
+
+
+def _mock_gateway_result(content="answer", usage=None):
+    """Build a dict matching ITSGateway.arun_chat_completion return (response_only=True)."""
+    if usage is None:
+        usage = {"prompt_tokens": 10, "completion_tokens": 15, "total_tokens": 25, "num_calls": 1}
+    return {"message": {"role": "assistant", "content": content}, "usage": usage}
+
+
+def _mock_gateway_full_result(content="answer", usage=None):
+    """Build a dict matching ITSGateway.arun_chat_completion return (response_only=False)."""
+    if usage is None:
+        usage = {"prompt_tokens": 10, "completion_tokens": 15, "total_tokens": 25, "num_calls": 1}
+    return {
+        "the_one": {"role": "assistant", "content": content},
+        "responses": [
+            {"role": "assistant", "content": content},
+            {"role": "assistant", "content": "other"},
+        ],
+        "response_counts": Counter({content: 2, "other": 1}),
+        "selected_index": 0,
+        "usage": usage,
+    }
+
+
+class TestIaaSAPIEndpoints:
+    def test_models_endpoint_empty(self, iaas_client):
+        response = iaas_client.get("/v1/models")
+        assert response.status_code == 200
+        assert response.json() == {"data": []}
+
+    def test_chat_completions_without_configuration(self, iaas_client):
+        request_data = TestDataFactory.create_chat_completion_request()
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 400
+        assert "api_endpoint" in response.json()["detail"]
+
+    def test_api_documentation_available(self, iaas_client):
+        response = iaas_client.get("/docs")
+        assert response.status_code == 200
+        assert "text/html" in response.headers.get("content-type", "")
+
+    def test_openapi_spec_available(self, iaas_client):
+        response = iaas_client.get("/openapi.json")
+        assert response.status_code == 200
+        spec = response.json()
+        assert spec["info"]["title"] == "its_hub Inference-as-a-Service"
+        assert spec["info"]["version"] == "0.1.0-alpha"
+        paths = spec["paths"]
+        assert "/configure" in paths
+        assert "/v1/models" in paths
+        assert "/v1/chat/completions" in paths
+
+
+class TestConfiguration:
+    def test_configuration_validation_missing_fields(self, iaas_client, vllm_endpoint):
+        invalid_config = {
+            "endpoint": vllm_endpoint,
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+        }
+        response = iaas_client.post("/configure", json=invalid_config)
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize(
+        "invalid_algorithm",
+        [
+            "invalid-algorithm",
+            "beam-search",
+            "particle-gibbs",
+        ],
+    )
+    def test_configuration_invalid_algorithm(
+        self, iaas_client, vllm_endpoint, invalid_algorithm
+    ):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": invalid_algorithm,
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 422
+        assert "not supported" in str(response.json())
+
+    def test_configure_creates_gateway(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 200
+        assert _state.gateway is not None
+        assert _state.config.model == TEST_CONSTANTS["DEFAULT_MODEL_NAME"]
+        assert _state.config.endpoint == vllm_endpoint
+
+    def test_models_endpoint_after_configure(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+        response = iaas_client.get("/v1/models")
+        assert response.status_code == 200
+        models = response.json()["data"]
+        assert len(models) == 1
+        assert models[0]["id"] == TEST_CONSTANTS["DEFAULT_MODEL_NAME"]
+
+
+class TestSelfConsistencyToolVote:
+    def test_self_consistency_basic_configuration(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 200
+        assert "success" in response.json()["status"]
+
+    @pytest.mark.parametrize(
+        "tool_vote",
+        ["tool_name", "tool_args", "tool_hierarchical"],
+    )
+    def test_self_consistency_with_tool_vote(
+        self, iaas_client, vllm_endpoint, tool_vote
+    ):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+            "tool_vote": tool_vote,
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 200
+        assert "success" in response.json()["status"]
+
+    def test_self_consistency_with_exclude_tool_args(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+            "tool_vote": "tool_args",
+            "exclude_tool_args": ["timestamp", "request_id"],
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 200
+
+    def test_invalid_tool_vote_value(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+            "tool_vote": "invalid_option",
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 400
+        assert "tool_vote must be one of" in response.json()["detail"]
+
+    def test_tool_vote_algorithm_usage_verification(self, iaas_client, vllm_endpoint):
+        with patch("its_hub.core.gateway.SelfConsistency") as mock_sc:
+            mock_sc.return_value = MagicMock()
+            config = {
+                "endpoint": vllm_endpoint,
+                "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+                "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+                "alg": "self-consistency",
+                "regex_patterns": [r"\\boxed{([^}]+)}"],
+                "tool_vote": "tool_hierarchical",
+                "exclude_tool_args": ["timestamp", "id"],
+            }
+            response = iaas_client.post("/configure", json=config)
+            assert response.status_code == 200
+
+            mock_sc.assert_called_once()
+            call_args = mock_sc.call_args
+            assert call_args.kwargs["tool_vote"] == "tool_hierarchical"
+            assert call_args.kwargs["exclude_args"] == ["timestamp", "id"]
+
+
+class TestChatCompletions:
+    def test_chat_completion_with_gateway(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(
+            return_value=_mock_gateway_result("Tool voting response")
+        )
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(
+            user_content="What is 2+2?", budget=8
+        )
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["choices"][0]["message"]["content"] == "Tool voting response"
+        assert data["usage"]["prompt_tokens"] == 10
+        mock_gw.arun_chat_completion.assert_called_once()
+
+    def test_chat_completion_full_result(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(
+            return_value=_mock_gateway_full_result()
+        )
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        request_data["return_response_only"] = False
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["metadata"] is not None
+        assert data["metadata"]["algorithm"] == "self-consistency"
+        assert data["metadata"]["selected_index"] == 0
+
+    @pytest.mark.parametrize(
+        "invalid_request",
+        [
+            {"model": "test-model", "messages": [], "budget": 4},
+            {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Test"}],
+                "budget": 0,
+            },
+        ],
+    )
+    def test_chat_completions_validation(self, iaas_client, invalid_request):
+        response = iaas_client.post("/v1/chat/completions", json=invalid_request)
+        assert response.status_code == 422
+
+
+class TestPydanticModels:
+    def test_valid_config_request(self):
+        config = ConfigRequest(
+            endpoint="http://localhost:8000",
+            api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
+            model=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            alg="self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+        )
+        assert config.endpoint == "http://localhost:8000"
+        assert config.alg == "self-consistency"
+
+    def test_invalid_algorithm_in_config(self):
+        with pytest.raises(ValueError, match="not supported"):
+            ConfigRequest(
+                endpoint="http://localhost:8000",
+                api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
+                model=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+                alg="invalid-algorithm",
+            )
+
+    def test_valid_chat_completion_request(self):
+        request = ChatCompletionRequest(
+            model=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            messages=[
+                ChatMessage(role="system", content="You are helpful"),
+                ChatMessage(role="user", content="Hello"),
+            ],
+            budget=8,
+            temperature=TEST_CONSTANTS["DEFAULT_TEMPERATURE"],
+        )
+        assert request.model == TEST_CONSTANTS["DEFAULT_MODEL_NAME"]
+        assert len(request.messages) == 2
+        assert request.budget == 8
+
+    @pytest.mark.parametrize("invalid_budget", [0, 1001])
+    def test_budget_validation_in_chat_request(self, invalid_budget):
+        with pytest.raises(ValueError):
+            ChatCompletionRequest(
+                model=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+                messages=[ChatMessage(role="user", content="Test")],
+                budget=invalid_budget,
+            )
+
+    def test_message_validation_empty_messages(self):
+        with pytest.raises(ValueError, match="At least one message is required"):
+            ChatCompletionRequest(
+                model=TEST_CONSTANTS["DEFAULT_MODEL_NAME"], messages=[], budget=4
+            )
+
+    def test_config_request_with_tool_vote_parameters(self):
+        config = ConfigRequest(
+            endpoint="http://localhost:8000",
+            api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
+            model=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            alg="self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+            tool_vote="tool_hierarchical",
+            exclude_tool_args=["timestamp", "id"],
+        )
+        assert config.tool_vote == "tool_hierarchical"
+        assert config.exclude_tool_args == ["timestamp", "id"]
+
+    def test_config_request_tool_vote_optional(self):
+        config = ConfigRequest(
+            endpoint="http://localhost:8000",
+            api_key=TEST_CONSTANTS["DEFAULT_API_KEY"],
+            model=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            alg="self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+        )
+        assert config.tool_vote is None
+        assert config.exclude_tool_args is None
+
+    def test_chat_completion_request_defaults(self):
+        request = ChatCompletionRequest(
+            model=TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            messages=[ChatMessage(role="user", content="Test")],
+            budget=4,
+        )
+        assert request.return_response_only is True
+
+
+class TestHeaderConfig:
+    """Tests for per-request configuration via X-ITS-* headers."""
+
+    def test_budget_from_header_overrides_body(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(return_value=_mock_gateway_result())
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        response = iaas_client.post(
+            "/v1/chat/completions",
+            json=request_data,
+            headers={"X-ITS-Budget": "16"},
+        )
+        assert response.status_code == 200
+
+        call_kwargs = mock_gw.arun_chat_completion.call_args.kwargs
+        assert call_kwargs["config"].budget == 16
+
+    def test_endpoint_from_header_overrides_service_default(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(return_value=_mock_gateway_result())
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        response = iaas_client.post(
+            "/v1/chat/completions",
+            json=request_data,
+            headers={"X-ITS-Endpoint": "http://override:9999/v1"},
+        )
+        assert response.status_code == 200
+
+        call_kwargs = mock_gw.arun_chat_completion.call_args.kwargs
+        assert call_kwargs["config"].api_endpoint == "http://override:9999/v1"
+
+    def test_api_key_from_header(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(return_value=_mock_gateway_result())
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        response = iaas_client.post(
+            "/v1/chat/completions",
+            json=request_data,
+            headers={"X-ITS-API-Key": "header-key"},
+        )
+        assert response.status_code == 200
+
+        call_kwargs = mock_gw.arun_chat_completion.call_args.kwargs
+        assert call_kwargs["config"].api_key == "header-key"
+
+    def test_headers_without_service_config(self, iaas_client):
+        """Headers alone can configure a request — no /configure needed."""
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(return_value=_mock_gateway_result())
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        response = iaas_client.post(
+            "/v1/chat/completions",
+            json=request_data,
+            headers={
+                "X-ITS-Budget": "8",
+                "X-ITS-Endpoint": "http://llm:8100/v1",
+                "X-ITS-API-Key": "sk-test",
+            },
+        )
+        assert response.status_code == 200
+
+        call_kwargs = mock_gw.arun_chat_completion.call_args.kwargs
+        assert call_kwargs["config"].budget == 8
+        assert call_kwargs["config"].api_endpoint == "http://llm:8100/v1"
+        assert call_kwargs["config"].api_key == "sk-test"
+
+    def test_400_when_no_endpoint_from_any_source(self, iaas_client):
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        response = iaas_client.post(
+            "/v1/chat/completions",
+            json=request_data,
+            headers={"X-ITS-Budget": "8"},
+        )
+        assert response.status_code == 400
+        assert "api_endpoint" in response.json()["detail"]
+
+
+class TestRegexValidation:
+    """Tests for regex pattern validation at configure time."""
+
+    def test_rejects_invalid_regex(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": ["[invalid("],
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 400
+        assert "Invalid regex pattern" in response.json()["detail"]
+
+
+class TestBudgetValidation:
+    """Tests for budget validation edge cases."""
+
+    def test_negative_budget_header_rejected(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(return_value=_mock_gateway_result())
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        response = iaas_client.post(
+            "/v1/chat/completions",
+            json=request_data,
+            headers={"X-ITS-Budget": "-5"},
+        )
+        assert response.status_code == 400
+        assert "budget" in response.json()["detail"].lower()
+
+    def test_configure_rejects_invalid_budget(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+            "budget": 0,
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 422
+
+
+class TestErrorSanitization:
+    """Tests that internal errors don't leak details to clients."""
+
+    def test_generation_error_is_sanitized(self, iaas_client, vllm_endpoint):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(
+            side_effect=RuntimeError("Connection to http://internal:8100 refused")
+        )
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 500
+        detail = response.json()["detail"]
+        assert "internal:8100" not in detail
+        assert "Check server logs" in detail
+
+
+class TestModelValidatorFixes:
+    """Tests that model validators fire even when fields are omitted."""
+
+    def test_self_consistency_requires_regex_when_omitted(self):
+        with pytest.raises(ValueError, match="regex_patterns are required"):
+            ConfigRequest(
+                endpoint="http://example.com:8000",
+                api_key="sk-test",
+                model="test-model",
+                alg="self-consistency",
+            )
+
+    def test_openai_requires_api_key_when_omitted(self):
+        with pytest.raises(ValueError, match="api_key is required"):
+            ConfigRequest(
+                endpoint="http://example.com:8000",
+                model="test-model",
+                alg="self-consistency",
+                regex_patterns=[r"\\boxed{([^}]+)}"],
+            )
+
+
+class TestExtProcessor:
+    """Tests for the IaaS ext_proc."""
+
+    @pytest.fixture
+    def _make_headers_request(self):
+        """Build an ext_proc ProcessingRequest with request_headers."""
+        from envoy.config.core.v3 import base_pb2
+        from envoy.service.ext_proc.v3 import external_processor_pb2 as ext_proc_pb2
+
+        from its_hub.integration.ext_proc.proto import envoy  # noqa: F401
+
+        def _build(headers: dict[str, str]):
+            header_list = [
+                base_pb2.HeaderValue(key=k, raw_value=v.encode())
+                for k, v in headers.items()
+            ]
+            return ext_proc_pb2.ProcessingRequest(
+                request_headers=ext_proc_pb2.HttpHeaders(
+                    headers=base_pb2.HeaderMap(headers=header_list)
+                )
+            )
+
+        return _build
+
+    @pytest.fixture
+    def ext_proc(self):
+        from its_hub.integration.iaas.ext_processor import ExternalProcessorService
+        return ExternalProcessorService()
+
+    @pytest.mark.asyncio
+    async def test_routes_and_preserves_headers_when_budget_present(
+        self, ext_proc, _make_headers_request
+    ):
+        request = _make_headers_request({
+            ":path": "/v1/chat/completions",
+            "x-its-budget": "4",
+            "x-its-endpoint": "http://localhost:8100/v1",
+            "x-its-api-key": "secret",
+        })
+
+        async def _stream():
+            yield request
+
+        responses = []
+        async for resp in ext_proc.Process(_stream(), MagicMock(peer=lambda: "test")):
+            responses.append(resp)
+
+        assert len(responses) == 1
+        resp = responses[0]
+        headers_resp = resp.request_headers.response
+
+        assert headers_resp.clear_route_cache is True
+
+        set_headers = {
+            h.header.key: h.header.raw_value.decode()
+            for h in headers_resp.header_mutation.set_headers
+        }
+        assert set_headers["X-ITS-Route"] == "its-service"
+
+        removed = list(headers_resp.header_mutation.remove_headers)
+        assert not removed
+
+    @pytest.mark.asyncio
+    async def test_passes_through_without_budget_header(
+        self, ext_proc, _make_headers_request
+    ):
+        request = _make_headers_request({
+            ":path": "/v1/chat/completions",
+            "content-type": "application/json",
+        })
+
+        async def _stream():
+            yield request
+
+        responses = []
+        async for resp in ext_proc.Process(_stream(), MagicMock(peer=lambda: "test")):
+            responses.append(resp)
+
+        assert len(responses) == 1
+        resp = responses[0]
+        headers_resp = resp.request_headers.response
+
+        assert headers_resp.clear_route_cache is False
+        assert not headers_resp.header_mutation.set_headers
+        assert not list(headers_resp.header_mutation.remove_headers)
+
+    @pytest.mark.asyncio
+    async def test_strips_stray_its_headers_on_pass_through(
+        self, ext_proc, _make_headers_request
+    ):
+        """Stray ITS headers without budget are stripped on pass-through."""
+        request = _make_headers_request({
+            ":path": "/v1/chat/completions",
+            "x-its-endpoint": "http://localhost:8100/v1",
+            "x-its-api-key": "secret",
+        })
+
+        async def _stream():
+            yield request
+
+        responses = []
+        async for resp in ext_proc.Process(_stream(), MagicMock(peer=lambda: "test")):
+            responses.append(resp)
+
+        resp = responses[0]
+        headers_resp = resp.request_headers.response
+
+        assert headers_resp.clear_route_cache is False
+        assert not headers_resp.header_mutation.set_headers
+
+        removed = list(headers_resp.header_mutation.remove_headers)
+        assert "x-its-endpoint" in removed
+        assert "x-its-api-key" in removed


### PR DESCRIPTION
## Summary

Adds an Envoy-native integration path for inference-time scaling via a gRPC ext_proc and a FastAPI IaaS service, deployed as two independent processes behind Envoy.

## Changes

- **ext_proc** (`ext_processor.py`) — lightweight gRPC External Processor. Checks for `X-ITS-Budget` header;
  if present, sets `X-ITS-Route: its-service` + `clear_route_cache` so Envoy re-routes to IaaS. On
  pass-through, defensively strips stray `X-ITS-*` headers so they never leak to the upstream LLM.
- **IaaS service** (`app.py`) — FastAPI OpenAI-compatible API that reads `X-ITS-Budget`, `X-ITS-Endpoint`,
  `X-ITS-API-Key` from request headers for per-request configuration (priority: header > body > service
  default). Delegates to `ITSGateway` for LM lifecycle and algorithm dispatch.
- **Entry points:** `its-iaas` (FastAPI/uvicorn) and `its-iaas-ext-proc` (gRPC), each with their own server
  module.

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check its_hub/`)
- [x] Added/updated tests for new functionality
- [x] Updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAI-compatible IaaS inference service with `POST /configure`, `GET /v1/models`, and `POST /v1/chat/completions` (non-streaming + SSE streaming with tool deltas and `[DONE]`).
  * Added the Envoy + ext_proc integration to route budgeted requests to IaaS and strip ITS headers for passthrough.
  * Introduced new server CLI entry points and composite stack start/stop commands.
* **Improvements**
  * Updated IaaS to run on port **8109** end-to-end.
  * Added runtime self-consistency configuration with regex validation and tool-voting controls.
* **Bug Fixes**
  * Improved validation when required API endpoint/config is missing.
* **Documentation**
  * Updated installation and IaaS/Envoy guides for the new port and setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->