### PR TITLE
docs(iaas): correct unsupported-algorithm status to 422

### DIFF
--- a/docs/iaas-service.md
+++ b/docs/iaas-service.md
@@ -336,7 +336,7 @@ CUDA_VISIBLE_DEVICES=1 uv run its-iaas \
 |---|---|---|
 | Service not configured (no `/configure` call) | 200 (SSE) / 400 | `"Service not configured"` error in stream or HTTP 400 |
 | Invalid budget (non-integer, out of range) | 400 | `"Bad Request"` with detail |
-| Unsupported algorithm | 400 | `"Algorithm 'X' not supported"` |
+| Unsupported algorithm | 422 | `"Algorithm 'X' not supported"` (Pydantic validation on `/configure`) |
 | Invalid regex pattern in `/configure` | 400 | Regex compilation error detail |
 | Downstream LLM unreachable / timeout | 500 | `"Generation failed. Check server logs for details."` |
 | Algorithm execution error | 500 | `"Generation failed. Check server logs for details."` |


### PR DESCRIPTION
## Summary

The Failure Policy table in `docs/iaas-service.md` lists an unsupported `alg` as
returning **400**. It's actually rejected by Pydantic validation on `/configure`
and returns **422**. This one-line fix makes the docs match observed behavior.

## Changes

- `docs/iaas-service.md`: Unsupported algorithm row → 422, with a note that it's
  Pydantic validation on `/configure`.

## Test Plan

Docs-only change. Behavior verified manually: `POST /configure` with an
unsupported `alg` returns HTTP 422.

- [x] Docs match observed behavior
