### PR TITLE
feat: Add self-certainty metric to ConfidenceSelection

### DIFF
--- a/its_hub/core/algorithms/confidence_selection.py
+++ b/its_hub/core/algorithms/confidence_selection.py
@@ -1,9 +1,12 @@
-"""ConfidenceSelection: select the best response by lowest tail entropy.
+"""ConfidenceSelection: select the best response by tail confidence metrics.
 
 Generates N candidate responses with logprobs enabled, computes per-token
-Shannon entropy from the top-k log probabilities, then selects the candidate
-whose tail (final portion) has the lowest aggregated entropy — indicating the
-model was most confident about its conclusion.
+confidence scores from the top-k log probabilities, then selects the candidate
+whose tail (final portion) shows the highest model confidence.
+
+Supports two metrics:
+- **entropy** (default): Shannon entropy; selects the *lowest* tail entropy.
+- **certainty**: KL(uniform || p_model); selects the *highest* tail certainty.
 """
 
 from __future__ import annotations
@@ -53,6 +56,40 @@ def compute_token_entropies(logprobs_content: list[dict]) -> list[float]:
     return entropies
 
 
+def compute_token_certainties(
+    logprobs_content: list[dict],
+    vocab_size: int | None = None,
+) -> list[float]:
+    """Compute per-token self-certainty from OpenAI-format logprobs.
+
+    Self-certainty is defined as ``KL(uniform || p_model)``:
+
+        certainty(t) = -log(V) - (1/V) * sum_v log p(v)
+
+    Higher values indicate a more peaked (decisive) distribution.
+
+    Args:
+        logprobs_content: The ``choice["logprobs"]["content"]`` list.
+        vocab_size: Vocabulary size *V* in the formula.  When *None*
+            (default), uses the number of top-k logprobs at each position.
+
+    Returns:
+        Per-token certainty values (nats).
+    """
+    certainties: list[float] = []
+    for token_info in logprobs_content:
+        top_lps = token_info.get("top_logprobs", [])
+        if not top_lps:
+            certainties.append(0.0)
+            continue
+        log_ps = np.array([t["logprob"] for t in top_lps])
+        v = vocab_size if vocab_size is not None else len(log_ps)
+        v = max(v, 1)
+        certainty = float(-np.log(v) - np.sum(log_ps) / v)
+        certainties.append(certainty)
+    return certainties
+
+
 def trim_length_outliers(
     lengths: list[int],
     trim_pct: float = 0.05,
@@ -99,21 +136,22 @@ def adaptive_tail_window(
 
 
 def tail_scores(
-    entropies_per_token: list[list[float]],
+    scores_per_token: list[list[float]],
     included: list[int],
     tail: int,
     agg: str = "median",
+    default_score: float = float("inf"),
 ) -> list[float]:
-    """Compute aggregated entropy over the tail window for each candidate."""
-    n = len(entropies_per_token)
+    """Compute aggregated score over the tail window for each candidate."""
+    n = len(scores_per_token)
     included_set = set(included)
     fn = np.median if agg == "median" else np.mean
     scores: list[float] = []
     for i in range(n):
-        if i not in included_set or not entropies_per_token[i]:
-            scores.append(float("inf"))
+        if i not in included_set or not scores_per_token[i]:
+            scores.append(default_score)
         else:
-            window = entropies_per_token[i][-tail:]
+            window = scores_per_token[i][-tail:]
             scores.append(float(fn(window)))
     return scores
 
@@ -153,6 +191,37 @@ def select_by_tail_entropy(
     return selected, scores, tail
 
 
+def select_by_tail_certainty(
+    certainties_per_token: list[list[float]],
+    tail_min: int = 64,
+    tail_max: int = 2048,
+    agg: str = "median",
+    trim_pct: float = 0.05,
+) -> tuple[int, list[float], int]:
+    """Select the response with highest tail certainty.
+
+    Same adaptive pipeline as :func:`select_by_tail_entropy` but picks by
+    **argmax** (higher certainty = more peaked distribution = more confident).
+
+    Returns:
+        ``(selected_index, scores, tail_window)``
+    """
+    usable = [i for i, c in enumerate(certainties_per_token) if c]
+    if not usable:
+        raise ValueError("No candidates have certainty data; cannot select.")
+
+    usable_lengths = [len(certainties_per_token[i]) for i in usable]
+    trimmed_usable = trim_length_outliers(usable_lengths, trim_pct)
+    included = [usable[j] for j in trimmed_usable]
+
+    tail = adaptive_tail_window(certainties_per_token, included, tail_min, tail_max)
+    scores = tail_scores(
+        certainties_per_token, included, tail, agg, default_score=float("-inf")
+    )
+    selected = int(np.argmax(scores))
+    return selected, scores, tail
+
+
 # ---------------------------------------------------------------------------
 # Algorithm class
 # ---------------------------------------------------------------------------
@@ -172,12 +241,15 @@ class ConfidenceSelectionResult(AbstractScalingResult):
 
 
 class ConfidenceSelection(AbstractScalingAlgorithm):
-    """Select the best-of-N response by lowest tail entropy.
+    """Select the best-of-N response by tail confidence metrics.
 
     Generates *budget* candidate responses with token-level logprobs,
-    computes per-token Shannon entropy from the top-k log probabilities,
-    then picks the candidate whose tail (final tokens) has the lowest
-    aggregated entropy — the response where the model was most confident.
+    computes per-token confidence scores, then picks the most confident
+    candidate based on the chosen metric:
+
+    - ``"entropy"`` (default): selects **lowest** tail entropy.
+    - ``"certainty"``: selects **highest** tail certainty
+      (KL divergence from uniform).
 
     No external reward model is required.
     """
