### PR TITLE
fix(release): publish unique dev versions to Test PyPI on main

### DIFF
--- a/.github/actions/set-dev-version/action.yml
+++ b/.github/actions/set-dev-version/action.yml
@@ -25,6 +25,10 @@ runs:
         # grep (not rg) because ripgrep isn't installed on the CI runners here.
         base=$(grep -m1 '^version = ' rust/Cargo.toml | sed -E 's/.*"(.*)".*/\1/')
         dev="${base}-dev.$(git rev-list --count HEAD)"
-        sed -i -E "0,/^version = .*/s//version = \"${dev}\"/" rust/Cargo.toml
-        sed -i -E "/^name = \"its_hub_rust\"/{n;s/^version = .*/version = \"${dev}\"/}" rust/Cargo.lock
+        # perl -i (not sed -i) so this works on both the GNU (Linux) and BSD
+        # (macOS) runners; macOS sed rejects the address/grouping forms below.
+        # Cargo.toml has a single top-level version; Cargo.lock has many, so
+        # target only the its_hub_rust entry.
+        perl -i -pe 's/^version = .*/version = "'"${dev}"'"/' rust/Cargo.toml
+        perl -0777 -i -pe 's/(name = "its_hub_rust"\nversion = )"[^"]*"/${1}"'"${dev}"'"/' rust/Cargo.lock
         echo "Set dev version: ${dev}"

--- a/.github/actions/set-dev-version/action.yml
+++ b/.github/actions/set-dev-version/action.yml
@@ -22,7 +22,8 @@ runs:
         # commit; base off rust/Cargo.toml (already the next release version).
         # Cargo requires SemVer, so the pre-release is written as "-dev.N";
         # maturin maps that to the PEP 440 "<base>.devN" the wheels ship as.
-        base=$(rg -m1 '^version = ' rust/Cargo.toml | sed -E 's/.*"(.*)".*/\1/')
+        # grep (not rg) because ripgrep isn't installed on the CI runners here.
+        base=$(grep -m1 '^version = ' rust/Cargo.toml | sed -E 's/.*"(.*)".*/\1/')
         dev="${base}-dev.$(git rev-list --count HEAD)"
         sed -i -E "0,/^version = .*/s//version = \"${dev}\"/" rust/Cargo.toml
         sed -i -E "/^name = \"its_hub_rust\"/{n;s/^version = .*/version = \"${dev}\"/}" rust/Cargo.lock

--- a/.github/actions/set-dev-version/action.yml
+++ b/.github/actions/set-dev-version/action.yml
@@ -20,7 +20,7 @@ runs:
         fi
         # rev-list --count is a monotonic commit counter, so devN is unique per
         # commit; base off rust/Cargo.toml (already the next release version).
-        base=$(grep -m1 '^version = ' rust/Cargo.toml | sed -E 's/.*"(.*)".*/\1/')
+        base=$(rg -m1 '^version = ' rust/Cargo.toml | sed -E 's/.*"(.*)".*/\1/')
         dev="${base}.dev$(git rev-list --count HEAD)"
         sed -i -E "0,/^version = .*/s//version = \"${dev}\"/" rust/Cargo.toml
         sed -i -E "/^name = \"its_hub_rust\"/{n;s/^version = .*/version = \"${dev}\"/}" rust/Cargo.lock

--- a/.github/actions/set-dev-version/action.yml
+++ b/.github/actions/set-dev-version/action.yml
@@ -20,8 +20,10 @@ runs:
         fi
         # rev-list --count is a monotonic commit counter, so devN is unique per
         # commit; base off rust/Cargo.toml (already the next release version).
+        # Cargo requires SemVer, so the pre-release is written as "-dev.N";
+        # maturin maps that to the PEP 440 "<base>.devN" the wheels ship as.
         base=$(rg -m1 '^version = ' rust/Cargo.toml | sed -E 's/.*"(.*)".*/\1/')
-        dev="${base}.dev$(git rev-list --count HEAD)"
+        dev="${base}-dev.$(git rev-list --count HEAD)"
         sed -i -E "0,/^version = .*/s//version = \"${dev}\"/" rust/Cargo.toml
         sed -i -E "/^name = \"its_hub_rust\"/{n;s/^version = .*/version = \"${dev}\"/}" rust/Cargo.lock
         echo "Set dev version: ${dev}"

--- a/.github/actions/set-dev-version/action.yml
+++ b/.github/actions/set-dev-version/action.yml
@@ -1,0 +1,27 @@
+name: Set dev version
+description: On main pushes, stamp a unique PEP 440 dev version so every Test PyPI upload is a brand-new release.
+
+# Test PyPI releases are write-once: republishing the same static version on
+# every push to main collides with the existing file, and once that release is
+# more than 14 days old the upload is rejected outright. To avoid both, we stamp
+# each main build with a unique <base>.devN version (the PyPA/setuptools-scm
+# convention) so every upload is a brand-new release. Tag builds keep their
+# static version so real releases stay clean.
+# Ref: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+          echo "Tag build (${GITHUB_REF}); keeping the static version."
+          exit 0
+        fi
+        # rev-list --count is a monotonic commit counter, so devN is unique per
+        # commit; base off rust/Cargo.toml (already the next release version).
+        base=$(grep -m1 '^version = ' rust/Cargo.toml | sed -E 's/.*"(.*)".*/\1/')
+        dev="${base}.dev$(git rev-list --count HEAD)"
+        sed -i -E "0,/^version = .*/s//version = \"${dev}\"/" rust/Cargo.toml
+        sed -i -E "/^name = \"its_hub_rust\"/{n;s/^version = .*/version = \"${dev}\"/}" rust/Cargo.lock
+        echo "Set dev version: ${dev}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,6 +61,9 @@ jobs:
             - name: "Compile Envoy proto files"
               uses: ./.github/actions/compile-protos
 
