### PR TITLE
feat: Add ConfidenceSelection algorithm with tail entropy selection

### DIFF
--- a/its_hub/__init__.py
+++ b/its_hub/__init__.py
@@ -16,6 +16,7 @@ from its_hub.api import (
 from its_hub.core.algorithms.adaptive_self_consistency import AdaptiveSelfConsistency
 from its_hub.core.algorithms.beta_self_consistency import BetaSelfConsistency
 from its_hub.core.algorithms.bon import BestOfN
+from its_hub.core.algorithms.confidence_selection import ConfidenceSelection
 from its_hub.core.algorithms.self_consistency import SelfConsistency
 
 __version__ = version("its_hub")
@@ -34,6 +35,7 @@ __all__ = [  # noqa: RUF022
     # Algorithms
     "AdaptiveSelfConsistency",
     "BetaSelfConsistency",
+    "ConfidenceSelection",
     "SelfConsistency",
     "BestOfN",
 ]

--- a/its_hub/core/algorithms/confidence_selection.py
+++ b/its_hub/core/algorithms/confidence_selection.py
@@ -139,8 +139,14 @@ def select_by_tail_entropy(
         aggregated entropy over the tail window for candidate *i*, and
         *tail_window* is the adaptive window size used.
     """
-    lengths = [len(e) for e in entropies_per_token]
-    included = trim_length_outliers(lengths, trim_pct)
+    usable = [i for i, e in enumerate(entropies_per_token) if e]
+    if not usable:
+        raise ValueError("No candidates have entropy data; cannot select.")
+
+    usable_lengths = [len(entropies_per_token[i]) for i in usable]
+    trimmed_usable = trim_length_outliers(usable_lengths, trim_pct)
+    included = [usable[j] for j in trimmed_usable]
+
     tail = adaptive_tail_window(entropies_per_token, included, tail_min, tail_max)
     scores = tail_scores(entropies_per_token, included, tail, agg)
     selected = int(np.argmin(scores))

--- a/its_hub/core/algorithms/confidence_selection.py
+++ b/its_hub/core/algorithms/confidence_selection.py
@@ -1,0 +1,253 @@
+"""ConfidenceSelection: select the best response by lowest tail entropy.
+
+Generates N candidate responses with logprobs enabled, computes per-token
+Shannon entropy from the top-k log probabilities, then selects the candidate
+whose tail (final portion) has the lowest aggregated entropy — indicating the
+model was most confident about its conclusion.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+
+from its_hub.api import (
+    AbstractLanguageModel,
+    AbstractOrchestrator,
+    AbstractScalingAlgorithm,
+    AbstractScalingResult,
+    ChatMessage,
+    ChatMessages,
+    GenerationUsage,
+)
+from its_hub.core.orchestrator import LMOrchestrator
+
+# ---------------------------------------------------------------------------
+# Pure functions — ported from research reference implementation
+# ---------------------------------------------------------------------------
+
+
+def compute_token_entropies(logprobs_content: list[dict]) -> list[float]:
+    """Compute per-token Shannon entropy from OpenAI-format logprobs.
+
+    Args:
+        logprobs_content: The ``choice["logprobs"]["content"]`` list. Each
+            element is a dict with a ``top_logprobs`` key containing a list
+            of ``{"token": str, "logprob": float}`` dicts.
+
+    Returns:
+        Per-token entropy values (nats).
+    """
+    entropies: list[float] = []
+    for token_info in logprobs_content:
+        top_lps = token_info.get("top_logprobs", [])
+        if not top_lps:
+            entropies.append(0.0)
+            continue
+        log_ps = np.array([t["logprob"] for t in top_lps])
+        ps = np.exp(log_ps)
+        entropy = float(-np.sum(ps * np.log(ps + 1e-10)))
+        entropies.append(entropy)
+    return entropies
+
+
+def trim_length_outliers(
+    lengths: list[int],
+    trim_pct: float = 0.05,
+) -> list[int]:
+    """Return indices of candidates within the [p5, p95] length range."""
+    n = len(lengths)
+    if n < 16:
+        return list(range(n))
+    lo = float(np.percentile(lengths, trim_pct * 100))
+    hi = float(np.percentile(lengths, (1 - trim_pct) * 100))
+    included = [i for i in range(n) if lo <= lengths[i] <= hi]
+    return included if len(included) >= 2 else list(range(n))
+
+
+def adaptive_tail_window(
+    entropies_per_token: list[list[float]],
+    included: list[int],
+    tail_min: int = 64,
+    tail_max: int = 2048,
+) -> int:
+    """Compute tail window size adaptive to length and entropy.
+
+    Formula: ``clamp(sqrt(mean_len) / mean_entropy, tail_min, tail_max)``
+
+    sqrt(mean_len) scales sub-linearly with response length.  Dividing by
+    mean entropy makes the window entropy-adaptive: confident (low-entropy)
+    sequences get a wider tail so more signal is captured, while uncertain
+    sequences get a shorter tail to avoid dilution.
+    """
+    lengths = [len(entropies_per_token[i]) for i in included]
+    mean_len = float(np.mean(lengths))
+    mean_entropy = float(
+        np.mean(
+            [
+                np.mean(entropies_per_token[i][-2048:])
+                for i in included
+                if entropies_per_token[i]
+            ]
+        )
+    )
+    mean_entropy = max(mean_entropy, 1e-6)
+    tail = int(np.clip(np.sqrt(mean_len) / mean_entropy, tail_min, tail_max))
+    return tail
+
+
+def tail_scores(
+    entropies_per_token: list[list[float]],
+    included: list[int],
+    tail: int,
+    agg: str = "median",
+) -> list[float]:
+    """Compute aggregated entropy over the tail window for each candidate."""
+    n = len(entropies_per_token)
+    included_set = set(included)
+    fn = np.median if agg == "median" else np.mean
+    scores: list[float] = []
+    for i in range(n):
+        if i not in included_set or not entropies_per_token[i]:
+            scores.append(float("inf"))
+        else:
+            window = entropies_per_token[i][-tail:]
+            scores.append(float(fn(window)))
+    return scores
+
+
+def select_by_tail_entropy(
+    entropies_per_token: list[list[float]],
+    tail_min: int = 64,
+    tail_max: int = 2048,
+    agg: str = "median",
+    trim_pct: float = 0.05,
+) -> tuple[int, list[float], int]:
+    """Select the response with lowest tail entropy.
+
+    Args:
+        entropies_per_token: N lists of per-token Shannon entropy (nats).
+        tail_min: Minimum tail window size in tokens.
+        tail_max: Maximum tail window size in tokens.
+        agg: Aggregation over the tail window (``"median"`` or ``"mean"``).
+        trim_pct: Fraction of length outliers to trim from each end.
+
+    Returns:
+        ``(selected_index, scores, tail_window)`` where *scores[i]* is the
+        aggregated entropy over the tail window for candidate *i*, and
+        *tail_window* is the adaptive window size used.
+    """
+    lengths = [len(e) for e in entropies_per_token]
+    included = trim_length_outliers(lengths, trim_pct)
+    tail = adaptive_tail_window(entropies_per_token, included, tail_min, tail_max)
+    scores = tail_scores(entropies_per_token, included, tail, agg)
+    selected = int(np.argmin(scores))
+    return selected, scores, tail
+
+
+# ---------------------------------------------------------------------------
+# Algorithm class
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConfidenceSelectionResult(AbstractScalingResult):
+    responses: list[dict]
+    scores: list[float]
+    selected_index: int
+    tail_window: int
+    usage: GenerationUsage | None = None
+
+    @property
+    def the_one(self) -> dict:
+        return self.responses[self.selected_index]
+
+
+class ConfidenceSelection(AbstractScalingAlgorithm):
+    """Select the best-of-N response by lowest tail entropy.
+
+    Generates *budget* candidate responses with token-level logprobs,
+    computes per-token Shannon entropy from the top-k log probabilities,
+    then picks the candidate whose tail (final tokens) has the lowest
+    aggregated entropy — the response where the model was most confident.
+
+    No external reward model is required.
+    """
+
+    def __init__(
+        self,
+        top_logprobs: int = 20,
+        tail_min: int = 64,
+        tail_max: int = 2048,
+        agg: str = "median",
+        trim_pct: float = 0.05,
+        orchestrator: AbstractOrchestrator | None = None,
+    ):
+        if agg not in ("median", "mean"):
+            raise ValueError(f"agg must be 'median' or 'mean', got: {agg!r}")
+        if not 1 <= top_logprobs <= 20:
+            raise ValueError(f"top_logprobs must be 1-20, got: {top_logprobs}")
+
+        self.top_logprobs = top_logprobs
+        self.tail_min = tail_min
+        self.tail_max = tail_max
+        self.agg = agg
+        self.trim_pct = trim_pct
+
+        if orchestrator is None:
+            orchestrator = LMOrchestrator()
+        self.orchestrator = orchestrator
+
+    async def ainfer(
+        self,
+        lm: AbstractLanguageModel,
+        prompt_or_messages: str | list[ChatMessage] | ChatMessages,
+        budget: int,
+        return_response_only: bool = True,
+        tools: list[dict] | None = None,
+        tool_choice: str | dict | None = None,
+    ) -> dict | ConfidenceSelectionResult:
+        """Run inference with confidence-based selection."""
+        chat_messages = ChatMessages.from_prompt_or_messages(prompt_or_messages)
+
+        usage = GenerationUsage()
+
+        responses = await self.orchestrator.agenerate(
+            lm,
+            chat_messages.to_batch(budget),
+            tools=tools,
+            tool_choice=tool_choice,
+            usage_accumulator=usage,
+            logprobs=True,
+            top_logprobs=self.top_logprobs,
+        )
+
+        entropies_per_token: list[list[float]] = []
+        for i, resp in enumerate(responses):
+            lp = resp.get("_logprobs")
+            if lp is not None and lp.get("content"):
+                entropies_per_token.append(compute_token_entropies(lp["content"]))
+            else:
+                logging.warning(
+                    "Response %d has no logprobs data; assigning infinite entropy", i
+                )
+                entropies_per_token.append([])
+
+        selected_index, scores, tail_window = select_by_tail_entropy(
+            entropies_per_token,
+            tail_min=self.tail_min,
+            tail_max=self.tail_max,
+            agg=self.agg,
+            trim_pct=self.trim_pct,
+        )
+
+        result = ConfidenceSelectionResult(
+            responses=responses,
+            scores=scores,
+            selected_index=selected_index,
+            tail_window=tail_window,
+            usage=usage,
+        )
+        return result.the_one if return_response_only else result

--- a/its_hub/core/algorithms/confidence_selection.py
+++ b/its_hub/core/algorithms/confidence_selection.py
@@ -57,14 +57,14 @@ def trim_length_outliers(
     lengths: list[int],
     trim_pct: float = 0.05,
 ) -> list[int]:
-    """Return indices of candidates within the [p5, p95] length range."""
+    """Return indices of candidates whose length is within the percentile range defined by *trim_pct*."""
     n = len(lengths)
     if n < 16:
         return list(range(n))
     lo = float(np.percentile(lengths, trim_pct * 100))
     hi = float(np.percentile(lengths, (1 - trim_pct) * 100))
     included = [i for i in range(n) if lo <= lengths[i] <= hi]
-    return included if len(included) >= 2 else list(range(n))
+    return included
 
 
 def adaptive_tail_window(

--- a/its_hub/core/lms/openai_lm.py
+++ b/its_hub/core/lms/openai_lm.py
@@ -175,6 +175,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         tools: list[dict] | None = None,
         tool_choice: str | dict | None = None,
         response_format: dict | None = None,
+        logprobs: bool | None = None,
+        top_logprobs: int | None = None,
     ) -> dict:
         # helper method to prepare request data for both sync and async methods
         # Convert dict messages to Message objects if needed
@@ -241,6 +243,12 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         if response_format is not None:
             request_data["response_format"] = response_format
 
+        # add logprobs for token-level log probability data
+        if logprobs is not None:
+            request_data["logprobs"] = logprobs
+        if top_logprobs is not None:
+            request_data["top_logprobs"] = top_logprobs
+
         return request_data
 
     async def _agenerate(
@@ -254,6 +262,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         tool_choice: str | dict | None = None,
         response_format: dict | None = None,
         usage_accumulator: GenerationUsage | None = None,
+        logprobs: bool | None = None,
+        top_logprobs: int | None = None,
     ) -> list[dict]:
         # limit concurrency to max_concurrency using a semaphore
         semaphore = asyncio.Semaphore(
@@ -285,6 +295,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                         tools,
                         tool_choice,
                         response_format,
+                        logprobs,
+                        top_logprobs,
                     )
 
                     async with session.post(
@@ -306,6 +318,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                                 **choice,
                                 "message": dict(choice["message"]),
                             }
+                        if (lp := choice.get("logprobs")) is not None:
+                            message["_logprobs"] = lp
                         if usage_accumulator is not None:
                             api_usage = response_json.get("usage", {})
                             usage_accumulator.add(
@@ -408,6 +422,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         response_format: dict | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
         usage_accumulator: GenerationUsage | None = None,
+        logprobs: bool | None = None,
+        top_logprobs: int | None = None,
     ) -> dict:
         max_completion_tokens = resolve_max_completion_tokens(
             max_completion_tokens, max_tokens
@@ -438,6 +454,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                 tools,
                 tool_choice,
                 response_format,
+                logprobs,
+                top_logprobs,
             )
 
             async with session.post(
@@ -459,6 +477,8 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
                         **choice,
                         "message": dict(choice["message"]),
                     }
+                if (lp := choice.get("logprobs")) is not None:
+                    message["_logprobs"] = lp
                 if usage_accumulator is not None:
                     api_usage = response_json.get("usage", {})
                     usage_accumulator.add(

--- a/its_hub/core/orchestrator.py
+++ b/its_hub/core/orchestrator.py
@@ -81,6 +81,8 @@ class LMOrchestrator(AbstractOrchestrator):
         tool_choice: str | dict | None = None,
         response_format: dict | None = None,
         usage_accumulator: GenerationUsage | None = None,
+        logprobs: bool | None = None,
+        top_logprobs: int | None = None,
     ) -> list[dict]:
         """
         Generate responses for a batch of messages asynchronously.
@@ -138,6 +140,8 @@ class LMOrchestrator(AbstractOrchestrator):
                     response_format=response_format,
                     loop=current_loop,
                     usage_accumulator=usage_accumulator,
+                    logprobs=logprobs,
+                    top_logprobs=top_logprobs,
                 )
 
         try:

--- a/tests/test_confidence_selection.py
+++ b/tests/test_confidence_selection.py
@@ -123,10 +123,11 @@ class TestTrimLengthOutliers:
         result = trim_length_outliers(lengths)
         assert result == list(range(20))
 
-    def test_fallback_when_trim_leaves_too_few(self):
+    def test_aggressive_trim(self):
         lengths = [1] * 8 + [1000] * 8
         result = trim_length_outliers(lengths, trim_pct=0.45)
-        assert result == list(range(16))
+        assert len(result) >= 1
+        assert all(0 <= i < 16 for i in result)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_confidence_selection.py
+++ b/tests/test_confidence_selection.py
@@ -1,6 +1,5 @@
 """Tests for ConfidenceSelection algorithm."""
 
-import asyncio
 
 import numpy as np
 import pytest
@@ -15,7 +14,6 @@ from its_hub.core.algorithms.confidence_selection import (
     trim_length_outliers,
 )
 from its_hub.core.orchestrator import LMOrchestrator
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -125,11 +123,10 @@ class TestTrimLengthOutliers:
         result = trim_length_outliers(lengths)
         assert result == list(range(20))
 
-    def test_fallback_on_aggressive_trim(self):
-        lengths = [100] * 16
-        lengths[0] = 1
-        result = trim_length_outliers(lengths, trim_pct=0.05)
-        assert len(result) >= 2
+    def test_fallback_when_trim_leaves_too_few(self):
+        lengths = [1] * 8 + [1000] * 8
+        result = trim_length_outliers(lengths, trim_pct=0.45)
+        assert result == list(range(16))
 
 
 # ---------------------------------------------------------------------------
@@ -192,7 +189,7 @@ class TestSelectByTailEntropy:
         low = [0.01] * 200
         mid = [0.5] * 200
         high = [1.0] * 200
-        selected, scores, tail = select_by_tail_entropy(
+        selected, scores, _tail = select_by_tail_entropy(
             [high, low, mid], tail_min=10, tail_max=500
         )
         assert selected == 1
@@ -200,7 +197,7 @@ class TestSelectByTailEntropy:
         assert scores[1] < scores[2]
 
     def test_single_response(self):
-        selected, scores, tail = select_by_tail_entropy(
+        selected, scores, _tail = select_by_tail_entropy(
             [[0.5] * 100], tail_min=10, tail_max=500
         )
         assert selected == 0
@@ -257,8 +254,8 @@ class TestConfidenceSelection:
         result = algo.infer(lm, "test prompt", budget=3, return_response_only=False)
 
         assert isinstance(result, ConfidenceSelectionResult)
-        assert result.selected_index == 1
         assert result.the_one["content"] == "correct answer"
+        assert result.scores[result.selected_index] == min(result.scores)
         assert result.tail_window > 0
 
     def test_infer_response_only(self):
@@ -298,8 +295,8 @@ class TestConfidenceSelection:
         )
         result = algo.infer(lm, "test prompt", budget=2, return_response_only=False)
 
-        assert result.selected_index == 1
-        assert result.scores[0] == float("inf")
+        assert result.the_one["content"] == "has logprobs"
+        assert float("inf") in result.scores
 
     def test_infer_with_messages_input(self):
         logprobs = _make_logprobs_content([0.1] * 100)
@@ -318,6 +315,21 @@ class TestConfidenceSelection:
         messages = [{"role": "user", "content": "test"}]
         result = algo.infer(lm, messages, budget=1, return_response_only=True)
         assert result["content"] == "answer"
+
+    def test_default_orchestrator(self):
+        logprobs = _make_logprobs_content([0.1] * 100)
+        responses = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "_logprobs": {"content": logprobs},
+            }
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(tail_min=10, tail_max=500)
+        result = algo.infer(lm, "test", budget=1, return_response_only=False)
+        assert result.the_one["content"] == "answer"
 
     def test_usage_tracking(self):
         logprobs = _make_logprobs_content([0.1] * 100)

--- a/tests/test_confidence_selection.py
+++ b/tests/test_confidence_selection.py
@@ -1,0 +1,338 @@
+"""Tests for ConfidenceSelection algorithm."""
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from its_hub.core.algorithms.confidence_selection import (
+    ConfidenceSelection,
+    ConfidenceSelectionResult,
+    adaptive_tail_window,
+    compute_token_entropies,
+    select_by_tail_entropy,
+    tail_scores,
+    trim_length_outliers,
+)
+from its_hub.core.orchestrator import LMOrchestrator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_logprobs_content(entropies: list[float]) -> list[dict]:
+    """Build OpenAI-format logprobs content from target entropy values.
+
+    Creates top_logprobs with two tokens whose probabilities yield
+    approximately the desired per-token entropy.
+    """
+    content = []
+    for h in entropies:
+        if h <= 0:
+            content.append(
+                {"top_logprobs": [{"token": "a", "logprob": 0.0}]}
+            )
+        else:
+            p = min(max(np.exp(-h), 0.01), 0.99)
+            content.append(
+                {
+                    "top_logprobs": [
+                        {"token": "a", "logprob": float(np.log(p))},
+                        {"token": "b", "logprob": float(np.log(1 - p))},
+                    ]
+                }
+            )
+    return content
+
+
+class LogprobsMockLM:
+    """Mock LM that returns responses with logprobs data."""
+
+    def __init__(self, responses_with_logprobs: list[dict]):
+        self.responses = responses_with_logprobs
+        self.call_count = 0
+
+    async def agenerate_single(self, messages, **kwargs):
+        idx = self.call_count % len(self.responses)
+        self.call_count += 1
+        return self.responses[idx]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: compute_token_entropies
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTokenEntropies:
+    def test_single_token_zero_entropy(self):
+        content = [{"top_logprobs": [{"token": "x", "logprob": 0.0}]}]
+        result = compute_token_entropies(content)
+        assert len(result) == 1
+        assert result[0] == pytest.approx(0.0, abs=1e-6)
+
+    def test_two_tokens_uniform(self):
+        p = 0.5
+        content = [
+            {
+                "top_logprobs": [
+                    {"token": "a", "logprob": float(np.log(p))},
+                    {"token": "b", "logprob": float(np.log(p))},
+                ]
+            }
+        ]
+        result = compute_token_entropies(content)
+        expected = -2 * p * np.log(p)
+        assert result[0] == pytest.approx(expected, rel=1e-4)
+
+    def test_multiple_tokens(self):
+        content = [
+            {"top_logprobs": [{"token": "a", "logprob": -0.1}]},
+            {"top_logprobs": [{"token": "b", "logprob": -0.5}]},
+            {"top_logprobs": [{"token": "c", "logprob": -1.0}]},
+        ]
+        result = compute_token_entropies(content)
+        assert len(result) == 3
+
+    def test_empty_top_logprobs(self):
+        content = [{"top_logprobs": []}]
+        result = compute_token_entropies(content)
+        assert result[0] == 0.0
+
+    def test_empty_input(self):
+        assert compute_token_entropies([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: trim_length_outliers
+# ---------------------------------------------------------------------------
+
+
+class TestTrimLengthOutliers:
+    def test_small_sample_returns_all(self):
+        lengths = [10, 20, 30, 40, 50]
+        assert trim_length_outliers(lengths) == list(range(5))
+
+    def test_exactly_16_applies_trimming(self):
+        lengths = [1] + [100] * 14 + [10000]
+        result = trim_length_outliers(lengths)
+        assert 0 not in result
+        assert 15 not in result
+
+    def test_uniform_lengths(self):
+        lengths = [100] * 20
+        result = trim_length_outliers(lengths)
+        assert result == list(range(20))
+
+    def test_fallback_on_aggressive_trim(self):
+        lengths = [100] * 16
+        lengths[0] = 1
+        result = trim_length_outliers(lengths, trim_pct=0.05)
+        assert len(result) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: adaptive_tail_window
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveTailWindow:
+    def test_basic(self):
+        ept = [list(np.random.rand(200)) for _ in range(4)]
+        included = list(range(4))
+        tail = adaptive_tail_window(ept, included, tail_min=10, tail_max=500)
+        assert 10 <= tail <= 500
+
+    def test_clamps_to_min(self):
+        ept = [[10.0] * 10 for _ in range(4)]
+        included = list(range(4))
+        tail = adaptive_tail_window(ept, included, tail_min=64, tail_max=2048)
+        assert tail == 64
+
+    def test_clamps_to_max(self):
+        ept = [[0.001] * 1_000_000 for _ in range(4)]
+        included = list(range(4))
+        tail = adaptive_tail_window(ept, included, tail_min=64, tail_max=2048)
+        assert tail == 2048
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: tail_scores
+# ---------------------------------------------------------------------------
+
+
+class TestTailScores:
+    def test_excluded_gets_inf(self):
+        ept = [[0.1] * 100, [0.2] * 100, [0.3] * 100]
+        scores = tail_scores(ept, included=[0, 2], tail=50)
+        assert scores[1] == float("inf")
+        assert scores[0] < float("inf")
+        assert scores[2] < float("inf")
+
+    def test_empty_gets_inf(self):
+        ept = [[], [0.1] * 100]
+        scores = tail_scores(ept, included=[0, 1], tail=50)
+        assert scores[0] == float("inf")
+
+    def test_median_vs_mean(self):
+        ept = [[0.1] * 50 + [10.0] + [0.1] * 49]
+        scores_median = tail_scores(ept, included=[0], tail=100, agg="median")
+        scores_mean = tail_scores(ept, included=[0], tail=100, agg="mean")
+        assert scores_median[0] < scores_mean[0]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: select_by_tail_entropy
+# ---------------------------------------------------------------------------
+
+
+class TestSelectByTailEntropy:
+    def test_selects_lowest_entropy(self):
+        low = [0.01] * 200
+        mid = [0.5] * 200
+        high = [1.0] * 200
+        selected, scores, tail = select_by_tail_entropy(
+            [high, low, mid], tail_min=10, tail_max=500
+        )
+        assert selected == 1
+        assert scores[1] < scores[0]
+        assert scores[1] < scores[2]
+
+    def test_single_response(self):
+        selected, scores, tail = select_by_tail_entropy(
+            [[0.5] * 100], tail_min=10, tail_max=500
+        )
+        assert selected == 0
+        assert len(scores) == 1
+
+    def test_returns_tail_window(self):
+        ept = [[0.5] * 200 for _ in range(4)]
+        _, _, tail = select_by_tail_entropy(ept, tail_min=10, tail_max=500)
+        assert 10 <= tail <= 500
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: ConfidenceSelection algorithm
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceSelection:
+    def test_constructor_validation(self):
+        with pytest.raises(ValueError, match="agg"):
+            ConfidenceSelection(agg="invalid")
+
+        with pytest.raises(ValueError, match="top_logprobs"):
+            ConfidenceSelection(top_logprobs=0)
+
+        with pytest.raises(ValueError, match="top_logprobs"):
+            ConfidenceSelection(top_logprobs=21)
+
+    def test_infer_selects_most_confident(self):
+        low_entropy_logprobs = _make_logprobs_content([0.01] * 200)
+        high_entropy_logprobs = _make_logprobs_content([1.0] * 200)
+
+        responses = [
+            {
+                "role": "assistant",
+                "content": "wrong answer",
+                "_logprobs": {"content": high_entropy_logprobs},
+            },
+            {
+                "role": "assistant",
+                "content": "correct answer",
+                "_logprobs": {"content": low_entropy_logprobs},
+            },
+            {
+                "role": "assistant",
+                "content": "another wrong",
+                "_logprobs": {"content": high_entropy_logprobs},
+            },
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            tail_min=10, tail_max=500, orchestrator=LMOrchestrator()
+        )
+        result = algo.infer(lm, "test prompt", budget=3, return_response_only=False)
+
+        assert isinstance(result, ConfidenceSelectionResult)
+        assert result.selected_index == 1
+        assert result.the_one["content"] == "correct answer"
+        assert result.tail_window > 0
+
+    def test_infer_response_only(self):
+        logprobs = _make_logprobs_content([0.1] * 100)
+        responses = [
+            {
+                "role": "assistant",
+                "content": f"response {i}",
+                "_logprobs": {"content": logprobs},
+            }
+            for i in range(3)
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            tail_min=10, tail_max=500, orchestrator=LMOrchestrator()
+        )
+        result = algo.infer(lm, "test prompt", budget=3, return_response_only=True)
+
+        assert isinstance(result, dict)
+        assert "content" in result
+
+    def test_infer_handles_missing_logprobs(self):
+        good = _make_logprobs_content([0.1] * 100)
+        responses = [
+            {"role": "assistant", "content": "no logprobs"},
+            {
+                "role": "assistant",
+                "content": "has logprobs",
+                "_logprobs": {"content": good},
+            },
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            tail_min=10, tail_max=500, orchestrator=LMOrchestrator()
+        )
+        result = algo.infer(lm, "test prompt", budget=2, return_response_only=False)
+
+        assert result.selected_index == 1
+        assert result.scores[0] == float("inf")
+
+    def test_infer_with_messages_input(self):
+        logprobs = _make_logprobs_content([0.1] * 100)
+        responses = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "_logprobs": {"content": logprobs},
+            }
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            tail_min=10, tail_max=500, orchestrator=LMOrchestrator()
+        )
+        messages = [{"role": "user", "content": "test"}]
+        result = algo.infer(lm, messages, budget=1, return_response_only=True)
+        assert result["content"] == "answer"
+
+    def test_usage_tracking(self):
+        logprobs = _make_logprobs_content([0.1] * 100)
+        responses = [
+            {
+                "role": "assistant",
+                "content": f"r{i}",
+                "_logprobs": {"content": logprobs},
+            }
+            for i in range(3)
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            tail_min=10, tail_max=500, orchestrator=LMOrchestrator()
+        )
+        result = algo.infer(lm, "test", budget=3, return_response_only=False)
+        assert result.usage is not None

--- a/tests/test_confidence_selection.py
+++ b/tests/test_confidence_selection.py
@@ -208,6 +208,17 @@ class TestSelectByTailEntropy:
         _, _, tail = select_by_tail_entropy(ept, tail_min=10, tail_max=500)
         assert 10 <= tail <= 500
 
+    def test_skips_empty_before_trimming(self):
+        ept = [[]] * 15 + [[0.1] * 100] + [[]] * 4
+        selected, scores, _tail = select_by_tail_entropy(ept, tail_min=10, tail_max=500)
+        assert selected == 15
+        assert scores[15] < float("inf")
+        assert all(s == float("inf") for i, s in enumerate(scores) if i != 15)
+
+    def test_all_empty_raises(self):
+        with pytest.raises(ValueError, match="No candidates have entropy data"):
+            select_by_tail_entropy([[], [], []])
+
 
 # ---------------------------------------------------------------------------
 # Integration tests: ConfidenceSelection algorithm
@@ -297,6 +308,39 @@ class TestConfidenceSelection:
 
         assert result.the_one["content"] == "has logprobs"
         assert float("inf") in result.scores
+
+    def test_infer_all_missing_logprobs_raises(self):
+        responses = [
+            {"role": "assistant", "content": "no logprobs 1"},
+            {"role": "assistant", "content": "no logprobs 2"},
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            tail_min=10, tail_max=500, orchestrator=LMOrchestrator()
+        )
+        with pytest.raises(ValueError, match="No candidates have entropy data"):
+            algo.infer(lm, "test prompt", budget=2)
+
+    def test_infer_16_responses_with_missing_logprobs(self):
+        good = _make_logprobs_content([0.1] * 100)
+        responses = [{"role": "assistant", "content": "no logprobs"}] * 15 + [
+            {
+                "role": "assistant",
+                "content": "has logprobs",
+                "_logprobs": {"content": good},
+            },
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            tail_min=10, tail_max=500, orchestrator=LMOrchestrator()
+        )
+        result = algo.infer(lm, "test prompt", budget=16, return_response_only=False)
+
+        assert result.the_one["content"] == "has logprobs"
+        non_inf = [s for s in result.scores if s != float("inf")]
+        assert len(non_inf) >= 1
 
     def test_infer_with_messages_input(self):
         logprobs = _make_logprobs_content([0.1] * 100)

--- a/tests/test_openai_compatible_language_model.py
+++ b/tests/test_openai_compatible_language_model.py
@@ -74,3 +74,29 @@ class TestRequestBodyKey:
         )
         assert data["max_completion_tokens"] == 200
         assert "max_tokens" not in data
+
+    def test_logprobs_params(self):
+        lm = OpenAICompatibleLanguageModel(
+            endpoint="http://localhost:8000/v1",
+            api_key="test",
+            model_name="test",
+        )
+        data = lm._prepare_request_data(
+            [ChatMessage(role="user", content="hi")],
+            logprobs=True,
+            top_logprobs=20,
+        )
+        assert data["logprobs"] is True
+        assert data["top_logprobs"] == 20
+
+    def test_logprobs_absent_by_default(self):
+        lm = OpenAICompatibleLanguageModel(
+            endpoint="http://localhost:8000/v1",
+            api_key="test",
+            model_name="test",
+        )
+        data = lm._prepare_request_data(
+            [ChatMessage(role="user", content="hi")],
+        )
+        assert "logprobs" not in data
+        assert "top_logprobs" not in data


### PR DESCRIPTION
## Summary

Adds `ConfidenceSelection`, a new scaling algorithm that selects the best-of-N response using the model's own token-level confidence — no external reward model required.

The algorithm generates N candidate responses with logprobs enabled, computes per-token Shannon entropy from the top-k log probabilities, then selects the candidate whose tail (final tokens) has the lowest aggregated entropy. Lower tail entropy at the conclusion of a response indicates the model was more confident about its answer, which empirically correlates with correctness across math, code, and QA benchmarks.

## Key design decisions

- **Entropy source**: Uses top-k logprobs returned natively by vLLM/OpenAI APIs (approximate but free — no extra model or forward pass needed).
- **Adaptive tail window**: The window size is computed as `clamp(sqrt(mean_len) / mean_entropy, 64, 2048)`, making it hyperparameter-free — it adapts automatically to both response length and model uncertainty.
- **Median aggregation**: Default aggregation over the tail window uses median rather than mean, which is robust to high-entropy spike tokens (transition words like "Therefore") that can corrupt the mean.
- **Length outlier trimming**: For batches of 16+ responses, excludes candidates outside the [5th, 95th] percentile length range to prevent degenerate responses from skewing selection.

## Changes

### Logprobs plumbing
- `its_hub/core/lms/openai_lm.py`: Added `logprobs` and `top_logprobs` parameters to `_prepare_request_data()`, `_agenerate()`, and `agenerate_single()`. When logprobs are present in the API response, they are attached to the response dict under `_logprobs`.
- `its_hub/core/orchestrator.py`: Added `logprobs` and `top_logprobs` parameters to `LMOrchestrator.agenerate()`, threaded to `lm.agenerate_single()`.
- These parameters are fully opt-in — existing algorithms are unaffected.

### New algorithm
- `its_hub/core/algorithms/confidence_selection.py`: Contains five pure selection functions (`compute_token_entropies`, `trim_length_outliers`, `adaptive_tail_window`, `tail_scores`, `select_by_tail_entropy`) and the `ConfidenceSelection` class implementing `AbstractScalingAlgorithm`.
- `its_hub/__init__.py`: Registered `ConfidenceSelection` in top-level exports.

### Tests
- `tests/test_confidence_selection.py`: 24 tests covering all pure functions (entropy computation, trimming, adaptive window, scoring, selection) and integration tests with a mock LM (selection correctness, missing logprobs handling, response-only mode, message input, usage tracking).

## Usage

```python
from its_hub import ConfidenceSelection

algo = ConfidenceSelection(
    top_logprobs=20,    # number of top logprobs to request (1-20)
    tail_min=64,        # minimum tail window size
    tail_max=2048,      # maximum tail window size
    agg="median",       # "median" or "mean"
)
result = algo.infer(lm, prompt, budget=32)
```

## Test plan

- [x] All 24 new tests pass (`uv run pytest tests/test_confidence_selection.py -v`)
- [x] Full test suite passes with no regressions (406 passed, 36 skipped, 3 pre-existing errors in unrelated e2e/proto modules)
- [x] Lint clean (`uv run ruff check its_hub/`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added confidence-based best-of-N response selection using token-level uncertainty.
  - Supports configurable scoring and adaptive analysis of response endings.
  - Added optional log probability data for compatible language model requests.
  - Selection results can include scores, the chosen response, and usage details.

- **Tests**
  - Added coverage for confidence scoring, response selection, configuration validation, missing log probabilities, and request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->