@@ -189,18 +261,26 @@ class ConfidenceSelection(AbstractScalingAlgorithm):
         tail_max: int = 2048,
         agg: str = "median",
         trim_pct: float = 0.05,
+        metric: str = "entropy",
+        vocab_size: int | None = None,
         orchestrator: AbstractOrchestrator | None = None,
     ):
         if agg not in ("median", "mean"):
             raise ValueError(f"agg must be 'median' or 'mean', got: {agg!r}")
         if not 1 <= top_logprobs <= 20:
             raise ValueError(f"top_logprobs must be 1-20, got: {top_logprobs}")
+        if metric not in ("entropy", "certainty"):
+            raise ValueError(
+                f"metric must be 'entropy' or 'certainty', got: {metric!r}"
+            )
 
         self.top_logprobs = top_logprobs
         self.tail_min = tail_min
         self.tail_max = tail_max
         self.agg = agg
         self.trim_pct = trim_pct
+        self.metric = metric
+        self.vocab_size = vocab_size
 
         if orchestrator is None:
             orchestrator = LMOrchestrator()
@@ -230,19 +310,34 @@ class ConfidenceSelection(AbstractScalingAlgorithm):
             top_logprobs=self.top_logprobs,
         )
 
-        entropies_per_token: list[list[float]] = []
+        use_certainty = self.metric == "certainty"
+        if use_certainty:
+
+            def score_fn(content: list[dict]) -> list[float]:
+                return compute_token_certainties(content, self.vocab_size)
+
+            select_fn = select_by_tail_certainty
+            label = "certainty"
+        else:
+            score_fn = compute_token_entropies
+            select_fn = select_by_tail_entropy
+            label = "entropy"
+
+        scores_per_token: list[list[float]] = []
         for i, resp in enumerate(responses):
             lp = resp.get("_logprobs")
             if lp is not None and lp.get("content"):
-                entropies_per_token.append(compute_token_entropies(lp["content"]))
+                scores_per_token.append(score_fn(lp["content"]))
             else:
                 logging.warning(
-                    "Response %d has no logprobs data; assigning infinite entropy", i
+                    "Response %d has no logprobs data; excluded from %s selection",
+                    i,
+                    label,
                 )