+            - name: "Set dev version"
+              uses: ./.github/actions/set-dev-version
+
             - name: "Build sdist"
               uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
               with:
@@ -106,6 +109,9 @@ jobs:
 
             - name: "Compile Envoy proto files"
               uses: ./.github/actions/compile-protos
+
+            - name: "Set dev version"
+              uses: ./.github/actions/set-dev-version
 
             - name: "Build wheels"
               uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
@@ -171,6 +177,9 @@ jobs:
             # wheels would carry them.
             - name: "Compile Envoy proto files"
               uses: ./.github/actions/compile-protos
+
+            - name: "Set dev version"
+              uses: ./.github/actions/set-dev-version
 
             - name: "Build wheels"
               uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
@@ -259,6 +268,10 @@ jobs:
               uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
               with:
                   repository-url: https://test.pypi.org/legacy/
+                  # dev versions already keep each version unique; this only
+                  # matters when the workflow is re-run on the same commit and
+                  # some files from the earlier attempt already uploaded.
+                  skip-existing: true
 
     # push to Production PyPI on
     # - a new GitHub release is published

--- a/docs/development.md
+++ b/docs/development.md
@@ -463,16 +463,36 @@ The package version comes from `rust/Cargo.toml` (maturin reads it from there):
 version = "0.2.0"
 ```
 
+This value is the **next unreleased version** — it should always be one step
+ahead of the latest published release. Bump it as soon as you cut a release so
+`main` starts building dev versions toward the next one (see below).
+
+### Dev versions on `main`
+
+Every push to `main` publishes to Test PyPI. Because (Test) PyPI releases are
+write-once, the `set-dev-version` composite action rewrites the version to a
+unique `<version>.devN` (where `N` is the commit count) before each build on
+`main`, so every upload is a brand-new release and never collides or hits Test
+PyPI's "no new files on releases older than 14 days" rule. Tag builds skip this
+step and use the static `rust/Cargo.toml` version as-is.
+
+So with `version = "1.2.1"` in `Cargo.toml`, merges to `main` publish
+`1.2.1.dev1`, `1.2.1.dev2`, … to Test PyPI, and tagging `v1.2.1` publishes the
+clean `1.2.1` to PyPI.
+
 ### Creating Releases
 
-1. Update the version in `rust/Cargo.toml`
+1. Make sure `rust/Cargo.toml` holds the exact version you're releasing (it
+   should already, since it tracks the next unreleased version)
 2. Update CHANGELOG.md
-3. Create git tag: `git tag -a v0.2.0 -m "Release v0.2.0"`
-4. Push tag: `git push origin v0.2.0`
+3. Create git tag: `git tag -a v1.2.1 -m "Release v1.2.1"`
+4. Push tag: `git push origin v1.2.1` (or publish a GitHub Release)
 5. GitHub Actions will handle PyPI publishing
+6. Bump `rust/Cargo.toml` to the next version (e.g. `1.2.2`) and merge to `main`
+   so dev builds move on to `1.2.2.devN`
 
 > The release workflow's `check-version` job fails the build if the release tag
-> (e.g. `v0.2.0`) doesn't match the version in `rust/Cargo.toml`, so keep the two
+> (e.g. `v1.2.1`) doesn't match the version in `rust/Cargo.toml`, so keep the two
 > in sync when bumping.
 
 ## Contributing

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "its_hub_rust"
-version = "1.1.0"
+version = "1.2.1"
 dependencies = [
  "futures-util",
  "pyo3",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "its_hub_rust"
-version = "1.1.0"
+# This is the next, unreleased version. Every push to main publishes a
+# <version>.devN build to Test PyPI, so it must stay one step ahead of the
+# latest released version. Bump it whenever you cut a release.
+version = "1.2.1"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## Problem

The **Build, test, and upload PyPI package** workflow fails on every merge to `main`. The `publish-test-pypi` job dies at the upload step with:

```
400 Uploading new files to releases older than 14 days is not allowed.
```

Root cause: the package version is static (`rust/Cargo.toml`), but the workflow republishes to Test PyPI on every merge. Test PyPI releases are write-once, so after the first upload every subsequent merge collides — and once that release is older than 14 days, Test PyPI rejects it outright. There was also drift between the `v1.2.0` tag and the `1.1.0` version in `Cargo.toml`.

## Fix

Adopt the PyPA / setuptools-scm pattern: stamp every `main` build with a unique `<base>.devN` version so each upload is a brand-new release that can never collide or hit the 14-day rule. This also restores the project's own historical pattern (Test PyPI already carries many `.devN` releases).

- **`.github/actions/set-dev-version`** (new composite action): on non-tag builds, rewrites the version in `Cargo.toml`/`Cargo.lock` to `<base>.dev<N>`, where `N = git rev-list --count HEAD` (monotonic → always unique). Tag builds keep the static version.
- **`release.yaml`**: runs the action before the build in all three build jobs (sdist, linux, macOS); adds `skip-existing: true` on the Test PyPI upload as a safety net.
- **Version**: base bumped `1.1.0 → 1.2.1` (next release after the `v1.2.0` tag), so dev builds sort *after* the published `1.2.0`.

## Result

- **Merge to `main`** → publishes `1.2.1.dev<N>` → always fresh, so CI stays green indefinitely.
- **Tag `v1.2.1`** → static `1.2.1` published to real PyPI; the existing `check-version` job still enforces tag == `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Management**
  - Development builds now receive unique `.devN` versions, while tagged releases retain their static versions.
  - The package version has been updated to 1.2.1.
  - Test package publishing now continues when a version already exists, reducing unnecessary release failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->