### PR TITLE
feat(iaas): add adaptive & beta self-consistency to the gateway

### DIFF
--- a/docs/iaas-service.md
+++ b/docs/iaas-service.md
@@ -4,7 +4,7 @@ This guide provides comprehensive instructions for setting up and running the it
 
 ## Overview
 
-The IaaS service provides an OpenAI-compatible API with inference-time scaling algorithms. **Optimized for tool-calling applications** including agents, function calling, and multi-step reasoning. Currently supports **Self-Consistency**, with **Best-of-N** coming soon.
+The IaaS service provides an OpenAI-compatible API with inference-time scaling algorithms. **Optimized for tool-calling applications** including agents, function calling, and multi-step reasoning. Currently supports the **Self-Consistency** family — plain **Self-Consistency** plus the adaptive-stopping variants **Adaptive Self-Consistency** and **Beta Self-Consistency** — with **Best-of-N** coming soon.
 
 ### Architecture
 
@@ -40,8 +40,22 @@ ext_proc routing but are also accepted on the standalone IaaS endpoint.
 ### Algorithm Selection
 
 The algorithm is configured globally via `POST /configure` with the `alg` field.
-Per-request algorithm selection is not supported. Currently only `self-consistency` is
-available through the gateway.
+Per-request algorithm selection is not supported. The following algorithms are available
+through the gateway:
+
+| `alg` | Description | Early-stopping option |
+|---|---|---|
+| `self-consistency` | Generate `budget` responses, vote for the most common answer | — |
+| `adaptive-self-consistency` | Sample in doubling rounds (2 → 4 → …), stop once a supermajority agrees | `threshold` (vote share, default `0.75`) |
+| `beta-self-consistency` | Fire up to `budget` samples concurrently, stop once the Beta posterior is confident in the leader | `confidence_threshold` (posterior probability, default `0.95`) |
+
+All three share the same voting surface (`regex_patterns` / `tool_vote`); the adaptive
+variants only differ in *when they stop sampling*, treating `budget` as a maximum.
+
+Neither `regex_patterns` nor `tool_vote` is required. By default the family votes on
+tool calls using the `tool_hierarchical` strategy, and text responses fall back to
+exact-content matching. Supply `regex_patterns` to vote on extracted text answers, or
+set `tool_vote` to pick a different tool-voting strategy.
 
 ## API Key Handling
 
