### PR TITLE
chore: gitignore factory output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,8 @@ its_hub/integration/ext_proc/proto/
 third_party/.submodules-initialized
 envoy.log
 envoy-grpc.log
+
+# Factory
+.factory/
+.factory-worktrees/
+.refactory/


### PR DESCRIPTION
Adds `.factory/`, `.factory-worktrees/`, and `.refactory/` to `.gitignore` so Factory-generated output isn't committed to the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore settings to exclude additional local tooling files and directories.
  * Prevented Envoy and Factory-generated logs and workspace data from appearing as untracked changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->