-                entropies_per_token.append([])
+                scores_per_token.append([])
 
-        selected_index, scores, tail_window = select_by_tail_entropy(
-            entropies_per_token,
+        selected_index, scores, tail_window = select_fn(
+            scores_per_token,
             tail_min=self.tail_min,
             tail_max=self.tail_max,
             agg=self.agg,

--- a/tests/test_confidence_selection.py
+++ b/tests/test_confidence_selection.py
@@ -8,7 +8,9 @@ from its_hub.core.algorithms.confidence_selection import (
     ConfidenceSelection,
     ConfidenceSelectionResult,
     adaptive_tail_window,
+    compute_token_certainties,
     compute_token_entropies,
+    select_by_tail_certainty,
     select_by_tail_entropy,
     tail_scores,
     trim_length_outliers,
@@ -393,3 +395,245 @@ class TestConfidenceSelection:
         )
         result = algo.infer(lm, "test", budget=3, return_response_only=False)
         assert result.usage is not None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: compute_token_certainties
+# ---------------------------------------------------------------------------
+
+
+def _make_certainty_logprobs(logprobs_per_token: list[list[float]]) -> list[dict]:
+    """Build OpenAI-format logprobs content from raw logprob lists."""
+    content = []
+    for lps in logprobs_per_token:
+        content.append(
+            {
+                "top_logprobs": [
+                    {"token": f"t{j}", "logprob": lp} for j, lp in enumerate(lps)
+                ]
+            }
+        )
+    return content
+
+
+class TestComputeTokenCertainties:
+    def test_uniform_gives_zero(self):
+        lp = float(np.log(0.5))
+        content = _make_certainty_logprobs([[lp, lp]])
+        result = compute_token_certainties(content)
+        assert len(result) == 1
+        assert result[0] == pytest.approx(0.0, abs=1e-6)
+
+    def test_peaked_gives_positive(self):
+        content = _make_certainty_logprobs([[np.log(0.99), np.log(0.01)]])
+        result = compute_token_certainties(content)
+        assert result[0] > 0
+
+    def test_more_peaked_gives_higher_certainty(self):
+        mild = _make_certainty_logprobs([[np.log(0.7), np.log(0.3)]])
+        strong = _make_certainty_logprobs([[np.log(0.99), np.log(0.01)]])
+        assert compute_token_certainties(strong)[0] > compute_token_certainties(mild)[0]
+
+    def test_single_token(self):
+        content = _make_certainty_logprobs([[0.0]])
+        result = compute_token_certainties(content)
+        assert result[0] == pytest.approx(0.0, abs=1e-6)
+
+    def test_empty_top_logprobs(self):
+        content = [{"top_logprobs": []}]
+        result = compute_token_certainties(content)
+        assert result[0] == 0.0
+
+    def test_empty_input(self):
+        assert compute_token_certainties([]) == []
+
+    def test_multiple_tokens(self):
+        content = _make_certainty_logprobs(
+            [[np.log(0.9), np.log(0.1)]] * 5
+        )
+        result = compute_token_certainties(content)
+        assert len(result) == 5
+        assert all(c > 0 for c in result)
+
+    def test_explicit_vocab_size(self):
+        content = _make_certainty_logprobs([[np.log(0.9), np.log(0.1)]])
+        default_v = compute_token_certainties(content)
+        large_v = compute_token_certainties(content, vocab_size=32000)
+        assert default_v[0] != pytest.approx(large_v[0], abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: select_by_tail_certainty
+# ---------------------------------------------------------------------------
+
+
+class TestSelectByTailCertainty:
+    def test_selects_highest_certainty(self):
+        high = [2.0] * 200
+        mid = [0.5] * 200
+        low = [0.01] * 200
+        selected, scores, _tail = select_by_tail_certainty(
+            [low, high, mid], tail_min=10, tail_max=500
+        )
+        assert selected == 1
+        assert scores[1] > scores[0]
+        assert scores[1] > scores[2]
+
+    def test_single_response(self):
+        selected, _scores, _tail = select_by_tail_certainty(
+            [[1.0] * 100], tail_min=10, tail_max=500
+        )
+        assert selected == 0
+
+    def test_returns_tail_window(self):
+        cpt = [[0.5] * 200 for _ in range(4)]
+        _, _, tail = select_by_tail_certainty(cpt, tail_min=10, tail_max=500)
+        assert 10 <= tail <= 500
+
+    def test_excluded_gets_neg_inf(self):
+        cpt = [[1.0] * 200, [], [0.5] * 200]
+        _, scores, _ = select_by_tail_certainty(cpt, tail_min=10, tail_max=500)
+        assert scores[1] == float("-inf")
+
+    def test_all_empty_raises(self):
+        with pytest.raises(ValueError, match="No candidates have certainty data"):
+            select_by_tail_certainty([[], [], []])
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: ConfidenceSelection with metric="certainty"
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceSelectionCertainty:
+    def test_constructor_validates_metric(self):
+        with pytest.raises(ValueError, match="metric"):
+            ConfidenceSelection(metric="invalid")
+
+    def test_certainty_selects_most_peaked(self):
+        peaked_logprobs = _make_certainty_logprobs(
+            [[np.log(0.99), np.log(0.01)]] * 200
+        )
+        flat_logprobs = _make_certainty_logprobs(
+            [[np.log(0.55), np.log(0.45)]] * 200
+        )
+
+        responses = [
+            {
+                "role": "assistant",
+                "content": "flat answer",
+                "_logprobs": {"content": flat_logprobs},
+            },
+            {
+                "role": "assistant",
+                "content": "peaked answer",
+                "_logprobs": {"content": peaked_logprobs},
+            },
+            {
+                "role": "assistant",
+                "content": "another flat",
+                "_logprobs": {"content": flat_logprobs},
+            },
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            metric="certainty",
+            tail_min=10,
+            tail_max=500,
+            orchestrator=LMOrchestrator(),
+        )
+        result = algo.infer(lm, "test prompt", budget=3, return_response_only=False)
+
+        assert isinstance(result, ConfidenceSelectionResult)
+        assert result.the_one["content"] == "peaked answer"
+        assert result.scores[result.selected_index] == max(result.scores)
+
+    def test_certainty_response_only(self):
+        logprobs = _make_certainty_logprobs([[np.log(0.9), np.log(0.1)]] * 100)
+        responses = [
+            {
+                "role": "assistant",
+                "content": f"r{i}",
+                "_logprobs": {"content": logprobs},
+            }
+            for i in range(3)
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            metric="certainty",
+            tail_min=10,
+            tail_max=500,
+            orchestrator=LMOrchestrator(),
+        )
+        result = algo.infer(lm, "test prompt", budget=3, return_response_only=True)
+        assert isinstance(result, dict)
+        assert "content" in result
+
+    def test_certainty_handles_missing_logprobs(self):
+        good = _make_certainty_logprobs([[np.log(0.9), np.log(0.1)]] * 100)
+        responses = [
+            {"role": "assistant", "content": "no logprobs"},
+            {
+                "role": "assistant",
+                "content": "has logprobs",
+                "_logprobs": {"content": good},
+            },
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            metric="certainty",
+            tail_min=10,
+            tail_max=500,
+            orchestrator=LMOrchestrator(),
+        )
+        result = algo.infer(lm, "test prompt", budget=2, return_response_only=False)
+        assert result.the_one["content"] == "has logprobs"
+        assert float("-inf") in result.scores
+
+    def test_certainty_with_vocab_size(self):
+        logprobs = _make_certainty_logprobs([[np.log(0.9), np.log(0.1)]] * 100)
+        responses = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "_logprobs": {"content": logprobs},
+            }
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            metric="certainty",
+            vocab_size=32000,
+            tail_min=10,
+            tail_max=500,
+            orchestrator=LMOrchestrator(),
+        )
+        result = algo.infer(lm, "test", budget=1, return_response_only=False)
+        assert result.the_one["content"] == "answer"
+
+    def test_entropy_default_unchanged(self):
+        low_entropy_logprobs = _make_logprobs_content([0.01] * 200)
+        high_entropy_logprobs = _make_logprobs_content([1.0] * 200)
+        responses = [
+            {
+                "role": "assistant",
+                "content": "high entropy",
+                "_logprobs": {"content": high_entropy_logprobs},
+            },
+            {
+                "role": "assistant",
+                "content": "low entropy",
+                "_logprobs": {"content": low_entropy_logprobs},
+            },
+        ]
+
+        lm = LogprobsMockLM(responses)
+        algo = ConfidenceSelection(
+            tail_min=10, tail_max=500, orchestrator=LMOrchestrator()
+        )
+        result = algo.infer(lm, "test", budget=2, return_response_only=False)
+        assert result.the_one["content"] == "low entropy"
+        assert algo.metric == "entropy"


### PR DESCRIPTION
## Summary

Adds self-certainty (KL divergence from uniform) as an alternative confidence metric alongside tail entropy in `ConfidenceSelection`. Users can now choose between two complementary metrics via `metric="entropy"` (default) or `metric="certainty"`.

- Self-certainty measures how far the model's output distribution is from maximum uncertainty (uniform), defined as `KL(uniform || p_model) = -log(V) - (1/V) * sum_v log p(v)`
- Higher certainty means the distribution is more peaked (model is more decisive); selection picks by **argmax** instead of argmin
- The adaptive tail window, trimming, and aggregation pipeline remain unchanged

## Changes

### New pure function
- `compute_token_certainties(logprobs_content, vocab_size)` — computes per-token self-certainty from top-k logprobs. When `vocab_size` is None (default), uses the number of observed top-k logprobs at each position.

### New selection function
- `select_by_tail_certainty()` — same adaptive pipeline as `select_by_tail_entropy` but selects by argmax (highest certainty) and uses `-inf` as the sentinel for excluded candidates.

### Updated `tail_scores`
- Added `default_score` parameter (defaults to `float("inf")` for backward compatibility). Certainty selection passes `float("-inf")` so excluded candidates are never selected by argmax.

### Updated `ConfidenceSelection` class
- New `metric` parameter: `"entropy"` (default) or `"certainty"`.
- New `vocab_size` parameter: optional vocabulary size for the certainty formula.
- `ainfer()` dispatches to the appropriate scoring and selection functions based on `metric`.

### Tests
- 19 new tests (48 total, all pass):
  - 8 unit tests for `compute_token_certainties` (uniform=zero, peaked=positive, monotonicity, single token, empty inputs, explicit vocab_size)
  - 5 unit tests for `select_by_tail_certainty` (argmax selection, single response, tail window bounds, `-inf` sentinel, empty raises)
  - 6 integration tests for `ConfidenceSelection(metric="certainty")` (selects most peaked, response-only mode, missing logprobs handling, vocab_size passthrough, entropy default unchanged)

## Usage

```python
from its_hub import ConfidenceSelection

algo = ConfidenceSelection(metric="certainty", agg="median")
result = algo.infer(lm, prompt, budget=32)
```

## Test plan

- [x] All 48 confidence selection tests pass (`uv run pytest tests/test_confidence_selection.py -v`)
- [x] Full test suite passes with no regressions (432 passed, 36 skipped, 3 pre-existing errors in unrelated e2e/proto modules)
- [x] Lint clean (`uv run ruff check its_hub/ tests/test_confidence_selection.py`)
