### PR TITLE
fix(lm): honor proxy env vars in aiohttp sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,26 @@ print(result)  # Best response as judged by LLM
 asyncio.run(lm.close())
 ```
 
+### Proxy Configuration
+
+Like `requests`, `httpx`, and the OpenAI SDK, `OpenAICompatibleLanguageModel`
+respects the standard proxy environment variables, so you can reach an upstream
+that is only accessible through a proxy without any code changes. Set them in the
+environment before creating the LM:
+
+| Variable | Purpose |
+| --- | --- |
+| `HTTP_PROXY` / `HTTPS_PROXY` | Proxy URL for `http://` / `https://` requests |
+| `NO_PROXY` | Comma-separated hosts/domains to connect to directly, bypassing the proxy |
+
+```bash
+export HTTPS_PROXY="http://proxy.example.com:8080"
+export NO_PROXY="localhost,127.0.0.1"
+```
+
+Credentials in `.netrc` are also honored. Lowercase variants (`http_proxy`, etc.)
+work as well.
+
 ## Key Features
 
 - 🔬 **Multiple Algorithms**: Self-Consistency, Best-of-N, Beam Search (experimental), Particle Filtering (experimental)

--- a/its_hub/core/lms/openai_lm.py
+++ b/its_hub/core/lms/openai_lm.py
@@ -124,9 +124,10 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
             if session is not None and not session.closed:
                 return session
 
-            # Create new session for the event loop
+            # Create new session for the event loop.
+            # trust_env=True so aiohttp honors HTTP(S)_PROXY/NO_PROXY/.netrc.
             connector = aiohttp.TCPConnector(ssl=self.ssl_context)
-            session = aiohttp.ClientSession(connector=connector)
+            session = aiohttp.ClientSession(connector=connector, trust_env=True)
             self._sessions[loop] = session
 
             return session
@@ -273,7 +274,9 @@ class OpenAICompatibleLanguageModel(AbstractLanguageModel):
         # create a single session for all requests in this call
         # Use the same SSL behavior as requests library
         connector = aiohttp.TCPConnector(ssl=self.ssl_context)
