### PR TITLE
fix(packaging): bundle generated Envoy proto modules in wheels/sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,11 +97,12 @@ manifest-path = "rust/Cargo.toml"
 module-name = "its_hub._rust"
 python-source = "."
 features = ["extension-module"]
-# Non-Python data files that setuptools shipped via package-data; maturin needs
-# them listed explicitly so they land in the sdist/wheel.
+# Data files and the generated proto package (produced by `make proto-compile`,
+# gitignored) must be listed explicitly so maturin ships them in the wheel/sdist.
 include = [
     "its_hub/integration/ext_proc/envoy_config.yaml",
     "its_hub/integration/iaas/envoy_config.yaml",
+    "its_hub/integration/proto/**/*.py",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Problem

The `ext_proc` and `envoy-iaas` gateways import `its_hub.integration.proto` at startup, but the generated proto package is never packaged into maturin-built artifacts:

- `its_hub/integration/proto/` is **gitignored** (produced by `make proto-compile`).
- `[tool.maturin] include` listed only the two `envoy_config.yaml` files.

maturin only ships tracked `.py` files under `python-source` plus paths in `include`, so it excluded the whole proto package. A `pip install "its_hub[ext_proc]"` from a maturin wheel then fails at gateway startup:

```
ModuleNotFoundError: No module named 'its_hub.integration.proto'
```

This is a latent regression from the setuptools→maturin migration: the last setuptools release (`1.2.0`, a `py3-none-any` wheel) still shipped the proto package via `package-data`, so the currently-published wheel works — but the next maturin-built release would not.

## Verification

Built the wheel from this repo both ways and inspected contents / ran the import chain in a clean `python:3.12-slim` container:

| Wheel | proto `.py` files | `from its_hub.integration.ext_proc.processor import ExternalProcessorService` |
|---|---|---|
| before (current `main`) | 0 | `ModuleNotFoundError` |
| after (this PR) | 154 | imports OK |

## Fix

Add `its_hub/integration/proto/**/*.py` to `[tool.maturin] include`. maturin's `include` force-adds these paths even though they are gitignored.

No CI change is needed: the release workflow already runs the `compile-protos` action before every build job (`sdist`, `linux-wheels`, `macos-wheels`), so the modules exist on disk at build time and are now bundled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package distribution to include generated integration modules, ensuring required functionality is available in installed builds.

* **Documentation**
  * Clarified packaging and build workflow requirements for generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->