### PR TITLE
feat(iaas): surface num_calls in chat completion usage

### DIFF
--- a/its_hub/integration/iaas/app.py
+++ b/its_hub/integration/iaas/app.py
@@ -223,6 +223,7 @@ async def chat_completions(
                 prompt_tokens=usage.get("prompt_tokens", 0),
                 completion_tokens=usage.get("completion_tokens", 0),
                 total_tokens=usage.get("total_tokens", 0),
+                num_calls=usage.get("num_calls", 0),
             ),
             metadata=metadata,
         )

--- a/its_hub/integration/iaas/models.py
+++ b/its_hub/integration/iaas/models.py
@@ -112,12 +112,8 @@ class ChatCompletionUsage(BaseModel):
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
-    num_calls: int = 0
-    """Number of underlying LM calls the ITS algorithm made for this request.
-
-    Lets clients measure how many samples adaptive algorithms (adaptive/beta
-    self-consistency) actually used versus the requested budget.
-    """
+    # Number of underlying LM calls the ITS algorithm made for this request
+    num_calls: int = 0 
 
 
 class ChatCompletionResponse(BaseModel):

--- a/its_hub/integration/iaas/models.py
+++ b/its_hub/integration/iaas/models.py
@@ -112,6 +112,12 @@ class ChatCompletionUsage(BaseModel):
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
+    num_calls: int = 0
+    """Number of underlying LM calls the ITS algorithm made for this request.
+
+    Lets clients measure how many samples adaptive algorithms (adaptive/beta
+    self-consistency) actually used versus the requested budget.
+    """
 
 
 class ChatCompletionResponse(BaseModel):

--- a/tests/test_iaas.py
+++ b/tests/test_iaas.py
@@ -355,7 +355,15 @@ class TestChatCompletions:
 
         mock_gw = MagicMock()
         mock_gw.arun_chat_completion = AsyncMock(
-            return_value=_mock_gateway_result("Tool voting response")
+            return_value=_mock_gateway_result(
+                "Tool voting response",
+                usage={
+                    "prompt_tokens": 10,
+                    "completion_tokens": 15,
+                    "total_tokens": 25,
+                    "num_calls": 6,
+                },
+            )
         )
         _state.gateway = mock_gw
 
@@ -368,6 +376,9 @@ class TestChatCompletions:
         data = response.json()
         assert data["choices"][0]["message"]["content"] == "Tool voting response"
         assert data["usage"]["prompt_tokens"] == 10
+        # num_calls is surfaced so clients can see how many LM calls the
+        # (possibly adaptive) algorithm actually made for this ITS request.
+        assert data["usage"]["num_calls"] == 6
         mock_gw.arun_chat_completion.assert_called_once()
 
     def test_chat_completion_full_result(self, iaas_client, vllm_endpoint):


### PR DESCRIPTION
## Summary

Surfaces `num_calls` in the IaaS chat-completion `usage` so clients can see how many underlying LM calls each ITS request made — the key metric for measuring how much the adaptive self-consistency algorithms save versus a fixed budget.

The value was already tracked end-to-end (`GenerationUsage.num_calls` → gateway `usage` dict); it was only being dropped at the HTTP response boundary.

## Changes
- `ChatCompletionUsage`: add `num_calls: int = 0`
- `app.py`: populate it from the gateway's `usage` dict (one line)
- `test_iaas.py`: assert `num_calls` is surfaced in the response

## Result
```json
"usage": {"prompt_tokens": …, "completion_tokens": …, "total_tokens": …, "num_calls": 6}
```
e.g. a budget-16 beta-SC request that stops early at 6 samples reports `num_calls: 6`.