-        async with aiohttp.ClientSession(connector=connector) as session:
+        async with aiohttp.ClientSession(
+            connector=connector, trust_env=True
+        ) as session:
 
             @backoff.on_exception(
                 backoff.expo,

--- a/tests/test_openai_compatible_language_model.py
+++ b/tests/test_openai_compatible_language_model.py
@@ -106,38 +106,39 @@ class TestRequestBodyKey:
 
 @pytest.mark.asyncio
 async def test_agenerate_single_honors_env_proxy(monkeypatch):
-    """The LM must route through HTTP(S)_PROXY, else proxy-gated upstreams break.
+    """The LM routes through HTTP_PROXY (requires trust_env=True on the session).
 
-    The endpoint host is unresolvable, so a direct connection can only fail; the
-    request succeeds only because it is routed to our stand-in proxy.
+    Pointing the LM at an unresolvable host means a direct connection can only
+    fail; the request succeeds only because it is routed to our stand-in proxy.
     """
 
-    async def handler(request):
+    # Stand-in proxy: answers every path with a valid chat-completion payload.
+    async def stand_in_proxy_handler(request):
         return web.json_response(
             {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
         )
 
-    app = web.Application()
-    app.router.add_route("*", "/{tail:.*}", handler)
-    server = TestServer(app)
-    await server.start_server()
+    proxy_app = web.Application()
+    proxy_app.router.add_route("*", "/{tail:.*}", stand_in_proxy_handler)
+    stand_in_proxy = TestServer(proxy_app)
+    await stand_in_proxy.start_server()
     try:
-        # Isolate from inherited proxy config: no_proxy could bypass our
-        # stand-in, and a lowercase http_proxy could shadow the value we set.
-        for var in ("NO_PROXY", "no_proxy", "http_proxy"):
-            monkeypatch.delenv(var, raising=False)
-        proxy = f"http://127.0.0.1:{server.port}"
-        monkeypatch.setenv("HTTP_PROXY", proxy)
-        monkeypatch.setenv("http_proxy", proxy)
+        # Clear inherited no-proxy config that could bypass our stand-in.
+        for inherited_var in ("NO_PROXY", "no_proxy"):
+            monkeypatch.delenv(inherited_var, raising=False)
+        proxy_url = f"http://127.0.0.1:{stand_in_proxy.port}"
+        monkeypatch.setenv("HTTP_PROXY", proxy_url)
+        monkeypatch.setenv("http_proxy", proxy_url)
+
         lm = OpenAICompatibleLanguageModel(
             endpoint="http://blackhole.invalid/v1",  # unresolvable without a proxy
             api_key="k",
             model_name="m",
             max_tries=1,
         )
-        message = await lm.agenerate_single([ChatMessage(role="user", content="hi")])
+        response = await lm.agenerate_single([ChatMessage(role="user", content="hi")])
         await lm.close()
     finally:
-        await server.close()
+        await stand_in_proxy.close()
 
-    assert message["content"] == "ok"
+    assert response["content"] == "ok"

--- a/tests/test_openai_compatible_language_model.py
+++ b/tests/test_openai_compatible_language_model.py
@@ -1,6 +1,8 @@
 """Tests for max_tokens → max_completion_tokens migration."""
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
 
 from its_hub.api.types import ChatMessage
 from its_hub.core.lms.openai_lm import OpenAICompatibleLanguageModel
@@ -100,3 +102,36 @@ class TestRequestBodyKey:
         )
         assert "logprobs" not in data
         assert "top_logprobs" not in data
+
+
+@pytest.mark.asyncio
+async def test_agenerate_single_honors_env_proxy(monkeypatch):
+    """The LM must route through HTTP(S)_PROXY, else proxy-gated upstreams break.
+
+    The endpoint host is unresolvable, so a direct connection can only fail; the
+    request succeeds only because it is routed to our stand-in proxy.
+    """
+
+    async def handler(request):
+        return web.json_response(
+            {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+        )
+
+    app = web.Application()
+    app.router.add_route("*", "/{tail:.*}", handler)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{server.port}")
+        lm = OpenAICompatibleLanguageModel(
+            endpoint="http://blackhole.invalid/v1",  # unresolvable without a proxy
+            api_key="k",
+            model_name="m",
+            max_tries=1,
+        )
+        message = await lm.agenerate_single([ChatMessage(role="user", content="hi")])
+        await lm.close()
+    finally:
+        await server.close()
+
+    assert message["content"] == "ok"

--- a/tests/test_openai_compatible_language_model.py
+++ b/tests/test_openai_compatible_language_model.py
@@ -122,7 +122,13 @@ async def test_agenerate_single_honors_env_proxy(monkeypatch):
     server = TestServer(app)
     await server.start_server()
     try:
-        monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{server.port}")
+        # Isolate from inherited proxy config: no_proxy could bypass our
+        # stand-in, and a lowercase http_proxy could shadow the value we set.
+        for var in ("NO_PROXY", "no_proxy", "http_proxy"):
+            monkeypatch.delenv(var, raising=False)
+        proxy = f"http://127.0.0.1:{server.port}"
+        monkeypatch.setenv("HTTP_PROXY", proxy)
+        monkeypatch.setenv("http_proxy", proxy)
         lm = OpenAICompatibleLanguageModel(
             endpoint="http://blackhole.invalid/v1",  # unresolvable without a proxy
             api_key="k",


### PR DESCRIPTION
## Summary

The LM's aiohttp sessions were created without `trust_env=True`, so aiohttp
silently ignored `HTTP(S)_PROXY`/`NO_PROXY` (and `.netrc`) — unlike `requests`,
`httpx`, and the OpenAI SDK, which honor them by default. The client therefore
connected directly and could not reach a **proxy-gated upstream**.

This was necessary to make an internal GLM endpoint (reachable only through a
CONNECT proxy) work: without it, requests fail with a connection/DNS error
because the proxy is never used.

## Changes

- Set `trust_env=True` at both `ClientSession` creation sites in
  `OpenAICompatibleLanguageModel`.
- Add one behavioral test that routes a request to an unresolvable host through
  a stand-in proxy — it fails without the fix and succeeds with it.

## Test Plan

- [x] `uv run pytest tests/test_openai_compatible_language_model.py`
- [x] `uv run ruff check` / `ruff format --check` clean on changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with configured network environments by honoring proxy, bypass, and authentication settings when connecting to compatible language model endpoints.
  * Fixed requests to work correctly when access requires an environment-defined HTTP proxy.

* **Documentation**
  * Added guidance for configuring proxies, bypass rules, and authentication credentials through environment settings.

* **Tests**
  * Added coverage verifying proxied requests and successful response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->