### PR TITLE
fix: include LICENSE in sdist so Test PyPI accepts the upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ features = ["extension-module"]
 # Data files and the generated proto package (produced by `make proto-compile`,
 # gitignored) must be listed explicitly so maturin ships them in the wheel/sdist.
 include = [
+    "LICENSE", # we need to explicitly list the license because pypi requires it but maturin omits it in sdist
     "its_hub/integration/ext_proc/envoy_config.yaml",
     "its_hub/integration/iaas/envoy_config.yaml",
     "its_hub/integration/proto/**/*.py",


### PR DESCRIPTION
maturin declares `License-File: LICENSE` in the sdist metadata but doesn't bundle the file, so Test PyPI rejects the sdist (Metadata 2.4). The 12 wheels upload fine — only the sdist 400s. Fix: list `LICENSE` in `[tool.maturin] include`.

Surfaced only after #279 fixed the 14-day collision; before that, every file died on the 14-day wall first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Source distributions now include the project license file.
  * Test package uploads safely skip artifacts that already exist.

* **Chores**
  * Development version metadata is updated consistently when building Linux and macOS packages.
  * Test package publishing now also runs for the relevant pull request workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->