@@ -104,9 +118,54 @@ curl -X POST http://localhost:8109/configure \
 ```
 
 **Parameters:**
-- `regex_patterns`: Required for self-consistency — each pattern needs a capturing group that extracts the answer to vote on (used for text responses; tool responses vote via `tool_vote`)
+- `regex_patterns`: Each pattern needs a capturing group that extracts the answer to vote on (used for text responses; tool responses vote via `tool_vote`). Optional: if omitted, text responses fall back to exact-content matching, which rarely agrees on free-form output — supply a pattern whenever you want meaningful voting over text answers.
 - `tool_vote`: Voting strategy - `"tool_name"`, `"tool_args"`, or `"tool_hierarchical"` (recommended)
 - `exclude_tool_args`: List of argument names to exclude from voting (e.g., timestamps, IDs)
+
+---
+
+### Adaptive & Beta Self-Consistency
+
+Best for: reducing average generation cost when many prompts reach agreement well before
+the full `budget` is spent. Both variants accept the same `regex_patterns` / `tool_vote` /
+`exclude_tool_args` options as plain self-consistency, treat `budget` as a **maximum**, and
+add a single early-stopping knob.
+
+Adaptive self-consistency samples in doubling rounds and stops when the leading answer's
+vote share reaches `threshold`:
+
+```bash
+curl -X POST http://localhost:8109/configure \
+  -H "Content-Type: application/json" \
+  -d '{
+    "endpoint": "https://api.openai.com/v1",
+    "api_key": "your-openai-api-key",
+    "model": "gpt-4o-mini",
+    "alg": "adaptive-self-consistency",
+    "tool_vote": "tool_hierarchical",
+    "threshold": 0.75
+  }'
+```
+
+Beta self-consistency fires samples concurrently and stops once the Beta posterior
+probability that the leader is the true majority reaches `confidence_threshold`:
+
+```bash
+curl -X POST http://localhost:8109/configure \
+  -H "Content-Type: application/json" \
+  -d '{
+    "endpoint": "https://api.openai.com/v1",
+    "api_key": "your-openai-api-key",
+    "model": "gpt-4o-mini",
+    "alg": "beta-self-consistency",
+    "tool_vote": "tool_hierarchical",
+    "confidence_threshold": 0.95
+  }'
+```
+
+**Parameters:**
+- `threshold`: (adaptive only) supermajority vote-share cutoff in `(0.5, 1.0]`, default `0.75`. Omit to use the default.
+- `confidence_threshold`: (beta only) Beta posterior probability cutoff in `(0.5, 1.0]`, default `0.95`. Omit to use the default.
 
 ---
 

--- a/its_hub/core/algorithms/adaptive_self_consistency.py
+++ b/its_hub/core/algorithms/adaptive_self_consistency.py
@@ -10,6 +10,7 @@ from its_hub.api import (
     GenerationUsage,
 )
 from its_hub.core.algorithms.self_consistency import (
+    DEFAULT_TOOL_VOTE,
     SelfConsistency,
     SelfConsistencyResult,
 )
@@ -32,7 +33,7 @@ class AdaptiveSelfConsistency(SelfConsistency):
         self,
         threshold: float = 0.75,
         consistency_space_projection_func: Callable | None = None,
-        tool_vote: str | None = None,
+        tool_vote: str | None = DEFAULT_TOOL_VOTE,
         exclude_args: list[str] | None = None,
         orchestrator: AbstractOrchestrator | None = None,
     ):

--- a/its_hub/core/algorithms/beta_self_consistency.py
+++ b/its_hub/core/algorithms/beta_self_consistency.py
@@ -12,6 +12,7 @@ from its_hub.api import (
     GenerationUsage,
 )
 from its_hub.core.algorithms.self_consistency import (
+    DEFAULT_TOOL_VOTE,
     SelfConsistency,
     SelfConsistencyResult,
 )
@@ -48,7 +49,7 @@ class BetaSelfConsistency(SelfConsistency):
         self,
         confidence_threshold: float = 0.95,
         consistency_space_projection_func: Callable | None = None,
-        tool_vote: str | None = None,
+        tool_vote: str | None = DEFAULT_TOOL_VOTE,
         exclude_args: list[str] | None = None,
         orchestrator: AbstractOrchestrator | None = None,
     ):

--- a/its_hub/core/algorithms/self_consistency.py
+++ b/its_hub/core/algorithms/self_consistency.py
@@ -19,6 +19,12 @@ from its_hub.api import (
 from its_hub.core.orchestrator import LMOrchestrator
 from its_hub.core.utils import extract_content_from_lm_response
 
+# Default tool-call voting strategy for the self-consistency family. Chosen so
+# that responses containing tool calls vote sensibly out of the box (the primary
+# use case for the IaaS gateway). Pass tool_vote=None to force content-only
+# voting, which raises if every response is a tool call.
+DEFAULT_TOOL_VOTE = "tool_hierarchical"
+
 
 def _default_projection_func(response: str) -> str:
     """Default projection function that uses exact content matching.
@@ -130,7 +136,7 @@ class SelfConsistency(AbstractScalingAlgorithm):
     def __init__(
         self,
         consistency_space_projection_func: Callable | None = None,
-        tool_vote: str | None = None,
+        tool_vote: str | None = DEFAULT_TOOL_VOTE,
         exclude_args: list[str] | None = None,
         orchestrator: AbstractOrchestrator | None = None,
     ):
@@ -142,10 +148,12 @@ class SelfConsistency(AbstractScalingAlgorithm):
                 responses don't contain tool calls. Can return str, tuple, or any hashable type.
 
             tool_vote: Tool voting strategy when responses contain tool calls. Options:
-                - None (default): Vote on message content using consistency_space_projection_func
+                - "tool_hierarchical" (default): Vote on tool name first, then arguments
+                - None: Vote on message content using consistency_space_projection_func;
+                  used when no tool calls are present, or to force content-only voting.
+                  Raises at inference time if every response is a tool call.
                 - "tool_name": Vote on tool function names only
                 - "tool_args": Vote on tool function arguments only (as dicts)
-                - "tool_hierarchical": Vote on tool name first, then arguments (hierarchical)
                 - "tool_flat_all": Vote on ALL tool calls combined as a flat sorted signature.
                   Unlike other modes which only consider the first tool call, this creates a
                   single signature from all tool calls in a response. Two responses calling

--- a/its_hub/core/gateway.py
+++ b/its_hub/core/gateway.py
@@ -19,6 +19,8 @@ from its_hub.api import (
     GenerationUsage,
     ITSRequestConfig,
 )
+from its_hub.core.algorithms.adaptive_self_consistency import AdaptiveSelfConsistency
+from its_hub.core.algorithms.beta_self_consistency import BetaSelfConsistency
 from its_hub.core.algorithms.self_consistency import (
     SelfConsistency,
     create_regex_projection_function,
@@ -29,7 +31,18 @@ from its_hub.core.orchestrator import LMOrchestrator
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_ALGORITHMS = frozenset({"self-consistency"})
+# The self-consistency family shares the same voting surface (regex/tool-vote
+# projection) and only differs in how it decides when to stop sampling.
+SELF_CONSISTENCY_ALGORITHMS = frozenset(
+    {
+        "self-consistency",
+        "adaptive-self-consistency",
+        "beta-self-consistency",
+    }
+)
+
+# All currently supported algorithms are self-consistency variants.
+SUPPORTED_ALGORITHMS = SELF_CONSISTENCY_ALGORITHMS
 
 
 class ITSGateway(AbstractGateway):
@@ -85,8 +98,14 @@ class ITSGateway(AbstractGateway):
         regex_patterns: list[str] | None = None,
         tool_vote: str | None = None,
         exclude_tool_args: list[str] | None = None,
+        threshold: float | None = None,
+        confidence_threshold: float | None = None,
     ) -> None:
         """Configure the gateway's scaling algorithm at runtime.
+
+        ``threshold`` applies only to ``adaptive-self-consistency`` and
+        ``confidence_threshold`` only to ``beta-self-consistency``; both fall
+        back to the algorithm's own default when left as ``None``.
 
         Raises ValueError for unsupported algorithms or invalid options.
         """
@@ -95,17 +114,35 @@ class ITSGateway(AbstractGateway):
                 f"Algorithm {alg!r} not supported. Choose from: {SUPPORTED_ALGORITHMS}"
             )
 
-        if alg == "self-consistency":
-            projection_func = None
-            if regex_patterns:
-                validate_regex_patterns(regex_patterns)
-                projection_func = create_regex_projection_function(regex_patterns)
-            algorithm = SelfConsistency(
-                consistency_space_projection_func=projection_func,
-                tool_vote=tool_vote,
-                exclude_args=exclude_tool_args,
-                orchestrator=self._orchestrator,
+        # The self-consistency family shares projection/tool-vote plumbing.
+        projection_func = None
+        if regex_patterns:
+            validate_regex_patterns(regex_patterns)
+            projection_func = create_regex_projection_function(regex_patterns)
+
+        common_kwargs = {
+            "consistency_space_projection_func": projection_func,
+            "exclude_args": exclude_tool_args,
+            "orchestrator": self._orchestrator,
+        }
+        # Only override the algorithm's default tool_vote when one is explicitly
+        # provided; otherwise let it fall back to DEFAULT_TOOL_VOTE so that
+        # tool-calling responses still vote sensibly with no extra config.
+        if tool_vote is not None:
+            common_kwargs["tool_vote"] = tool_vote
+
+        if alg == "adaptive-self-consistency":
+            extra = {} if threshold is None else {"threshold": threshold}
+            algorithm = AdaptiveSelfConsistency(**common_kwargs, **extra)
+        elif alg == "beta-self-consistency":
+            extra = (
+                {}
+                if confidence_threshold is None
+                else {"confidence_threshold": confidence_threshold}
             )
+            algorithm = BetaSelfConsistency(**common_kwargs, **extra)
+        else:  # self-consistency
+            algorithm = SelfConsistency(**common_kwargs)
 
         self._algorithm = algorithm
         self._algorithm_name = type(algorithm).__name__

--- a/its_hub/integration/iaas/app.py
+++ b/its_hub/integration/iaas/app.py
@@ -38,6 +38,7 @@ class _ServiceConfig:
     api_key: str | None = None
     budget: int = 4
     temperature: float | None = None
+    alg: str = "self-consistency"
 
 
 class _ServiceState:
@@ -106,10 +107,13 @@ async def config_service(request: ConfigRequest) -> dict[str, str]:
             regex_patterns=request.regex_patterns,
             tool_vote=request.tool_vote,
             exclude_tool_args=request.exclude_tool_args,
+            threshold=request.threshold,
+            confidence_threshold=request.confidence_threshold,
         )
         _state.config.endpoint = request.endpoint
         _state.config.model = request.model
         _state.config.api_key = request.api_key
+        _state.config.alg = request.alg
         if request.budget is not None:
             _state.config.budget = request.budget
         if request.temperature is not None:
@@ -198,7 +202,7 @@ async def chat_completions(
         metadata = None
         if not request.return_response_only:
             metadata = {
-                "algorithm": "self-consistency",
+                "algorithm": _state.config.alg,
                 "all_responses": result.get("responses"),
                 "response_counts": result.get("response_counts"),
                 "selected_index": result.get("selected_index"),

--- a/its_hub/integration/iaas/models.py
+++ b/its_hub/integration/iaas/models.py
@@ -42,6 +42,18 @@ class ConfigRequest(BaseModel):
         None,
         description="Tool argument names to exclude from voting",
     )
+    threshold: float | None = Field(
+        None,
+        gt=0.5,
+        le=1.0,
+        description="Supermajority vote-share threshold for adaptive-self-consistency early stopping (default 0.75)",
+    )
+    confidence_threshold: float | None = Field(
+        None,
+        gt=0.5,
+        le=1.0,
+        description="Beta posterior confidence threshold for beta-self-consistency early stopping (default 0.95)",
+    )
 
     @field_validator("alg")
     @classmethod
@@ -54,10 +66,6 @@ class ConfigRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_config_requirements(self):
-        if self.alg == "self-consistency" and not self.regex_patterns:
-            raise ValueError(
-                "regex_patterns are required when using self-consistency algorithm"
-            )
         if self.provider == "openai" and not self.api_key:
             raise ValueError("api_key is required when using openai provider")
         return self

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -24,7 +24,12 @@ def _make_result(usage=None):
 
 
 def _make_config(**overrides):
-    defaults = {"budget": 3, "api_endpoint": "http://llm/v1", "model": "gpt-4", "api_key": "sk-test"}
+    defaults = {
+        "budget": 3,
+        "api_endpoint": "http://llm/v1",
+        "model": "gpt-4",
+        "api_key": "sk-test",
+    }
     defaults.update(overrides)
     return ITSRequestConfig(**defaults)
 
@@ -99,7 +104,9 @@ class TestLMClientCaching:
         gw = ITSGateway(algorithm=MagicMock())
         mock_lm = MagicMock()
         mock_lm.close = AsyncMock()
-        with patch("its_hub.core.gateway.OpenAICompatibleLanguageModel", return_value=mock_lm):
+        with patch(
+            "its_hub.core.gateway.OpenAICompatibleLanguageModel", return_value=mock_lm
+        ):
             await gw._get_or_create_lm("http://a/v1", "m1", "key1")
         assert len(gw._lm_cache) == 1
         await gw.ashutdown()
@@ -160,7 +167,9 @@ class TestRunChatCompletion:
         gw = ITSGateway(algorithm=algo)
         tools = [{"type": "function", "function": {"name": "f"}}]
         with patch.object(gw, "_get_or_create_lm", return_value=MagicMock()):
-            await gw.arun_chat_completion(_make_config(), MESSAGES, tools=tools, tool_choice="auto")
+            await gw.arun_chat_completion(
+                _make_config(), MESSAGES, tools=tools, tool_choice="auto"
+            )
         call_kwargs = algo.ainfer.call_args.kwargs
         assert call_kwargs["tools"] is tools
         assert call_kwargs["tool_choice"] == "auto"
@@ -177,8 +186,10 @@ class TestRunChatCompletion:
         algo = MagicMock()
         algo.ainfer = AsyncMock(side_effect=RuntimeError("boom"))
         gw = ITSGateway(algorithm=algo)
-        with patch.object(gw, "_get_or_create_lm", return_value=MagicMock()), \
-             pytest.raises(RuntimeError, match="boom"):
+        with (
+            patch.object(gw, "_get_or_create_lm", return_value=MagicMock()),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
             await gw.arun_chat_completion(_make_config(), MESSAGES)
 
     @pytest.mark.asyncio
@@ -215,6 +226,12 @@ class TestConfigure:
             regex_patterns=[r"\\boxed{([^}]+)}"],
         )
         assert gw._algorithm_name == "SelfConsistency"
+
+    def test_configure_defaults_tool_vote_when_omitted(self):
+        """With neither regex nor tool_vote, the algorithm's DEFAULT_TOOL_VOTE applies."""
+        gw = ITSGateway(algorithm=MagicMock())
+        gw.configure(alg="self-consistency")
+        assert gw._algorithm.tool_vote == "tool_hierarchical"
 
     def test_configure_with_tool_vote(self):
         gw = ITSGateway(algorithm=MagicMock())
@@ -258,10 +275,73 @@ class TestConfigure:
                 tool_vote="invalid",
             )
 
+    def test_configure_adaptive_self_consistency(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        gw.configure(
+            alg="adaptive-self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+        )
+        assert gw._algorithm_name == "AdaptiveSelfConsistency"
+        # Unset threshold falls back to the class default.
+        assert gw._algorithm.threshold == pytest.approx(0.75)
+
+    def test_configure_adaptive_threshold_plumbed(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        gw.configure(
+            alg="adaptive-self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+            threshold=0.9,
+        )
+        assert gw._algorithm.threshold == pytest.approx(0.9)
+
+    def test_configure_beta_self_consistency(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        gw.configure(
+            alg="beta-self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+        )
+        assert gw._algorithm_name == "BetaSelfConsistency"
+        # Unset confidence_threshold falls back to the class default.
+        assert gw._algorithm.confidence_threshold == pytest.approx(0.95)
+
+    def test_configure_beta_confidence_threshold_plumbed(self):
+        gw = ITSGateway(algorithm=MagicMock())
+        gw.configure(
+            alg="beta-self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+            confidence_threshold=0.8,
+        )
+        assert gw._algorithm.confidence_threshold == pytest.approx(0.8)
+
+    @pytest.mark.parametrize(
+        "alg",
+        ["adaptive-self-consistency", "beta-self-consistency"],
+    )
+    def test_configure_family_shares_tool_vote(self, alg):
+        """Adaptive/beta inherit the tool-vote voting surface from SelfConsistency."""
+        gw = ITSGateway(algorithm=MagicMock())
+        gw.configure(alg=alg, tool_vote="tool_name")
+        assert gw._algorithm.tool_vote == "tool_name"
+
+    def test_configure_preserves_orchestrator_for_family(self):
+        orch = MagicMock()
+        gw = ITSGateway(algorithm=MagicMock(), orchestrator=orch)
+        gw.configure(
+            alg="beta-self-consistency",
+            regex_patterns=[r"\\boxed{([^}]+)}"],
+        )
+        assert gw._algorithm.orchestrator is orch
+
 
 class TestSupportedAlgorithms:
     def test_self_consistency_supported(self):
         assert "self-consistency" in SUPPORTED_ALGORITHMS
+
+    def test_adaptive_self_consistency_supported(self):
+        assert "adaptive-self-consistency" in SUPPORTED_ALGORITHMS
+
+    def test_beta_self_consistency_supported(self):
+        assert "beta-self-consistency" in SUPPORTED_ALGORITHMS
 
     def test_is_frozenset(self):
         assert isinstance(SUPPORTED_ALGORITHMS, frozenset)

--- a/tests/test_iaas.py
+++ b/tests/test_iaas.py
@@ -34,14 +34,24 @@ def vllm_endpoint(vllm_server):
 def _mock_gateway_result(content="answer", usage=None):
     """Build a dict matching ITSGateway.arun_chat_completion return (response_only=True)."""
     if usage is None:
-        usage = {"prompt_tokens": 10, "completion_tokens": 15, "total_tokens": 25, "num_calls": 1}
+        usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 15,
+            "total_tokens": 25,
+            "num_calls": 1,
+        }
     return {"message": {"role": "assistant", "content": content}, "usage": usage}
 
 
 def _mock_gateway_full_result(content="answer", usage=None):
     """Build a dict matching ITSGateway.arun_chat_completion return (response_only=False)."""
     if usage is None:
-        usage = {"prompt_tokens": 10, "completion_tokens": 15, "total_tokens": 25, "num_calls": 1}
+        usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 15,
+            "total_tokens": 25,
+            "num_calls": 1,
+        }
     return {
         "the_one": {"role": "assistant", "content": content},
         "responses": [
@@ -223,6 +233,115 @@ class TestSelfConsistencyToolVote:
             assert call_args.kwargs["exclude_args"] == ["timestamp", "id"]
 
 
+class TestAdaptiveAndBetaSelfConsistency:
+    """Configuration of the adaptive/beta self-consistency variants via /configure."""
+
+    @pytest.mark.parametrize(
+        "alg",
+        ["adaptive-self-consistency", "beta-self-consistency"],
+    )
+    def test_family_basic_configuration(self, iaas_client, vllm_endpoint, alg):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": alg,
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 200
+        assert "success" in response.json()["status"]
+        assert _state.config.alg == alg
+
+    def test_adaptive_threshold_forwarded_to_algorithm(
+        self, iaas_client, vllm_endpoint
+    ):
+        with patch("its_hub.core.gateway.AdaptiveSelfConsistency") as mock_alg:
+            mock_alg.return_value = MagicMock()
+            config = {
+                "endpoint": vllm_endpoint,
+                "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+                "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+                "alg": "adaptive-self-consistency",
+                "regex_patterns": [r"\\boxed{([^}]+)}"],
+                "threshold": 0.9,
+            }
+            response = iaas_client.post("/configure", json=config)
+            assert response.status_code == 200
+            mock_alg.assert_called_once()
+            assert mock_alg.call_args.kwargs["threshold"] == 0.9
+
+    def test_beta_confidence_threshold_forwarded_to_algorithm(
+        self, iaas_client, vllm_endpoint
+    ):
+        with patch("its_hub.core.gateway.BetaSelfConsistency") as mock_alg:
+            mock_alg.return_value = MagicMock()
+            config = {
+                "endpoint": vllm_endpoint,
+                "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+                "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+                "alg": "beta-self-consistency",
+                "regex_patterns": [r"\\boxed{([^}]+)}"],
+                "confidence_threshold": 0.8,
+            }
+            response = iaas_client.post("/configure", json=config)
+            assert response.status_code == 200
+            mock_alg.assert_called_once()
+            assert mock_alg.call_args.kwargs["confidence_threshold"] == 0.8
+
+    def test_threshold_omitted_uses_algorithm_default(self, iaas_client, vllm_endpoint):
+        """When threshold is unset, it is not forwarded so the class default applies."""
+        with patch("its_hub.core.gateway.AdaptiveSelfConsistency") as mock_alg:
+            mock_alg.return_value = MagicMock()
+            config = {
+                "endpoint": vllm_endpoint,
+                "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+                "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+                "alg": "adaptive-self-consistency",
+                "regex_patterns": [r"\\boxed{([^}]+)}"],
+            }
+            response = iaas_client.post("/configure", json=config)
+            assert response.status_code == 200
+            assert "threshold" not in mock_alg.call_args.kwargs
+
+    @pytest.mark.parametrize(
+        ("field", "alg"),
+        [
+            ("threshold", "adaptive-self-consistency"),
+            ("confidence_threshold", "beta-self-consistency"),
+        ],
+    )
+    def test_threshold_out_of_range_rejected(
+        self, iaas_client, vllm_endpoint, field, alg
+    ):
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": alg,
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+            field: 0.5,  # not > 0.5
+        }
+        response = iaas_client.post("/configure", json=config)
+        assert response.status_code == 422
+
+    def test_family_tool_vote_forwarded(self, iaas_client, vllm_endpoint):
+        with patch("its_hub.core.gateway.BetaSelfConsistency") as mock_alg:
+            mock_alg.return_value = MagicMock()
+            config = {
+                "endpoint": vllm_endpoint,
+                "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+                "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+                "alg": "beta-self-consistency",
+                "tool_vote": "tool_hierarchical",
+                "exclude_tool_args": ["timestamp"],
+            }
+            response = iaas_client.post("/configure", json=config)
+            assert response.status_code == 200
+            assert mock_alg.call_args.kwargs["tool_vote"] == "tool_hierarchical"
+            assert mock_alg.call_args.kwargs["exclude_args"] == ["timestamp"]
+
+
 class TestChatCompletions:
     def test_chat_completion_with_gateway(self, iaas_client, vllm_endpoint):
         config = {
@@ -277,6 +396,31 @@ class TestChatCompletions:
         assert data["metadata"]["algorithm"] == "self-consistency"
         assert data["metadata"]["selected_index"] == 0
 
+    def test_chat_completion_metadata_reports_configured_algorithm(
+        self, iaas_client, vllm_endpoint
+    ):
+        """Metadata reflects the configured algorithm, not a hardcoded value."""
+        config = {
+            "endpoint": vllm_endpoint,
+            "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
+            "model": TEST_CONSTANTS["DEFAULT_MODEL_NAME"],
+            "alg": "beta-self-consistency",
+            "regex_patterns": [r"\\boxed{([^}]+)}"],
+        }
+        iaas_client.post("/configure", json=config)
+
+        mock_gw = MagicMock()
+        mock_gw.arun_chat_completion = AsyncMock(
+            return_value=_mock_gateway_full_result()
+        )
+        _state.gateway = mock_gw
+
+        request_data = TestDataFactory.create_chat_completion_request(budget=4)
+        request_data["return_response_only"] = False
+        response = iaas_client.post("/v1/chat/completions", json=request_data)
+        assert response.status_code == 200
+        assert response.json()["metadata"]["algorithm"] == "beta-self-consistency"
+
     @pytest.mark.parametrize(
         "invalid_request",
         [
@@ -303,14 +447,16 @@ class TestStreamingChatCompletions:
         chunks = []
         for line in response.text.splitlines():
             if line.startswith("data: "):
-                payload = line[len("data: "):]
+                payload = line[len("data: ") :]
                 if payload == "[DONE]":
                     chunks.append("[DONE]")
                 else:
                     chunks.append(json.loads(payload))
         return chunks
 
-    def _configure_and_mock(self, iaas_client, endpoint, mock_return=None, side_effect=None):
+    def _configure_and_mock(
+        self, iaas_client, endpoint, mock_return=None, side_effect=None
+    ):
         _state.config.endpoint = endpoint
         _state.config.model = TEST_CONSTANTS["DEFAULT_MODEL_NAME"]
         _state.config.api_key = TEST_CONSTANTS["DEFAULT_API_KEY"]
@@ -350,9 +496,16 @@ class TestStreamingChatCompletions:
                     }
                 ],
             },
-            "usage": {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15, "num_calls": 1},
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 10,
+                "total_tokens": 15,
+                "num_calls": 1,
+            },
         }
-        self._configure_and_mock(iaas_client, vllm_endpoint, mock_return=tool_call_result)
+        self._configure_and_mock(
+            iaas_client, vllm_endpoint, mock_return=tool_call_result
+        )
 
         request_data = TestDataFactory.create_chat_completion_request(budget=4)
         request_data["stream"] = True
@@ -505,7 +658,9 @@ class TestHeaderConfig:
         call_kwargs = mock_gw.arun_chat_completion.call_args.kwargs
         assert call_kwargs["config"].budget == 16
 
-    def test_endpoint_from_header_overrides_service_default(self, iaas_client, vllm_endpoint):
+    def test_endpoint_from_header_overrides_service_default(
+        self, iaas_client, vllm_endpoint
+    ):
         config = {
             "endpoint": vllm_endpoint,
             "api_key": TEST_CONSTANTS["DEFAULT_API_KEY"],
@@ -697,14 +852,36 @@ class TestErrorSanitization:
 class TestModelValidatorFixes:
     """Tests that model validators fire even when fields are omitted."""
 
-    def test_self_consistency_requires_regex_when_omitted(self):
-        with pytest.raises(ValueError, match="regex_patterns are required"):
-            ConfigRequest(
-                endpoint="http://example.com:8000",
-                api_key="sk-test",
-                model="test-model",
-                alg="self-consistency",
-            )
+    @pytest.mark.parametrize(
+        "alg",
+        [
+            "self-consistency",
+            "adaptive-self-consistency",
+            "beta-self-consistency",
+        ],
+    )
+    def test_family_accepts_neither_regex_nor_tool_vote(self, alg):
+        """Neither projection field is required; the algorithm defaults handle voting."""
+        config = ConfigRequest(
+            endpoint="http://example.com:8000",
+            api_key="sk-test",
+            model="test-model",
+            alg=alg,
+        )
+        assert config.regex_patterns is None
+        assert config.tool_vote is None
+
+    def test_self_consistency_accepts_tool_vote_without_regex(self):
+        """tool_vote alone is a valid projection surface."""
+        config = ConfigRequest(
+            endpoint="http://example.com:8000",
+            api_key="sk-test",
+            model="test-model",
+            alg="self-consistency",
+            tool_vote="tool_hierarchical",
+        )
+        assert config.regex_patterns is None
+        assert config.tool_vote == "tool_hierarchical"
 
     def test_openai_requires_api_key_when_omitted(self):
         with pytest.raises(ValueError, match="api_key is required"):
@@ -743,18 +920,21 @@ class TestExtProcessor:
     @pytest.fixture
     def ext_proc(self):
         from its_hub.integration.iaas.ext_processor import ExternalProcessorService
+
         return ExternalProcessorService()
 
     @pytest.mark.asyncio
     async def test_routes_and_preserves_headers_when_budget_present(
         self, ext_proc, _make_headers_request
     ):
-        request = _make_headers_request({
-            ":path": "/v1/chat/completions",
-            "x-its-budget": "4",
-            "x-its-endpoint": "http://localhost:8100/v1",
-            "x-its-api-key": "secret",
-        })
+        request = _make_headers_request(
+            {
+                ":path": "/v1/chat/completions",
+                "x-its-budget": "4",
+                "x-its-endpoint": "http://localhost:8100/v1",
+                "x-its-api-key": "secret",
+            }
+        )
 
         async def _stream():
             yield request
@@ -782,10 +962,12 @@ class TestExtProcessor:
     async def test_passes_through_without_budget_header(
         self, ext_proc, _make_headers_request
     ):
-        request = _make_headers_request({
-            ":path": "/v1/chat/completions",
-            "content-type": "application/json",
-        })
+        request = _make_headers_request(
+            {
+                ":path": "/v1/chat/completions",
+                "content-type": "application/json",
+            }
+        )
 
         async def _stream():
             yield request
@@ -807,11 +989,13 @@ class TestExtProcessor:
         self, ext_proc, _make_headers_request
     ):
         """Stray ITS headers without budget are stripped on pass-through."""
-        request = _make_headers_request({
-            ":path": "/v1/chat/completions",
-            "x-its-endpoint": "http://localhost:8100/v1",
-            "x-its-api-key": "secret",
-        })
+        request = _make_headers_request(
+            {
+                ":path": "/v1/chat/completions",
+                "x-its-endpoint": "http://localhost:8100/v1",
+                "x-its-api-key": "secret",
+            }
+        )
 
         async def _stream():
             yield request
@@ -838,9 +1022,7 @@ class TestAppServer:
         from its_hub.integration.iaas.app_server import _configure_logging
 
         _configure_logging("DEBUG")
-        assert (
-            logging.getLogger("its_hub.integration.iaas.app").level == logging.DEBUG
-        )
+        assert logging.getLogger("its_hub.integration.iaas.app").level == logging.DEBUG
 
     def test_configure_logging_invalid_level(self):
         from its_hub.integration.iaas.app_server import _configure_logging

--- a/tests/test_tool_calls.py
+++ b/tests/test_tool_calls.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from its_hub.core.algorithms.self_consistency import SelfConsistency, SelfConsistencyResult
+from its_hub.core.algorithms.self_consistency import (
+    SelfConsistency,
+    SelfConsistencyResult,
+)
 
 
 class ToolCallMockLanguageModel:
@@ -65,7 +68,9 @@ class TestToolCallHandling:
         sc = SelfConsistency(extract_number)
 
         # This should not throw a NotImplementedError and should handle tool calls gracefully
-        result = sc.infer(mock_lm, "What is 6 * 7?", budget=4, return_response_only=False)
+        result = sc.infer(
+            mock_lm, "What is 6 * 7?", budget=4, return_response_only=False
+        )
 
         assert isinstance(result, SelfConsistencyResult)
         # Should vote on content only, ignoring tool calls
@@ -104,40 +109,58 @@ class TestToolCallHandling:
         assert "The answer is 42." in response_counts
 
         # The selected response should be one of the content strings
-        assert result.the_one["content"] in ["I need to calculate this. The answer is 42.", "The answer is 42."]
+        assert result.the_one["content"] in [
+            "I need to calculate this. The answer is 42.",
+            "The answer is 42.",
+        ]
 
     def test_self_consistency_with_empty_content_and_tool_calls(self):
-        """Test self-consistency raises error when all responses have tool calls but tool_vote is not set."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {"id": "call_0", "type": "function", "function": {"name": "search"}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {"id": "call_1", "type": "function", "function": {"name": "search"}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {"id": "call_2", "type": "function", "function": {"name": "search"}},
-                ],
-            },
-        ])
+        """Content-only voting (tool_vote=None) raises when every response is a tool call."""
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_0",
+                            "type": "function",
+                            "function": {"name": "search"},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "search"},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "search"},
+                        },
+                    ],
+                },
+            ]
+        )
 
         def identity_projection(text):
             return text
 
-        sc = SelfConsistency(identity_projection)
+        # tool_vote=None forces content-only voting; with every response a tool
+        # call there is nothing to vote on.
+        sc = SelfConsistency(identity_projection, tool_vote=None)
 
-        # Should raise ValueError when all responses have tool calls but tool_vote is not set
         with pytest.raises(
             ValueError, match="No eligible responses found after filtering"
         ):
@@ -145,15 +168,68 @@ class TestToolCallHandling:
                 mock_lm, "Search for information", budget=3, return_response_only=False
             )
 
+    def test_default_tool_vote_handles_all_tool_calls(self):
+        """With the default tool_vote, all-tool-call responses vote instead of raising."""
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_0",
+                            "type": "function",
+                            "function": {"name": "search"},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "search"},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "lookup"},
+                        },
+                    ],
+                },
+            ]
+        )
+
+        # No tool_vote passed -> DEFAULT_TOOL_VOTE ("tool_hierarchical") applies.
+        sc = SelfConsistency()
+        assert sc.tool_vote == "tool_hierarchical"
+
+        result = sc.infer(
+            mock_lm, "Search for information", budget=3, return_response_only=False
+        )
+
+        # "search" wins 2-1 over "lookup"; the winner is a search tool call.
+        assert result.the_one["tool_calls"][0]["function"]["name"] == "search"
+
 
 class TestToolCallVotingBackwardCompatibility:
     """Test that tool vote features maintain backward compatibility."""
 
     def test_existing_behavior_unchanged_without_tool_vote(self):
-        """Test that existing code without tool_vote parameter works unchanged."""
+        """Positional-arg construction still works; the '42' answer is selected."""
         mock_lm = ToolCallMockLanguageModel()
 
-        # Old way of initializing - should work exactly as before
+        # Old way of initializing (projection func only) still works. Note the
+        # default tool_vote now routes tool-majority batches to tool voting, so
+        # the selected response may be a tool call rather than a text message.
         def extract_number(text):
             import re
 
@@ -161,9 +237,10 @@ class TestToolCallVotingBackwardCompatibility:
             return numbers[0] if numbers else ""
 
         sc = SelfConsistency(extract_number)  # No tool_vote parameter
-        result = sc.infer(mock_lm, "What is 6 * 7?", budget=4, return_response_only=False)
+        result = sc.infer(
+            mock_lm, "What is 6 * 7?", budget=4, return_response_only=False
+        )
 
-        # Should behave exactly as before - vote on content only
         assert isinstance(result, SelfConsistencyResult)
         assert result.the_one["content"] in [
             "I need to calculate this. The answer is 42.",
@@ -177,28 +254,54 @@ class TestToolCallVoting:
 
     def test_tool_name_voting(self):
         """Test voting on tool function names only."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Calculating...",
-                "tool_calls": [{"id": "1", "type": "function", "function": {"name": "calculate", "arguments": {"x": 1}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Computing...",
-                "tool_calls": [{"id": "2", "type": "function", "function": {"name": "calculate", "arguments": {"x": 2}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Processing...",
-                "tool_calls": [{"id": "3", "type": "function", "function": {"name": "search", "arguments": {"q": "test"}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Working...",
-                "tool_calls": [{"id": "4", "type": "function", "function": {"name": "calculate", "arguments": {"x": 3}}}],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Calculating...",
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {"name": "calculate", "arguments": {"x": 1}},
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Computing...",
+                    "tool_calls": [
+                        {
+                            "id": "2",
+                            "type": "function",
+                            "function": {"name": "calculate", "arguments": {"x": 2}},
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Processing...",
+                    "tool_calls": [
+                        {
+                            "id": "3",
+                            "type": "function",
+                            "function": {"name": "search", "arguments": {"q": "test"}},
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Working...",
+                    "tool_calls": [
+                        {
+                            "id": "4",
+                            "type": "function",
+                            "function": {"name": "calculate", "arguments": {"x": 3}},
+                        }
+                    ],
+                },
+            ]
+        )
 
         sc = SelfConsistency(lambda x: x, tool_vote="tool_name")
         result = sc.infer(mock_lm, "Test prompt", budget=4, return_response_only=False)
@@ -211,28 +314,66 @@ class TestToolCallVoting:
 
     def test_tool_args_voting(self):
         """Test voting on tool arguments only."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Test1",
-                "tool_calls": [{"id": "1", "type": "function", "function": {"name": "func1", "arguments": {"x": 1, "y": 2}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Test2",
-                "tool_calls": [{"id": "2", "type": "function", "function": {"name": "func2", "arguments": {"x": 1, "y": 2}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Test3",
-                "tool_calls": [{"id": "3", "type": "function", "function": {"name": "func3", "arguments": {"a": 3, "b": 4}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Test4",
-                "tool_calls": [{"id": "4", "type": "function", "function": {"name": "func4", "arguments": {"x": 1, "y": 2}}}],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Test1",
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {
+                                "name": "func1",
+                                "arguments": {"x": 1, "y": 2},
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test2",
+                    "tool_calls": [
+                        {
+                            "id": "2",
+                            "type": "function",
+                            "function": {
+                                "name": "func2",
+                                "arguments": {"x": 1, "y": 2},
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test3",
+                    "tool_calls": [
+                        {
+                            "id": "3",
+                            "type": "function",
+                            "function": {
+                                "name": "func3",
+                                "arguments": {"a": 3, "b": 4},
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test4",
+                    "tool_calls": [
+                        {
+                            "id": "4",
+                            "type": "function",
+                            "function": {
+                                "name": "func4",
+                                "arguments": {"x": 1, "y": 2},
+                            },
+                        }
+                    ],
+                },
+            ]
+        )
 
         sc = SelfConsistency(lambda x: x, tool_vote="tool_args")
         result = sc.infer(mock_lm, "Test prompt", budget=4, return_response_only=False)
@@ -243,28 +384,54 @@ class TestToolCallVoting:
 
     def test_tool_hierarchical_voting(self):
         """Test hierarchical voting: tool name first, then arguments."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Test1",
-                "tool_calls": [{"id": "1", "type": "function", "function": {"name": "calculate", "arguments": {"x": 1}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Test2",
-                "tool_calls": [{"id": "2", "type": "function", "function": {"name": "calculate", "arguments": {"x": 2}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Test3",
-                "tool_calls": [{"id": "3", "type": "function", "function": {"name": "search", "arguments": {"q": "test"}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Test4",
-                "tool_calls": [{"id": "4", "type": "function", "function": {"name": "calculate", "arguments": {"x": 1}}}],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Test1",
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {"name": "calculate", "arguments": {"x": 1}},
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test2",
+                    "tool_calls": [
+                        {
+                            "id": "2",
+                            "type": "function",
+                            "function": {"name": "calculate", "arguments": {"x": 2}},
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test3",
+                    "tool_calls": [
+                        {
+                            "id": "3",
+                            "type": "function",
+                            "function": {"name": "search", "arguments": {"q": "test"}},
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test4",
+                    "tool_calls": [
+                        {
+                            "id": "4",
+                            "type": "function",
+                            "function": {"name": "calculate", "arguments": {"x": 1}},
+                        }
+                    ],
+                },
+            ]
+        )
 
         sc = SelfConsistency(lambda x: x, tool_vote="tool_hierarchical")
         result = sc.infer(mock_lm, "Test prompt", budget=4, return_response_only=False)
@@ -276,18 +443,38 @@ class TestToolCallVoting:
 
     def test_exclude_args_functionality(self):
         """Test excluding certain argument names from voting."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Test1",
-                "tool_calls": [{"id": "1", "type": "function", "function": {"name": "func", "arguments": {"x": 1, "timestamp": "123", "id": "abc"}}}],
-            },
-            {
-                "role": "assistant",
-                "content": "Test2",
-                "tool_calls": [{"id": "2", "type": "function", "function": {"name": "func", "arguments": {"x": 1, "timestamp": "456", "id": "def"}}}],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Test1",
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {
+                                "name": "func",
+                                "arguments": {"x": 1, "timestamp": "123", "id": "abc"},
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test2",
+                    "tool_calls": [
+                        {
+                            "id": "2",
+                            "type": "function",
+                            "function": {
+                                "name": "func",
+                                "arguments": {"x": 1, "timestamp": "456", "id": "def"},
+                            },
+                        }
+                    ],
+                },
+            ]
+        )
 
         sc = SelfConsistency(
             lambda x: x, tool_vote="tool_args", exclude_args=["timestamp", "id"]
@@ -300,11 +487,13 @@ class TestToolCallVoting:
 
     def test_fallback_to_content_voting_when_no_tool_calls(self):
         """Test that it falls back to content voting when responses have no tool calls."""
-        mock_lm = _make_fixed_list_mock([
-            {"role": "assistant", "content": "Answer: 42"},
-            {"role": "assistant", "content": "Answer: 42"},
-            {"role": "assistant", "content": "Answer: 24"},
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {"role": "assistant", "content": "Answer: 42"},
+                {"role": "assistant", "content": "Answer: 42"},
+                {"role": "assistant", "content": "Answer: 24"},
+            ]
+        )
 
         def extract_answer(text):
             import re
@@ -318,33 +507,55 @@ class TestToolCallVoting:
         # Should fall back to content voting since no tool calls
         assert result.response_counts["42"] == 2
         assert result.response_counts["24"] == 1
-        assert result.the_one["content"] == "Answer: 42"  # Returns full content, not extracted value
+        assert (
+            result.the_one["content"] == "Answer: 42"
+        )  # Returns full content, not extracted value
 
     def test_tool_flat_all_single_tool(self):
         """Test tool_flat_all with single tool calls behaves like tool_hierarchical."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Test1",
-                "tool_calls": [
-                    {"id": "1", "type": "function", "function": {"name": "pods_log", "arguments": {"namespace": "demo-oom"}}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "Test2",
-                "tool_calls": [
-                    {"id": "2", "type": "function", "function": {"name": "events_list", "arguments": {}}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "Test3",
-                "tool_calls": [
-                    {"id": "3", "type": "function", "function": {"name": "pods_log", "arguments": {"namespace": "demo-oom"}}},
-                ],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Test1",
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {
+                                "name": "pods_log",
+                                "arguments": {"namespace": "demo-oom"},
+                            },
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test2",
+                    "tool_calls": [
+                        {
+                            "id": "2",
+                            "type": "function",
+                            "function": {"name": "events_list", "arguments": {}},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test3",
+                    "tool_calls": [
+                        {
+                            "id": "3",
+                            "type": "function",
+                            "function": {
+                                "name": "pods_log",
+                                "arguments": {"namespace": "demo-oom"},
+                            },
+                        },
+                    ],
+                },
+            ]
+        )
 
         sc = SelfConsistency(lambda x: x, tool_vote="tool_flat_all")
         result = sc.infer(mock_lm, "Test prompt", budget=3, return_response_only=False)
@@ -355,31 +566,53 @@ class TestToolCallVoting:
 
     def test_tool_flat_all_multiple_tools_order_independent(self):
         """Test tool_flat_all treats [A, B] and [B, A] as the same signature."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Test1",
-                "tool_calls": [
-                    {"id": "1a", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "x"}}},
-                    {"id": "1b", "type": "function", "function": {"name": "events_list", "arguments": {}}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "Test2",
-                "tool_calls": [
-                    {"id": "2a", "type": "function", "function": {"name": "events_list", "arguments": {}}},
-                    {"id": "2b", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "x"}}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "Test3",
-                "tool_calls": [
-                    {"id": "3a", "type": "function", "function": {"name": "resources_get", "arguments": {}}},
-                ],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Test1",
+                    "tool_calls": [
+                        {
+                            "id": "1a",
+                            "type": "function",
+                            "function": {"name": "pods_log", "arguments": {"ns": "x"}},
+                        },
+                        {
+                            "id": "1b",
+                            "type": "function",
+                            "function": {"name": "events_list", "arguments": {}},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test2",
+                    "tool_calls": [
+                        {
+                            "id": "2a",
+                            "type": "function",
+                            "function": {"name": "events_list", "arguments": {}},
+                        },
+                        {
+                            "id": "2b",
+                            "type": "function",
+                            "function": {"name": "pods_log", "arguments": {"ns": "x"}},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test3",
+                    "tool_calls": [
+                        {
+                            "id": "3a",
+                            "type": "function",
+                            "function": {"name": "resources_get", "arguments": {}},
+                        },
+                    ],
+                },
+            ]
+        )
 
         sc = SelfConsistency(lambda x: x, tool_vote="tool_flat_all")
         result = sc.infer(mock_lm, "Test prompt", budget=3, return_response_only=False)
@@ -391,31 +624,53 @@ class TestToolCallVoting:
 
     def test_tool_flat_all_different_tool_sets(self):
         """Test tool_flat_all distinguishes [A] from [A, B]."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Test1",
-                "tool_calls": [
-                    {"id": "1", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "x"}}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "Test2",
-                "tool_calls": [
-                    {"id": "2a", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "x"}}},
-                    {"id": "2b", "type": "function", "function": {"name": "events_list", "arguments": {}}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "Test3",
-                "tool_calls": [
-                    {"id": "3a", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "x"}}},
-                    {"id": "3b", "type": "function", "function": {"name": "events_list", "arguments": {}}},
-                ],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Test1",
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {"name": "pods_log", "arguments": {"ns": "x"}},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test2",
+                    "tool_calls": [
+                        {
+                            "id": "2a",
+                            "type": "function",
+                            "function": {"name": "pods_log", "arguments": {"ns": "x"}},
+                        },
+                        {
+                            "id": "2b",
+                            "type": "function",
+                            "function": {"name": "events_list", "arguments": {}},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test3",
+                    "tool_calls": [
+                        {
+                            "id": "3a",
+                            "type": "function",
+                            "function": {"name": "pods_log", "arguments": {"ns": "x"}},
+                        },
+                        {
+                            "id": "3b",
+                            "type": "function",
+                            "function": {"name": "events_list", "arguments": {}},
+                        },
+                    ],
+                },
+            ]
+        )
 
         sc = SelfConsistency(lambda x: x, tool_vote="tool_flat_all")
         result = sc.infer(mock_lm, "Test prompt", budget=3, return_response_only=False)
@@ -425,75 +680,123 @@ class TestToolCallVoting:
 
     def test_tool_flat_all_exclude_args(self):
         """Test exclude_args works with tool_flat_all across all tool calls."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Test1",
-                "tool_calls": [
-                    {"id": "1", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "x", "timestamp": "111"}}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "Test2",
-                "tool_calls": [
-                    {"id": "2", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "x", "timestamp": "222"}}},
-                ],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Test1",
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {
+                                "name": "pods_log",
+                                "arguments": {"ns": "x", "timestamp": "111"},
+                            },
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test2",
+                    "tool_calls": [
+                        {
+                            "id": "2",
+                            "type": "function",
+                            "function": {
+                                "name": "pods_log",
+                                "arguments": {"ns": "x", "timestamp": "222"},
+                            },
+                        },
+                    ],
+                },
+            ]
+        )
 
-        sc = SelfConsistency(lambda x: x, tool_vote="tool_flat_all", exclude_args=["timestamp"])
+        sc = SelfConsistency(
+            lambda x: x, tool_vote="tool_flat_all", exclude_args=["timestamp"]
+        )
         result = sc.infer(mock_lm, "Test prompt", budget=2, return_response_only=False)
 
         assert len(result.response_counts) == 1
 
     def test_tool_flat_all_uses_flat_voting(self):
         """Test that tool_flat_all uses flat Counter voting, not hierarchical."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Test1",
-                "tool_calls": [
-                    {"id": "1", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "a"}}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "Test2",
-                "tool_calls": [
-                    {"id": "2", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "a"}}},
-                ],
-            },
-            {
-                "role": "assistant",
-                "content": "Test3",
-                "tool_calls": [
-                    {"id": "3", "type": "function", "function": {"name": "pods_log", "arguments": {"ns": "b"}}},
-                ],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Test1",
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {"name": "pods_log", "arguments": {"ns": "a"}},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test2",
+                    "tool_calls": [
+                        {
+                            "id": "2",
+                            "type": "function",
+                            "function": {"name": "pods_log", "arguments": {"ns": "a"}},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "Test3",
+                    "tool_calls": [
+                        {
+                            "id": "3",
+                            "type": "function",
+                            "function": {"name": "pods_log", "arguments": {"ns": "b"}},
+                        },
+                    ],
+                },
+            ]
+        )
 
         sc = SelfConsistency(lambda x: x, tool_vote="tool_flat_all")
         result = sc.infer(mock_lm, "Test prompt", budget=3, return_response_only=False)
 
         for key in result.response_counts:
-            assert isinstance(key, frozenset), f"Expected frozenset key, got {type(key)}"
+            assert isinstance(key, frozenset), (
+                f"Expected frozenset key, got {type(key)}"
+            )
 
     def test_mixed_responses_with_and_without_tool_calls(self):
         """Test behavior when some responses have tool calls and others don't."""
-        mock_lm = _make_fixed_list_mock([
-            {
-                "role": "assistant",
-                "content": "Using calculator",
-                "tool_calls": [{"id": "1", "type": "function", "function": {"name": "calculate", "arguments": {"x": 1}}}],
-            },
-            {"role": "assistant", "content": "Direct answer: 42"},
-            {
-                "role": "assistant",
-                "content": "Let me compute",
-                "tool_calls": [{"id": "2", "type": "function", "function": {"name": "calculate", "arguments": {"x": 1}}}],
-            },
-        ])
+        mock_lm = _make_fixed_list_mock(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Using calculator",
+                    "tool_calls": [
+                        {
+                            "id": "1",
+                            "type": "function",
+                            "function": {"name": "calculate", "arguments": {"x": 1}},
+                        }
+                    ],
+                },
+                {"role": "assistant", "content": "Direct answer: 42"},
+                {
+                    "role": "assistant",
+                    "content": "Let me compute",
+                    "tool_calls": [
+                        {
+                            "id": "2",
+                            "type": "function",
+                            "function": {"name": "calculate", "arguments": {"x": 1}},
+                        }
+                    ],
+                },
+            ]
+        )
 
         sc = SelfConsistency(lambda x: x, tool_vote="tool_name")
         result = sc.infer(mock_lm, "Test prompt", budget=3, return_response_only=False)


### PR DESCRIPTION
## Summary

Exposes the two adaptive-stopping self-consistency variants —
**Adaptive Self-Consistency** and **Beta Self-Consistency** — through the IaaS
gateway, alongside plain Self-Consistency. Both treat `budget` as a maximum and
add a single early-stopping knob so many prompts finish before spending the full
budget.

## Changes

- **Gateway** (`core/gateway.py`): `configure()` now constructs
  `AdaptiveSelfConsistency` / `BetaSelfConsistency` and plumbs their
  early-stopping knobs (`threshold` / `confidence_threshold`), falling back to
  the algorithm class defaults (`0.75` / `0.95`) when unset. Adds a
  `SELF_CONSISTENCY_ALGORITHMS` grouping.
- **Config model** (`integration/iaas/models.py`): `ConfigRequest` gains `alg`,
  `threshold`, and `confidence_threshold` fields. Drops the "requires
  `regex_patterns` or `tool_vote`" guard — neither is required anymore.
- **App** (`integration/iaas/app.py`): forwards the algorithm choice and new
  knobs to `configure()`.
- **Algorithms**: the self-consistency family now defaults `tool_vote` to
  `tool_hierarchical` (`DEFAULT_TOOL_VOTE`), so tool-calling responses vote
  sensibly with no extra config. Text responses fall back to exact-content
  matching; `tool_vote=None` forces content-only voting. Applied consistently
  to `self_consistency.py`, `adaptive_self_consistency.py`, and
  `beta_self_consistency.py`.
- **Docs** (`docs/iaas-service.md`): documents the new algorithms, their
  early-stopping knobs, and the voting defaults.

## Test Plan

Unit tests cover gateway wiring, config validation (including the
neither-field-required path), threshold plumbing, and the default tool-voting
behavior. Manually verified end-to-end against a live OpenAI-compatible
GLM-5.2 endpoint: all three algorithms, tool voting, regex text voting,
exact-content fallback, unsupported-algorithm rejection, and the streaming path.

- [x] Tests pass locally (`uv run pytest tests/`) — new/changed files green
      (pre-existing `envoy` proto import errors unrelated to this change)
- [x] Linting passes (`uv run ruff check its_hub/`) — clean on changed files
- [x] Formatting passes (`uv run ruff format --check its_hub/`) — clean on changed files

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check its_hub/`)
- [x] Added/updated tests for new functionality
- [x] Updated documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive and beta self-consistency options alongside standard self-consistency.
  * Added configurable adaptive thresholds and beta confidence thresholds.
  * Added hierarchical tool voting as the default behavior.
  * Enabled self-consistency configurations without regex patterns, with exact-content fallback.
  * Added algorithm details to response metadata.

* **Documentation**
  * Expanded configuration guidance, voting behavior, defaults, stopping controls, and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->